### PR TITLE
docs: update team model inheritance

### DIFF
--- a/concepts/teams/building-teams.mdx
+++ b/concepts/teams/building-teams.mdx
@@ -46,9 +46,10 @@ team.print_response("What's the latest news and weather in Tokyo?", stream=True)
 </Tip>
 
 <Note>
-Team members inherit the model from their parent team when no model is specified. Members with an explicit model keep their own. In nested teams, members inherit from their immediate parent. Teams without a model default to OpenAI `gpt-4o`.
+Team members inherit their `model` from their parent team if not specified. Members with an explicitly assigned `model` retain their own. In nested team structures, inheritance always happens from the direct parent.
+Teams without a defined model default to OpenAI `gpt-4o`.
 
-This applies to: `model`, `reasoning_model`, `parser_model`, and `output_model`.
+The `reasoning_model`, `parser_model`, and `output_model` must be explicitly defined for each team or team member.
 
 See the [model inheritance example](/examples/concepts/teams/basic/model_inheritance).
 </Note>

--- a/concepts/teams/running-teams.mdx
+++ b/concepts/teams/running-teams.mdx
@@ -78,9 +78,8 @@ The `Team.run()` function returns a `TeamRunOutput` object when not streaming. H
 - `member_responses`: The list of member responses. Optional to add when `store_member_responses=True` on the `Team`.
 
 <Note>
-Team members with no specified model will inherit the model from their parent team.
-This applies to: `model`, `reasoning_model`, `parser_model`, and `output_model`.
-
+Team members inherit the `model` from their parent team if no `model` is specified.
+The `reasoning_model`, `parser_model`, and `output_model` must be explicitly set for each team or team member.
 See the [model inheritance example](/examples/concepts/teams/basic/model_inheritance).
 </Note>
 

--- a/examples/concepts/teams/basic/model_inheritance.mdx
+++ b/examples/concepts/teams/basic/model_inheritance.mdx
@@ -6,17 +6,16 @@ sidebarTitle: Model Inheritance
 This example demonstrates how agents automatically inherit the model from their parent team.
 
 **When the Team has a model:**
-- Agents without a model use the Team's model
+- Agents without a model use the Team's `model`
 - Agents with their own model keep their own model
-- In nested teams, agents use the model from their direct parent team
-- All model types are inherited: `model`, `reasoning_model`, `parser_model`, `output_model`
+- In nested teams, agents use the `model` from their direct parent team
+- The `reasoning_model`, `parser_model`, and `output_model` must be set explicitly on each team member or team
 
 **When the Team has no model:**
 - The Team and all agents default to OpenAI `gpt-4o`
 
 ```python model_inheritance.py
 from agno.agent import Agent
-from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIChat
 from agno.team.team import Team
 
@@ -49,13 +48,13 @@ analyst = Agent(
 
 sub_team = Team(
     name="Analysis Team",
-    model=Claude(id="claude-3-5-haiku-20241022"),
+    model=OpenAIChat(id="gpt-5-mini"),
     members=[analyst],
 )
 
 team = Team(
     name="Content Production Team",
-    model=Claude(id="claude-3-5-sonnet-20241022"),
+    model=OpenAIChat(id="gpt-4o"),
     members=[researcher, writer, editor, sub_team],
     instructions=[
         "Research the topic thoroughly",
@@ -68,14 +67,14 @@ team = Team(
 
 team.initialize_team()
 
-# researcher and writer inherit Claude Sonnet from team
+# researcher and writer inherit gpt-4o from team
 print(f"Researcher model: {researcher.model.id}")
 print(f"Writer model: {writer.model.id}")
 
 # editor keeps its explicit model
 print(f"Editor model: {editor.model.id}")
 
-# analyst inherits Claude Haiku from its sub-team
+# analyst inherits gpt-5-mini from its sub-team
 print(f"Analyst model: {analyst.model.id}")
 
 team.print_response(
@@ -91,13 +90,12 @@ team.print_response(
 
     <Step title="Install required libraries">
         ```bash
-        pip install agno anthropic openai
+        pip install agno openai
         ```
     </Step>
 
     <Step title="Set environment variables">
         ```bash
-        export ANTHROPIC_API_KEY=****
         export OPENAI_API_KEY=****
         ```
     </Step>


### PR DESCRIPTION
## Description

   Update documentation to reflect PR #5322 changes where team members now only inherit the primary model, not auxiliary models  (reasoning_model, parser_model, output_model).

   Changes:
   - Updated concepts/teams/building-teams.mdx to clarify only `model` is inherited
   - Updated concepts/teams/running-teams.mdx with same inheritance behavior
   - Updated examples/concepts/teams/basic/model_inheritance.mdx example code to use OpenAI models (gpt-4o, gpt-4o-mini,
   gpt-5-mini)

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

- Related SDK PR: agno-agi/agno#5322 

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
