### PR TITLE
docs: update Nebius branding from AI Studio to Token Factory

### DIFF
--- a/concepts/knowledge/embedder/nebius.mdx
+++ b/concepts/knowledge/embedder/nebius.mdx
@@ -3,7 +3,7 @@ title: Nebius Embedder
 sidebarTitle: Nebius
 ---
 
-The `NebiusEmbedder` can be used to embed text data into vectors using the Nebius AI Studio API. Nebius uses the OpenAI API specification, so the `NebiusEmbedder` class is similar to the `OpenAIEmbedder` class, incorporating adjustments to ensure compatibility with the Nebius platform. Get your key from [here](https://studio.nebius.com/).
+The `NebiusEmbedder` can be used to embed text data into vectors using the Nebius Token Factory API. Nebius uses the OpenAI API specification, so the `NebiusEmbedder` class is similar to the `OpenAIEmbedder` class, incorporating adjustments to ensure compatibility with the Nebius platform. Get your key from [here](https://tokenfactory.nebius.com/).
 
 ## Usage
 

--- a/concepts/models/nebius.mdx
+++ b/concepts/models/nebius.mdx
@@ -1,16 +1,16 @@
 ---
-title: Nebius
+title: Nebius Token Factory
 description: Learn how to use Nebius models in Agno.
 ---
 
-Nebius AI Studio is a platform from Nebius that simplifies the process of building applications using AI models. It provides a suite of tools and services for developers to easily test, integrate and fine-tune various AI models, including those for text and image generation.
-You can checkout the list of available models [here](https://studio.nebius.com/).
+Nebius Token Factory is a platform from Nebius that simplifies the process of building applications using AI models. It provides a suite of tools and services for developers to easily test, integrate and fine-tune various AI models, including those for text and image generation.
+You can checkout the list of available models [here](https://tokenfactory.nebius.com/).
 
 We recommend experimenting to find the best-suited-model for your use-case.
 
 ## Authentication
 
-Set your `NEBIUS_API_KEY` environment variable. Get your key [from Nebius AI Studio here](https://studio.nebius.com/?modals=create-api-key).
+Set your `NEBIUS_API_KEY` environment variable. Get your key [from Nebius Token Factory here](https://tokenfactory.nebius.com/?modals=create-api-key).
 
 <CodeGroup>
 
@@ -58,4 +58,4 @@ agent.print_response("Share a 2 sentence horror story.")
 | `name`       | `str`              | `"Nebius"`                     | The name of the model                                                 |
 | `provider`   | `str`              | `"Nebius"`                     | The provider of the model                                             |
 | `api_key`    | `Optional[str]`    | `None`                         | The API key for Nebius (defaults to NEBIUS_API_KEY env var)          |
-| `base_url`   | `str`              | `"https://api.studio.nebius.ai/v1"` | The base URL for the Nebius API                                |
+| `base_url`   | `str`              | `"https://api.tokenfactory.nebius.com/v1"` | The base URL for the Nebius API                                |

--- a/concepts/models/overview.mdx
+++ b/concepts/models/overview.mdx
@@ -324,12 +324,12 @@ Agno supports the following model providers organized by category:
     LiteLLM OpenAI-compatible models.
   </Card>
   <Card
-    title="Nebius AI Studio"
+    title="Nebius Token Factory"
     icon="star"
     iconType="duotone"
     href="/concepts/models/nebius"
   >
-    Nebius AI Studio models.
+    Nebius Token Factory models.
   </Card>
   <Card
     title="Nexus"

--- a/concepts/tools/toolkits/models/nebius.mdx
+++ b/concepts/tools/toolkits/models/nebius.mdx
@@ -1,11 +1,11 @@
 ---
 title: Nebius
-description: NebiusTools provides access to Nebius AI Studio's text-to-image generation capabilities with advanced AI models.
+description: NebiusTools provides access to Nebius Token Factory's text-to-image generation capabilities with advanced AI models.
 ---
 
 ## Example
 
-The following agent can generate images using Nebius AI Studio:
+The following agent can generate images using Nebius Token Factory:
 
 ```python
 from agno.agent import Agent
@@ -13,7 +13,7 @@ from agno.tools.models.nebius import NebiusTools
 
 agent = Agent(
     instructions=[
-        "You are an AI image generation assistant using Nebius AI Studio",
+        "You are an AI image generation assistant using Nebius Token Factory",
         "Create high-quality images based on user descriptions",
         "Provide detailed information about the generated images",
         "Help users refine their prompts for better results",
@@ -29,7 +29,7 @@ agent.print_response("Generate an image of a futuristic city with flying cars at
 | Parameter            | Type                | Default                           | Description                                                    |
 | -------------------- | ------------------- | --------------------------------- | -------------------------------------------------------------- |
 | `api_key`            | `Optional[str]`     | `None`                            | Nebius API key. Uses NEBIUS_API_KEY if not set.              |
-| `base_url`           | `str`               | `"https://api.studio.nebius.com/v1"` | Nebius API base URL.                                       |
+| `base_url`           | `str`               | `"https://api.tokenfactory.nebius.com/v1"` | Nebius API base URL.                                       |
 | `image_model`        | `str`               | `"black-forest-labs/flux-schnell"` | Default image generation model.                              |
 | `image_quality`      | `Optional[str]`     | `"standard"`                      | Image quality setting.                                        |
 | `image_size`         | `Optional[str]`     | `"1024x1024"`                     | Default image dimensions.                                     |
@@ -40,11 +40,11 @@ agent.print_response("Generate an image of a futuristic city with flying cars at
 
 | Function         | Description                                                      |
 | ---------------- | ---------------------------------------------------------------- |
-| `generate_image` | Generate images from text descriptions using Nebius AI models.  |
+| `generate_image` | Generate images from text descriptions using Nebius Token Factory AI models.  |
 
 
 ## Developer Resources
 
 - View [Tools Source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/models/nebius.py)
-- [Nebius AI Studio Documentation](https://docs.nebius.com/)
-- [Nebius API Reference](https://api.studio.nebius.com/docs)
+- [Nebius Token Factory Documentation](https://docs.tokenfactory.nebius.com/)
+- [Nebius API Reference](https://api.tokenfactory.nebius.com/docs)

--- a/concepts/tools/toolkits/toolkits.mdx
+++ b/concepts/tools/toolkits/toolkits.mdx
@@ -481,7 +481,7 @@ The following **Toolkits** are available to use
     iconType="duotone"
     href="/concepts/tools/toolkits/models/nebius"
   >
-    Tools to generate images using Nebius AI Studio.
+    Tools to generate images using Nebius Token Factory.
   </Card>
 </CardGroup>
 

--- a/examples/concepts/tools/models/nebius.mdx
+++ b/examples/concepts/tools/models/nebius.mdx
@@ -10,7 +10,7 @@ from agno.tools.models.nebius import NebiusTools
 
 agent = Agent(
     instructions=[
-        "You are an AI image generation assistant using Nebius AI Studio",
+        "You are an AI image generation assistant using Nebius Token Factory",
         "Create high-quality images based on user descriptions",
         "Provide detailed information about the generated images",
     ],

--- a/reference/knowledge/embedder/nebius.mdx
+++ b/reference/knowledge/embedder/nebius.mdx
@@ -2,7 +2,7 @@
 title: Nebius
 ---
 
-Nebius Embedder is a class that allows you to embed documents using Nebius AI Studio's embedding models. It extends the OpenAI Embedder class and uses a compatible API interface.
+Nebius Embedder is a class that allows you to embed documents using Nebius Token Factory's embedding models. It extends the OpenAI Embedder class and uses a compatible API interface.
 
 ### Parameters
 
@@ -14,7 +14,7 @@ Nebius Embedder is a class that allows you to embed documents using Nebius AI St
 | `user` | `Optional[str]` | A unique identifier representing your end-user | `None` |
 | `api_key` | `Optional[str]` | Nebius API key | Environment variable `NEBIUS_API_KEY` |
 | `organization` | `Optional[str]` | Organization ID for API requests | `None` |
-| `base_url` | `str` | Base URL for API requests | `"https://api.studio.nebius.com/v1/"` |
+| `base_url` | `str` | Base URL for API requests | `"https://api.tokenfactory.nebius.com/v1/"` |
 | `request_params` | `Optional[Dict[str, Any]]` | Additional parameters for embedding requests | `None` |
 | `client_params` | `Optional[Dict[str, Any]]` | Additional parameters for client initialization | `None` |
 | `openai_client` | `Optional[OpenAIClient]` | Pre-configured OpenAI client | `None` |

--- a/reference/models/nebius.mdx
+++ b/reference/models/nebius.mdx
@@ -13,6 +13,6 @@ The Nebius model provides access to Nebius's text and image models.
 | `name`       | `str`              | `"Nebius"`                     | The name of the model                                                 |
 | `provider`   | `str`              | `"Nebius"`                     | The provider of the model                                             |
 | `api_key`    | `Optional[str]`    | `None`                         | The API key for Nebius (defaults to NEBIUS_API_KEY env var)          |
-| `base_url`   | `str`              | `"https://api.studio.nebius.ai/v1"` | The base URL for the Nebius API                                |
+| `base_url`   | `str`              | `"https://api.tokenfactory.nebius.com/v1"` | The base URL for the Nebius API                                |
 
 Nebius extends the OpenAI-compatible interface and supports most parameters from OpenAI.


### PR DESCRIPTION
## Description

This update aligns all documentation with the new **Nebius Token Factory** branding. It replaces outdated references to **Nebius AI Studio** and updates URLs, examples, and documentation links accordingly. The goal is to ensure consistent naming, clear guidance, and accurate API references across all docs.

**Key changes:**

* Updated all mentions of *"Nebius AI Studio"* → *"Nebius Token Factory"*
* Changed API base URLs from `studio.nebius.com` → `tokenfactory.nebius.com`
* Updated internal and external documentation links to the new Token Factory domain
* Revised setup examples and usage snippets to reflect the latest API endpoints

## Type of Change

* [ ] Bug fix (errors, broken links, outdated info)
* [x] Content improvement
* [ ] New content
* [ ] Other:

## Checklist

* [x] Content is accurate and up-to-date
* [x] All links tested and working
* [x] Code examples verified and updated (where applicable)
* [x] Spelling and grammar checked
* [ ] Screenshots updated (if applicable)