### PR TITLE
docs: add team model inheritance documentation

### DIFF
--- a/concepts/teams/building-teams.mdx
+++ b/concepts/teams/building-teams.mdx
@@ -45,6 +45,10 @@ team.print_response("What's the latest news and weather in Tokyo?", stream=True)
   The `id` is used to identify the team member in the team and in the team leader's context.
 </Tip>
 
+<Note>
+Agents without a model inherit from their parent team. Agents with a model parameter set keep their own model. In nested team structures, agents inherit from their immediate parent team. Teams without a model default to OpenAI `gpt-4o`. This applies to: `model`, `reasoning_model`, `parser_model`, and `output_model`. See the [model inheritance example](https://github.com/agno-agi/agno/blob/main/cookbook/teams/other/team_model_inheritance.py).
+</Note>
+
 ## Run your Team
 
 When running your team, use the `Team.print_response()` method to print the response in the terminal. 

--- a/concepts/teams/building-teams.mdx
+++ b/concepts/teams/building-teams.mdx
@@ -46,7 +46,11 @@ team.print_response("What's the latest news and weather in Tokyo?", stream=True)
 </Tip>
 
 <Note>
-Agents without a model inherit from their parent team. Agents with a model parameter set keep their own model. In nested team structures, agents inherit from their immediate parent team. Teams without a model default to OpenAI `gpt-4o`. This applies to: `model`, `reasoning_model`, `parser_model`, and `output_model`. See the [model inheritance example](https://github.com/agno-agi/agno/blob/main/cookbook/teams/other/team_model_inheritance.py).
+Team members inherit the model from their parent team when no model is specified. Members with an explicit model keep their own. In nested teams, members inherit from their immediate parent. Teams without a model default to OpenAI `gpt-4o`.
+
+This applies to: `model`, `reasoning_model`, `parser_model`, and `output_model`.
+
+See the [model inheritance example](/examples/concepts/teams/basic/model_inheritance).
 </Note>
 
 ## Run your Team

--- a/concepts/teams/running-teams.mdx
+++ b/concepts/teams/running-teams.mdx
@@ -78,7 +78,10 @@ The `Team.run()` function returns a `TeamRunOutput` object when not streaming. H
 - `member_responses`: The list of member responses. Optional to add when `store_member_responses=True` on the `Team`.
 
 <Note>
-Agents inherit their model parameters from the parent team unless explicitly set. For more information see the [Building Teams](/concepts/teams/building-teams) documentation.
+Team members with no specified model will inherit the model from their parent team.
+This applies to: `model`, `reasoning_model`, `parser_model`, and `output_model`.
+
+See the [model inheritance example](/examples/concepts/teams/basic/model_inheritance).
 </Note>
 
 See detailed documentation in the [TeamRunOutput](/reference/teams/team-response) documentation.

--- a/concepts/teams/running-teams.mdx
+++ b/concepts/teams/running-teams.mdx
@@ -77,6 +77,10 @@ The `Team.run()` function returns a `TeamRunOutput` object when not streaming. H
 - `model`: The model used for the run.
 - `member_responses`: The list of member responses. Optional to add when `store_member_responses=True` on the `Team`.
 
+<Note>
+Agents inherit their model parameters from the parent team unless explicitly set. For more information see the [Building Teams](/concepts/teams/building-teams) documentation.
+</Note>
+
 See detailed documentation in the [TeamRunOutput](/reference/teams/team-response) documentation.
 
 ## Streaming

--- a/docs.json
+++ b/docs.json
@@ -1250,7 +1250,8 @@
                     "pages": [
                       "examples/concepts/teams/basic/basic_coordination",
                       "examples/concepts/teams/basic/respond_directly_router_team",
-                      "examples/concepts/teams/basic/delegate_to_all_members_cooperation"
+                      "examples/concepts/teams/basic/delegate_to_all_members_cooperation",
+                      "examples/concepts/teams/basic/model_inheritance"
                     ]
                   },
                   {
@@ -1423,7 +1424,8 @@
                       "examples/concepts/teams/other/few_shot_learning",
                       "examples/concepts/teams/other/run_as_cli",
                       "examples/concepts/teams/other/team_cancel_a_run",
-                      "examples/concepts/teams/other/team_exponential_backoff"
+                      "examples/concepts/teams/other/team_exponential_backoff",
+                      "examples/concepts/teams/other/team_model_inheritance"
                     ]
                   }
                 ]

