### PR TITLE
docs: clarify agent statelessness and session state to resolve

### DIFF
--- a/concepts/agents/state.mdx
+++ b/concepts/agents/state.mdx
@@ -5,22 +5,21 @@ description: Learn about state in agents.
 
 **State** is any kind of data that needs to be maintained throughout runs in a session.
 
-<Check>
 A simple yet common use case for Agents is to manage lists, items and other "information" for a user. For example, a shopping list, a todo list, a wishlist, etc.
+This can be easily managed using the `session_state`. The Agent can access or update the `session_state` in tool calls and exposes them to the Model via the system message.
 
-This can be easily managed using the `session_state`. The Agent updates the `session_state` in tool calls and exposes them to the Model via the system message.
+The session state is then persisted in the configured database and made available across runs within that session.
 
-The session state is then persisted in a database and made available across runs within that session.
-</Check>
+<Note>
+**Understanding Agent "Statelessness"**: Agents in Agno don't maintain working state between different sessions or runs, but they do provide state management capabilities:
+
+- The `session_state` parameter on `Agent` provides the default state template for new sessions
+- The `get_session_state()` method retrieves the session state of a particular session from the database  
+- Working state is managed per run and persisted to the database per session
+- The agent instance (or attributes thereof) itself is not modified during runs
+</Note>
 
 ## State Management
-
-**Understanding Agent "Statelessness"**: Agents in Agno v2 don't maintain working state between different sessions or runs, but they do provide state management capabilities:
-
-- Agent `session_state` parameter provides default state template for new sessions
-- `get_session_state()` retrieves current session state from the database  
-- Working state is managed per run and persisted to the database per session
-- The agent instance itself is not modified during runs
 
 Agno provides a powerful and elegant state management system. Here's how it works:
 
@@ -289,27 +288,6 @@ agent.print_response(
     stream=True,
 )
 print(f"Stored session state: {agent.get_session_state()}")
