### PR TITLE
fix: fastapi install reference

### DIFF
--- a/agent-os/creating-your-first-os.mdx
+++ b/agent-os/creating-your-first-os.mdx
@@ -42,7 +42,7 @@ Create and activate a virtual environment:
 Install dependencies:
 
 ```bash
-pip install -U agno fastapi["standard"] uvicorn openai
+pip install -U agno "fastapi[standard]" uvicorn openai
 ```
 
 ## Minimal Setup

--- a/agent-os/customize/os/override_routes.mdx
+++ b/agent-os/customize/os/override_routes.mdx
@@ -104,7 +104,7 @@ When `on_route_conflict="preserve_agentos"` (default):
 
   <Step title="Install libraries">
     ```bash
-    pip install -U agno anthropic fastapi["standard"] uvicorn sqlalchemy pgvector psycopg
+    pip install -U agno anthropic "fastapi[standard]" uvicorn sqlalchemy pgvector psycopg
     ```
   </Step>
 

--- a/examples/agent-os/middleware/custom-fastapi-jwt.mdx
+++ b/examples/agent-os/middleware/custom-fastapi-jwt.mdx
@@ -106,7 +106,7 @@ if __name__ == "__main__":
 
   <Step title="Install libraries">
     ```bash
-    pip install -U agno openai pyjwt ddgs fastapi["standard"] uvicorn sqlalchemy pgvector psycopg python-multipart
+    pip install -U agno openai pyjwt ddgs "fastapi[standard]" uvicorn sqlalchemy pgvector psycopg python-multipart
     ```
   </Step>
 

--- a/examples/agent-os/middleware/custom-middleware.mdx
+++ b/examples/agent-os/middleware/custom-middleware.mdx
@@ -178,7 +178,7 @@ if __name__ == "__main__":
 
   <Step title="Install libraries">
     ```bash
-    pip install -U agno openai ddgs fastapi["standard"] uvicorn sqlalchemy pgvector psycopg
+    pip install -U agno openai ddgs "fastapi[standard]" uvicorn sqlalchemy pgvector psycopg
     ```
   </Step>
 

--- a/examples/agent-os/middleware/jwt-cookies.mdx
+++ b/examples/agent-os/middleware/jwt-cookies.mdx
@@ -159,7 +159,7 @@ if __name__ == "__main__":
 
   <Step title="Install libraries">
     ```bash
-    pip install -U agno openai pyjwt fastapi["standard"] uvicorn sqlalchemy pgvector psycopg
+    pip install -U agno openai pyjwt "fastapi[standard]" uvicorn sqlalchemy pgvector psycopg
     ```
   </Step>
 

--- a/examples/agent-os/middleware/jwt-middleware.mdx
+++ b/examples/agent-os/middleware/jwt-middleware.mdx
@@ -104,7 +104,7 @@ if __name__ == "__main__":
 
   <Step title="Install libraries">
     ```bash
-    pip install -U agno openai pyjwt fastapi["standard"] uvicorn sqlalchemy pgvector psycopg
+    pip install -U agno openai pyjwt "fastapi[standard]" uvicorn sqlalchemy pgvector psycopg
     ```
   </Step>
 


### PR DESCRIPTION
## Description

While trying to setup the Agno I figured out that installation reference for fastapi was incorrect. This PR fixes that. 

```
zsh: no matches found: fastapi["standard"]
```
## Type of Change

- [ x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Checklist

- [ x] Content is accurate and up-to-date
- [ x] All links tested and working
- [ ] Code examples verified (if applicable)
- [ x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