--- a/examples/concepts/teams/basic/model_inheritance.mdx
+++ b/examples/concepts/teams/basic/model_inheritance.mdx
@@ -1,0 +1,111 @@
+---
+title: Model Inheritance
+sidebarTitle: Model Inheritance
+---
+
+This example demonstrates how agents automatically inherit the model from their parent team.
+
+**When the Team has a model:**
+- Agents without a model use the Team's model
+- Agents with their own model keep their own model
+- In nested teams, agents use the model from their direct parent team
+- All model types are inherited: `model`, `reasoning_model`, `parser_model`, `output_model`
+
+**When the Team has no model:**
+- The Team and all agents default to OpenAI `gpt-4o`
+
+```python model_inheritance.py
+from agno.agent import Agent
+from agno.models.anthropic import Claude
+from agno.models.openai import OpenAIChat
+from agno.team.team import Team
+
+# These agents don't have models set
+researcher = Agent(
+    name="Researcher",
+    role="Research and gather information",
+    instructions=["Be thorough and detailed"],
+)
+
+writer = Agent(
+    name="Writer",
+    role="Write content based on research",
+    instructions=["Write clearly and concisely"],
+)
+
+# This agent has a model set
+editor = Agent(
+    name="Editor",
+    role="Edit and refine content",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions=["Ensure clarity and correctness"],
+)
+
+# Nested team setup
+analyst = Agent(
+    name="Analyst",
+    role="Analyze data and provide insights",
+)
+
+sub_team = Team(
+    name="Analysis Team",
+    model=Claude(id="claude-3-5-haiku-20241022"),
+    members=[analyst],
+)
+
+team = Team(
+    name="Content Production Team",
+    model=Claude(id="claude-3-5-sonnet-20241022"),
+    members=[researcher, writer, editor, sub_team],
+    instructions=[
+        "Research the topic thoroughly",
+        "Write clear and engaging content",
+        "Edit for quality and clarity",
+        "Coordinate the entire process",
+    ],
+    show_members_responses=True,
+)
+
+team.initialize_team()
+
+# researcher and writer inherit Claude Sonnet from team
+print(f"Researcher model: {researcher.model.id}")
+print(f"Writer model: {writer.model.id}")
+
+# editor keeps its explicit model
+print(f"Editor model: {editor.model.id}")
+
+# analyst inherits Claude Haiku from its sub-team
+print(f"Analyst model: {analyst.model.id}")
+
+team.print_response(
+    "Write a brief article about AI", stream=True
+)
+```
+
+## Usage
+
+<Steps>
+
+    <Snippet file="create-venv-step.mdx" />
+
+    <Step title="Install required libraries">
+        ```bash
+        pip install agno anthropic openai
+        ```
+    </Step>
+
+    <Step title="Set environment variables">
+        ```bash
+        export ANTHROPIC_API_KEY=****
+        export OPENAI_API_KEY=****
+        ```
+    </Step>
+
+    <Step title="Run the agent">
+        ```bash
+        python model_inheritance.py
+        ```
+    </Step>
+
+</Steps>


### PR DESCRIPTION
## Description
Adds brief documentation for team model inheritance feature in building-teams and running-teams pages.

  ## Changes
  - Added model inheritance Note in `concepts/teams/building-teams.mdx`
  - Added cross-reference Note in `concepts/teams/running-teams.mdx`
  - Documents inheritance behavior, nested teams, and default models
  - Added model_inheritance.mdx example in examples/concepts/teams/basic/

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

- Related SDK PR: agno-agi/agno#5207

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
