### PR TITLE
Add missing mcp dependency to installation steps

### DIFF
--- a/introduction/first-agent.mdx
+++ b/introduction/first-agent.mdx
@@ -62,11 +62,11 @@ Create a virtual environment, install dependencies, export your API key and run 
 
     <CodeGroup>
     ```bash Mac
-    uv pip install -U agno openai
+    uv pip install -U agno openai mcp
     ```
 
     ```bash Windows
-    uv pip install -U agno openai
+    uv pip install -U agno openai mcp
     ```
     </CodeGroup>
 


### PR DESCRIPTION
The mcp package is required for MCPTools but was missing from 
installation instructions, causing ModuleNotFoundError.