### PR TITLE
fix: remove duplicate team_model_inheritance reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1428,8 +1428,7 @@
                       "examples/concepts/teams/other/few_shot_learning",
                       "examples/concepts/teams/other/run_as_cli",
                       "examples/concepts/teams/other/team_cancel_a_run",
-                      "examples/concepts/teams/other/team_exponential_backoff",
-                      "examples/concepts/teams/other/team_model_inheritance"
+                      "examples/concepts/teams/other/team_exponential_backoff"
                     ]
                   }
                 ]


### PR DESCRIPTION
## Description

  Removes duplicate `team_model_inheritance` reference from docs.json navigation that was causing a "file does      
  not exist" warning.

  ## Details
  The `team_model_inheritance` example was previously moved from
  `examples/concepts/teams/other/team_model_inheritance` to `examples/concepts/teams/basic/model_inheritance`,      
  but the old reference in the "Advanced Input and Output" section wasn't removed, causing the build warning.       

  ## Changes
  - Removed the duplicate reference at line 1428 in docs.json
  - The correct reference remains at line 1254 under "Basic" -> "Basic Teams"

## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [ ] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
