### PR TITLE
docs: replace enable_a2a with a2a_interface

### DIFF
--- a/agent-os/interfaces/a2a/introduction.mdx
+++ b/agent-os/interfaces/a2a/introduction.mdx
@@ -11,7 +11,7 @@ This is done with our `A2A` interface, which you can use with our [AgentOS](/age
 
 ## Setup
 
-You just need to set `enable_a2a=True` when creating your `AgentOS` instance and serve it as normal:
+You just need to set `a2a_interface=True` when creating your `AgentOS` instance and serve it as normal:
 
 ```python a2a_agentos.py
 from agno.agent import Agent
@@ -22,7 +22,7 @@ agent = Agent(name="My Agno Agent")
 
 agent_os = AgentOS(
     agents=[agent],
-    enable_a2a=True,
+    a2a_interface=True,
 )
 app = agent_os.get_app()
 

--- a/examples/agent-os/interfaces/a2a/agent_with_tools.mdx
+++ b/examples/agent-os/interfaces/a2a/agent_with_tools.mdx
@@ -23,7 +23,7 @@ agent = Agent(
 
 agent_os = AgentOS(
     agents=[agent],
-    enable_a2a=True,
+    a2a_interface=True,
 )
 app = agent_os.get_app()
 

--- a/examples/agent-os/interfaces/a2a/basic.mdx
+++ b/examples/agent-os/interfaces/a2a/basic.mdx
@@ -21,7 +21,7 @@ chat_agent = Agent(
 
 agent_os = AgentOS(
     agents=[chat_agent],
-    enable_a2a=True,
+    a2a_interface=True,
 )
 app = agent_os.get_app()
 

--- a/examples/agent-os/interfaces/a2a/team.mdx
+++ b/examples/agent-os/interfaces/a2a/team.mdx
@@ -43,7 +43,7 @@ research_team = Team(
 # Setup our AgentOS app
 agent_os = AgentOS(
     teams=[research_team],
-    enable_a2a=True,
+    a2a_interface=True,
 )
 app = agent_os.get_app()
 


### PR DESCRIPTION
## Description
For enabling a2a interface in agentOs, you have to set `a2a_interface=True`  (See https://github.com/agno-agi/agno/blob/87af603737f1a16d92a4e834c6385f171b2685f9/libs/agno/agno/os/app.py#L102 and https://github.com/agno-agi/agno/pull/4888) 

## Type of Change
- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [X] Content improvement
- [ ] Other: ____

## Related Issues/PRs (if applicable)
<!-- Link any related items -->
- Related SDK PR: agno-agi/agno#4888

## Checklist
- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
