### PR TITLE
docs: workflow level duration metric

### DIFF
--- a/concepts/workflows/metrics.mdx
+++ b/concepts/workflows/metrics.mdx
@@ -8,7 +8,7 @@ When you run a workflow in Agno, the response you get (**WorkflowRunOutput**) in
 These metrics help you understand token usage, execution time, performance, and step-level details across all agents, teams, and custom functions in your workflow.
 
 Metrics are available at multiple levels:
-- **Per workflow**: Each `WorkflowRunOutput` includes `metrics.duration` tracking total workflow execution time.
+- **Per workflow**: Each `WorkflowRunOutput` includes a metrics object containing the workflow duration.
 - **Per step**: Each step has its own metrics including duration, token usage, and model information.
 - **Per session**: Session metrics aggregate all step-level metrics across all runs in the session.
 

--- a/concepts/workflows/metrics.mdx
+++ b/concepts/workflows/metrics.mdx
@@ -3,7 +3,9 @@ title: Metrics
 description: Understanding workflow run and session metrics in Agno
 ---
 
-When you run a workflow in Agno, the response you get (**WorkflowRunOutput**) includes detailed metrics about the workflow execution. These metrics help you understand resource usage (like token usage and execution time), performance, and step-level details across all agents, teams, and custom functions in your workflow.
+When you run a workflow in Agno, the response you get (**WorkflowRunOutput**) includes detailed metrics about the workflow execution. 
+
+These metrics help you understand token usage, execution time, performance, and step-level details across all agents, teams, and custom functions in your workflow.
 
 Metrics are available at multiple levels:
 - **Per workflow**: Each `WorkflowRunOutput` includes `metrics.duration` tracking total workflow execution time.

--- a/concepts/workflows/metrics.mdx
+++ b/concepts/workflows/metrics.mdx
@@ -1,0 +1,112 @@
+---
+title: Metrics
+description: Understanding workflow run and session metrics in Agno
+---
+
+When you run a workflow in Agno, the response you get (**WorkflowRunOutput**) includes detailed metrics about the workflow execution. These metrics help you understand resource usage (like token usage and execution time), performance, and step-level details across all agents, teams, and custom functions in your workflow.
+
+Metrics are available at multiple levels:
+- **Per workflow**: Each `WorkflowRunOutput` includes `metrics.duration` tracking total workflow execution time.
+- **Per step**: Each step has its own metrics including duration, token usage, and model information.
+- **Per session**: Session metrics aggregate all step-level metrics across all runs in the session.
+
+
+## Example Usage
+
+Here's how you can access and use workflow metrics:
+
+```python
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.team import Team
+from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.tools.hackernews import HackerNewsTools
+from agno.workflow import Step, Workflow
+from rich.pretty import pprint
+
+# Define agents
+hackernews_agent = Agent(
+    name="Hackernews Agent",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    tools=[HackerNewsTools()],
+    role="Extract key insights from Hackernews posts",
+)
+
+web_agent = Agent(
+    name="Web Agent",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    tools=[DuckDuckGoTools()],
+    role="Search the web for latest trends",
+)
+
+# Define research team
+research_team = Team(
+    name="Research Team",
+    members=[hackernews_agent, web_agent],
+    instructions="Research tech topics from Hackernews and the web",
+)
+
+content_planner = Agent(
+    name="Content Planner",
+    model=OpenAIChat(id="gpt-4o"),
+    instructions="Plan a content schedule based on research",
+)
+
+# Create workflow
+workflow = Workflow(
+    name="Content Creation Workflow",
+    db=SqliteDb(db_file="tmp/workflow.db"),
+    steps=[
+        Step(name="Research Step", team=research_team),
+        Step(name="Content Planning Step", agent=content_planner),
+    ],
+)
+
+# Run workflow
+response = workflow.run(input="AI trends in 2024")
+
+# Print workflow-level metrics
+print("Workflow Metrics")
+if response.metrics:
+    pprint(response.metrics.to_dict())
+
+# Print workflow duration
+if response.metrics and response.metrics.duration:
+    print(f"\nTotal execution time: {response.metrics.duration:.2f} seconds")
+
+# Print step-level metrics
+print("Step Metrics")
+if response.metrics:
+    for step_name, step_metrics in response.metrics.steps.items():
+        print(f"\nStep: {step_name}")
+        print(f"Executor: {step_metrics.executor_name} ({step_metrics.executor_type})")
+        if step_metrics.metrics:
+            print(f"Duration: {step_metrics.metrics.duration:.2f}s")
+            print(f"Tokens: {step_metrics.metrics.total_tokens}")
+
+# Print session metrics
+print("Session Metrics")
+pprint(workflow.get_session_metrics().to_dict())
+```
+
+You'll see the outputs with following information:
+
+**Workflow-level metrics:**
+- `duration`: Total workflow execution time in seconds (from start to finish, including orchestration overhead)
+- `steps`: Dictionary mapping step names to their individual step metrics
+
+**Step-level metrics:**
+- `step_name`: Name of the step
+- `executor_type`: Type of executor ("agent", "team", or "function")
+- `executor_name`: Name of the executor
+- `metrics`: Execution metrics including tokens, duration, and model information (see [Metrics schema](/reference/agents/metrics))
+
+**Session metrics:**
+- Aggregates step-level metrics (tokens, duration) across all runs in the session
+- Includes only agent/team execution time, not workflow orchestration overhead
+
+
+## Developer Resources
+
+- View the [WorkflowRunOutput schema](/reference/workflows/workflow_run_output)