-```
-
-## Understanding `get_session_state()` and Race Conditions
-
-The `agent.get_session_state()` method retrieves session state from the database for a specific session. This explains why agents can have state methods without being stateful - they provide access to database-stored state.
-
-```python
-# This retrieves the current session's state from the database
-current_state = agent.get_session_state()
-```
-
-**Race condition considerations**: When using `agent.run()` with `session_state`:
-- Each session maintains isolated state in the database
-- Use different `session_id` values for different users/contexts  
-- For high-concurrency scenarios, consider using separate agent instances per session
-- The agent instance itself is not modified, only the working state for each run
-
-```python
-# Recommended: Different sessions with unique IDs
-agent.run("Add milk", session_id="user_1", session_state={"list": []})
-agent.run("Add bread", session_id="user_2", session_state={"list": []})
 ```
 
 ## Developer Resources

--- a/concepts/agents/state.mdx
+++ b/concepts/agents/state.mdx
@@ -3,24 +3,33 @@ title: Agent State
 description: Learn about state in agents.
 ---
 
-**State** is any kind of data the Agent needs to maintain throughout runs in a session.
+**State** is any kind of data that needs to be maintained throughout runs in a session.
 
 <Check>
 A simple yet common use case for Agents is to manage lists, items and other "information" for a user. For example, a shopping list, a todo list, a wishlist, etc.
 
 This can be easily managed using the `session_state`. The Agent updates the `session_state` in tool calls and exposes them to the Model via the system message.
 
-The session state is then persisted in a database and made available across runs and sessions.
+The session state is then persisted in a database and made available across runs within that session.
 </Check>
 
 ## State Management
-Agno provides a powerful and elegant state management system, here's how it works:
 
-- You can set the `Agent`'s `session_state` parameter with a dictionary of state variables.
+**Understanding Agent "Statelessness"**: Agents in Agno v2 don't maintain working state between different sessions or runs, but they do provide state management capabilities:
+
+- Agent `session_state` parameter provides default state template for new sessions
+- `get_session_state()` retrieves current session state from the database  
+- Working state is managed per run and persisted to the database per session
+- The agent instance itself is not modified during runs
+
+Agno provides a powerful and elegant state management system. Here's how it works:
+
+- You can set the Agent's `session_state` parameter with a dictionary of default state variables.
 - You update the `session_state` dictionary in tool calls or other functions.
-- You share the current `session_state` with the LLM via the system message by referencing the state variables in `description` and `instructions`.
-- You can also pass `session_state` to the agent on `agent.run()`, overriding any state that was set on Agent initialization.
-- The `session_state` is stored with Agent sessions and is persisted in your database. Meaning, it is available across execution cycles. This also means when switching sessions between calls to `agent.run()`, the state is loaded and available.
+- You share the current `session_state` with the LLM via the system message by referencing state variables in `description` and `instructions`.
+- You can pass `session_state` to `agent.run()`, which takes precedence over the agent's default state.
+- The `session_state` is stored per session in your database and persists across runs within that session.
+- When switching sessions via `session_id` in `agent.run()`, the appropriate session state is loaded from the database.
 
 Here's an example of an Agent managing a shopping list:
 
@@ -39,7 +48,7 @@ def add_item(session_state, item: str) -> str:
 # Create an Agent that maintains state
 agent = Agent(
     model=OpenAIChat(id="gpt-5-mini"),
-    # Database to store the session and session state
+    # Database to store sessions and their state
     db=SqliteDb(db_file="tmp/agents.db"),
     # Initialize the session state with an empty shopping list
     session_state={"shopping_list": []},
@@ -64,9 +73,9 @@ print(f"Final session state: {agent.get_session_state()}")
   [Teams](/concepts/teams/state) for more information.
 </Check>
 
-## Maintaining state across multiple runs
+## Maintaining state across multiple runs within a session
 
-A big advantage of **sessions** is the ability to maintain state across multiple runs. For example, let's say the agent is helping a user keep track of their shopping list.
+A big advantage of **sessions** is the ability to maintain state across multiple runs within the same session. For example, let's say the agent is helping a user keep track of their shopping list.
 
 <Tip>
   You have to configure your storage via the `db` parameter for state to be persisted across runs.
@@ -280,6 +289,27 @@ agent.print_response(
     stream=True,
 )
 print(f"Stored session state: {agent.get_session_state()}")
+```
+
+## Understanding `get_session_state()` and Race Conditions
+
+The `agent.get_session_state()` method retrieves session state from the database for a specific session. This explains why agents can have state methods without being stateful - they provide access to database-stored state.
+
+```python
+# This retrieves the current session's state from the database
+current_state = agent.get_session_state()
+```
+
+**Race condition considerations**: When using `agent.run()` with `session_state`:
+- Each session maintains isolated state in the database
+- Use different `session_id` values for different users/contexts  
+- For high-concurrency scenarios, consider using separate agent instances per session
+- The agent instance itself is not modified, only the working state for each run
+
+```python
+# Recommended: Different sessions with unique IDs
+agent.run("Add milk", session_id="user_1", session_state={"list": []})
+agent.run("Add bread", session_id="user_2", session_state={"list": []})
 ```
 
 ## Developer Resources


### PR DESCRIPTION
## Description

User reported confusion about apparent contradiction between Agno v2 agents being "stateless" while having `agent.get_session_state()` method and `session_state` parameter.

Added clear explanations that:
* Agents don't maintain working state between sessions/runs but provide session state interfaces
* `get_session_state()` retrieves from database, not agent instance
* Session state is isolated per session in database
* Race condition safety when using `agent.run()` with different session IDs


## Type of Change
- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: ____

## Related Issues/PRs (if applicable)
<!-- Link any related items -->
- Closes #____
- Related SDK PR: agno-agi/agno#____

## Checklist
- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
