### PR TITLE
docs: added reference doc for  FieldLabeledCSVReader 

### DIFF
--- a/_snippets/field-labeled-csv-reader-reference.mdx
+++ b/_snippets/field-labeled-csv-reader-reference.mdx
@@ -1,0 +1,5 @@
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `file` | `Union[Path, IO[Any]]` | Required | Path to CSV file or file-like object |
+| `delimiter` | `str` | `","` | Character used to separate fields in the CSV |
+| `quotechar` | `str` | `'"'` | Character used to quote fields in the CSV |

--- a/concepts/knowledge/readers.mdx
+++ b/concepts/knowledge/readers.mdx
@@ -181,6 +181,7 @@ The following readers are currently supported:
 |------------------|---------------------------------------------------------|
 | ArxivReader      | Fetches and processes academic papers from arXiv         |
 | CSVReader        | Parses CSV files and converts rows to documents          |
+| FieldLabeledCSVReader | Parses CSV files, labels row fields with headers, and converts them to documents|
 | FirecrawlReader  | Uses Firecrawl API to scrape and crawl web content       |
 | JSONReader       | Processes JSON files and converts them into documents    |
 | MarkdownReader   | Reads and parses Markdown files                          |

--- a/docs.json
+++ b/docs.json
@@ -2822,6 +2822,7 @@
                       "reference/knowledge/reader/base",
                       "reference/knowledge/reader/arxiv",
                       "reference/knowledge/reader/csv",
+                      "reference/knowledge/reader/field-labeled-csv",
                       "reference/knowledge/reader/docx",
                       "reference/knowledge/reader/json",
                       "reference/knowledge/reader/pdf",

--- a/reference/knowledge/reader/field-labeled-csv.mdx
+++ b/reference/knowledge/reader/field-labeled-csv.mdx
@@ -1,0 +1,8 @@
+---
+title: Field Labeled CSV Reader
+sidebarTitle: Field Labeled CSV
+---
+
+FieldLabeledCSVReader is a reader class that reads CSV files, using headers to label the fields of each row.
+
+<Snippet file="field-labeled-csv-reader-reference.mdx" />


### PR DESCRIPTION
## Description
This PR adds documentation for the new CSV reader — `FieldLabeledCSVReader` — recently added to agno.

## Type of Change
- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [x] Content improvement
- [ ] Other: ____

## Related Issues/PRs (if applicable)
<!-- Link any related items -->

- Related SDK PR: agno-agi/agno#3960 

## Checklist
- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [ ] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)


Reference page for `**FieldLabeledCSVReader**`:

<img width="1600" height="900" alt="FieldLabeledCSVReader_reference" src="https://github.com/user-attachments/assets/8732f162-e80b-4462-b5c1-4c129dc47fc1" />

Added to the list of **supported readers**:

<img width="1600" height="900" alt="added_supported_reader_list" src="https://github.com/user-attachments/assets/b81aabe1-da78-4140-a214-6b1d7f127a6e" />