--- a/docs.json
+++ b/docs.json
@@ -168,6 +168,7 @@
                   "concepts/workflows/access-previous-steps",
                   "concepts/workflows/early-stop",
                   "concepts/workflows/cancel-workflow",
+                  "concepts/workflows/metrics",
                   "concepts/workflows/workflow-tools",
                   "concepts/workflows/background-execution"
                 ]

--- a/reference/workflows/workflow_run_output.mdx
+++ b/reference/workflows/workflow_run_output.mdx
@@ -20,7 +20,7 @@ sidebarTitle: WorkflowRunOutput & Events
 | `step_results` | `List[Union[StepOutput, List[StepOutput]]]` | `[]` | Actual step execution results as StepOutput objects |
 | `step_executor_runs` | `Optional[List[Union[RunOutput, TeamRunOutput]]]` | `None` | Store agent/team responses separately with parent_run_id references |
 | `events` | `Optional[List[WorkflowRunOutputEvent]]` | `None` | Events captured during workflow execution |
-| `metrics` | `Optional[WorkflowMetrics]` | `None` | Workflow metrics aggregated from all steps |
+| `metrics` | `Optional[WorkflowMetrics]` | `None` | Workflow metrics including duration and step-level data |
 | `metadata` | `Optional[Dict[str, Any]]` | `None` | Additional metadata stored with the response |
 | `created_at` | `int` | `int(time())` | Unix timestamp when the response was created |
 | `status` | `RunStatus` | `RunStatus.pending` | Current status of the workflow run |
@@ -237,3 +237,19 @@ sidebarTitle: WorkflowRunOutput & Events
 | `success` | `bool` | - | Whether the step succeeded |
 | `error` | `Optional[str]` | - | Error message if step failed |
 | `stop` | `bool` | - | Whether the step requested early termination |
+
+## WorkflowMetrics
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `steps` | `Dict[str, StepMetrics]` | - | Step-level metrics mapped by step name |
+| `duration` | `Optional[float]` | `None` | Total workflow execution time in seconds |
+
+### StepMetrics
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `step_name` | `str` | - | Name of the step |
+| `executor_type` | `str` | - | Type of executor ("agent", "team", or "function") |
+| `executor_name` | `str` | - | Name of the executor |
+| `metrics` | `Optional[Metrics]` | `None` | Execution metrics (duration, tokens, model usage) |


### PR DESCRIPTION
## Description

  Documents the workflow-level duration feature that measures total execution time from start to finish.

  Workflow-Level Duration Tracking
  - WorkflowMetrics.duration - Total workflow execution time in seconds (from start to finish)
  - Includes orchestration overhead, data passing between steps, and all step execution
  - Tracked for all workflow runs (sync, async, streaming, error cases)

  Step-Level Metrics Structure
  - StepMetrics contains: step_name, executor_type, executor_name, and metrics
  - Each step tracks its own duration, token usage, and model information

  Session Metrics Aggregation
  - workflow.get_session_metrics() aggregates step-level metrics across all runs
  - Returns sum of agent/team execution times

  Documentation Added

  - concepts/workflows/metrics.mdx - Complete guide with working code example showing how to access workflow duration, step metrics, and session metrics
  - reference/workflows/workflow_run_output.mdx - Added WorkflowMetrics and StepMetrics schema documentation
  - docs.json - Added metrics to workflows navigation

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Related SDK PR: agno-agi/agno#5369

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
