### PR TITLE
Add upsert_sessions and upsert_memories methods to storage reference pages

### DIFF
--- a/_snippets/db-new-bulk-methods.mdx
+++ b/_snippets/db-new-bulk-methods.mdx
@@ -1,0 +1,22 @@
+
+## Methods
+
+### `upsert_sessions(sessions: List[Session], deserialize: Optional[bool] = True)`
+
+Bulk upsert multiple sessions for improved performance on large datasets.
+
+**Parameters:**
+- `sessions` (List[Session]): List of sessions to upsert
+- `deserialize` (Optional[bool]): Whether to deserialize the sessions. Defaults to `True`
+
+**Returns:** `List[Union[Session, Dict[str, Any]]]`
+
+### `upsert_memories(memories: List[UserMemory], deserialize: Optional[bool] = True)`
+
+Bulk upsert multiple memories for improved performance on large datasets.
+
+**Parameters:**
+- `memories` (List[UserMemory]): List of memories to upsert  
+- `deserialize` (Optional[bool]): Whether to deserialize the memories. Defaults to `True`
+
+**Returns:** `List[Union[UserMemory, Dict[str, Any]]]`

--- a/_snippets/db-new-bulk-methods.mdx
+++ b/_snippets/db-new-bulk-methods.mdx
@@ -1,6 +1,6 @@
 ## Methods
 
-### `upsert_sessions(sessions: List[Session], deserialize: Optional[bool] = True)`
+### `upsert_sessions`
 
 Bulk upsert multiple sessions for improved performance on large datasets.
 
@@ -10,7 +10,7 @@ Bulk upsert multiple sessions for improved performance on large datasets.
 
 **Returns:** `List[Union[Session, Dict[str, Any]]]`
 
-### `upsert_memories(memories: List[UserMemory], deserialize: Optional[bool] = True)`
+### `upsert_memories`
 
 Bulk upsert multiple memories for improved performance on large datasets.
 

--- a/_snippets/db-new-bulk-methods.mdx
+++ b/_snippets/db-new-bulk-methods.mdx
@@ -1,4 +1,3 @@
-
 ## Methods
 
 ### `upsert_sessions(sessions: List[Session], deserialize: Optional[bool] = True)`

--- a/reference/storage/dynamodb.mdx
+++ b/reference/storage/dynamodb.mdx
@@ -5,3 +5,4 @@ title: DynamoDB
 DynamoDB is a class that implements the Db interface using Amazon DynamoDB as the backend storage system. It provides scalable, managed storage for agent sessions with support for indexing and efficient querying.
 
 <Snippet file="db-dynamodb-params.mdx" />
+<Snippet file="db-new-bulk-methods.mdx" />

--- a/reference/storage/firestore.mdx
+++ b/reference/storage/firestore.mdx
@@ -5,3 +5,4 @@ title: FirestoreDb
 `FirestoreDb` is a class that implements the Db interface using Google Firestore as the backend storage system. It provides high-performance, distributed storage for agent sessions with support for JSON data types and schema versioning.
 
 <Snippet file="db-firestore-params.mdx" />
+<Snippet file="db-new-bulk-methods.mdx" />

--- a/reference/storage/gcs.mdx
+++ b/reference/storage/gcs.mdx
@@ -5,3 +5,4 @@ title: GcsJsonDb
 `GcsJsonDb` is a class that implements the Db interface using Google Cloud Storage as a database using JSON files. It provides high-performance, distributed storage for agent sessions with support for JSON data types and schema versioning.
 
 <Snippet file="db-gcs-params.mdx" />
+<Snippet file="db-new-bulk-methods.mdx" />

--- a/reference/storage/in_memory.mdx
+++ b/reference/storage/in_memory.mdx
@@ -5,3 +5,4 @@ title: InMemoryDb
 `InMemoryDb` is a class that implements the Db interface using an in-memory database. It provides lightweight, in-memory storage for agent/team sessions.
 
 <Snippet file="db-in-memory-params.mdx" />
+<Snippet file="db-new-bulk-methods.mdx" />

--- a/reference/storage/json.mdx
+++ b/reference/storage/json.mdx
@@ -5,3 +5,4 @@ title: JsonDb
 `JsonDb` is a class that implements the Db interface using JSON files as the backend storage system. It provides a simple, file-based storage solution for agent sessions with each session stored in a separate JSON file.
 
 <Snippet file="db-json-params.mdx" />  
+<Snippet file="db-new-bulk-methods.mdx" />

--- a/reference/storage/mongodb.mdx
+++ b/reference/storage/mongodb.mdx
@@ -5,3 +5,4 @@ title: MongoDB
 `MongoDb` is a class that implements the Db interface using MongoDB as the backend storage system. It provides scalable, document-based storage for agent sessions with support for indexing and efficient querying.
 
 <Snippet file="db-mongodb-params.mdx" />    
+<Snippet file="db-new-bulk-methods.mdx" />

--- a/reference/storage/mysql.mdx
+++ b/reference/storage/mysql.mdx
@@ -5,3 +5,5 @@ title: MySQLDb
 `MySQLDb` is a class that implements the Db interface using MySQL as the backend storage system. It provides robust, relational storage for agent sessions with support for JSONB data types, schema versioning, and efficient querying.    
 
 <Snippet file="db-mysql-params.mdx" />     
+
+<Snippet file="db-new-bulk-methods.mdx" />

--- a/reference/storage/postgres.mdx
+++ b/reference/storage/postgres.mdx
@@ -5,3 +5,5 @@ title: PostgresDb
 `PostgresDb` is a class that implements the Db interface using PostgreSQL as the backend storage system. It provides robust, relational storage for agent sessions with support for JSONB data types, schema versioning, and efficient querying.
 
 <Snippet file="db-postgres-params.mdx" />
+
+<Snippet file="db-new-bulk-methods.mdx" />

--- a/reference/storage/redis.mdx
+++ b/reference/storage/redis.mdx
@@ -5,3 +5,4 @@ title: RedisDb
 `RedisDb` is a class that implements the Db interface using Redis as the backend storage system. It provides high-performance, distributed storage for agent sessions with support for JSON data types and schema versioning.
 
 <Snippet file="db-redis-params.mdx" />
+<Snippet file="db-new-bulk-methods.mdx" />

--- a/reference/storage/singlestore.mdx
+++ b/reference/storage/singlestore.mdx
@@ -5,3 +5,4 @@ title: SingleStoreDb
 `SingleStoreDb` is a class that implements the Db interface using SingleStore  as the backend storage system. It provides high-performance, distributed storage for agent sessions with support for JSON data types and schema versioning.
 
 <Snippet file="db-singlestore-params.mdx" />
+<Snippet file="db-new-bulk-methods.mdx" />

--- a/reference/storage/sqlite.mdx
+++ b/reference/storage/sqlite.mdx
@@ -5,3 +5,4 @@ title: SqliteDb
 `SqliteDb` is a class that implements the Db interface using SQLite as the backend storage system. It provides lightweight, file-based storage for agent sessions with support for JSON data types and schema versioning.
 
 <Snippet file="db-sqlite-params.mdx" />
+<Snippet file="db-new-bulk-methods.mdx" />


### PR DESCRIPTION
## Description
Add `upsert_sessions` and `upsert_memories` methods to storage reference pages

## Type of Change
- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [ ] Content improvement
- [ ] Other: ____

## Related Issues/PRs (if applicable)
<!-- Link any related items -->
- Closes #____
- Related SDK PR: agno-agi/agno#4736

## Checklist
- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
