### PR TITLE
feat: AgentOS MCP pages

### DIFF
--- a/agent-os/mcp/mcp.mdx
+++ b/agent-os/mcp/mcp.mdx
@@ -1,6 +1,7 @@
 ---
 title: "AgentOS as MCP Server"
 description: "Learn how and why to expose your AgentOS as an MCP server"
+keywords: [agentos, mcp, mcp server, expose as mcp]
 ---
 
 Your AgentOS will by default be exposed as an API. But you can also expose it as an **MCP server**.

--- a/agent-os/mcp/mcp.mdx
+++ b/agent-os/mcp/mcp.mdx
@@ -141,9 +141,4 @@ Delete the desired memory
 - `db_id` (str): The ID of the database to use
 - `memory_id` (str): The ID of the memory to delete
 
-
-
-<<<<<<< Updated upstream
-See here for a [full example](/examples/agent-os/mcp/enable-mcp-example).
-=======
->>>>>>> Stashed changes
+See a full example [here](/examples/agent-os/mcp/enable-mcp-example).

--- a/agent-os/mcp/mcp.mdx
+++ b/agent-os/mcp/mcp.mdx
@@ -1,11 +1,24 @@
 ---
-title: "MCP enabled AgentOS"
-description: "Learn how to enable MCP functionality in your AgentOS"
-mode: wide
+title: "AgentOS as MCP Server"
+description: "Learn how and why to expose your AgentOS as an MCP server"
 ---
 
-Model Context Protocol (MCP) gives Agents the ability to interact with external systems through a standardized interface.
-To turn your AgentOS into an MCP server, you can set `enable_mcp_server=True` when creating your AgentOS instance.
+Your AgentOS will by default be exposed as an API. But you can also expose it as an **MCP server**.
+
+This is done by setting `enable_mcp_server=True` when creating your AgentOS instance:
+
+```python
+agent_os = AgentOS(enable_mcp_server=True)
+```
+
+## Why use MCP?
+
+The [MCP protocol](https://modelcontextprotocol.io) has become the industry standard to handle connecting AI applications with external tools and data sources.
+
+By exposing your AgentOS as an MCP server, external clients that can handle MCP-compatible applications will be able to connect to your AgentOS and interact with it.
+
+
+## Example
 
 ```python enable_mcp_example.py
 from agno.agent import Agent
@@ -38,13 +51,99 @@ app = agent_os.get_app()
 if __name__ == "__main__":
     # Your MCP server will be available at http://localhost:7777/mcp
     agent_os.serve(app="enable_mcp_example:app", reload=True)
+
 ```
 
-Once enabled, your AgentOS will expose an MCP server at the `/mcp` endpoint that provides:
-- Access to your AgentOS configuration
-- Information about available agents, teams, and workflows
-- The ability to run agents, teams, and workflows
-- The ability to create and delete sessions
-- The ability to create, update, and delete memories
+Once enabled, your AgentOS will expose an MCP server via the `/mcp` endpoint.
 
+You can see a complete example [here](/examples/agent-os/mcp/enable_mcp_example).
+
+## Available MCP Tools
+
+When you expose your AgentOS as an MCP server, the following MCP tools will be available:
+
+### `get_agentos_config`
+Get the configuration of the AgentOS
+
+### `run_agent`
+Run the desired Agent
+
+- `agent_id` (str): The ID of the agent to run
+- `message` (str): The message to send to the agent
+
+### `run_team`
+Run the desired Team
+
+- `team_id` (str): The ID of the team to run
+- `message` (str): The message to send to the team
+
+### `run_workflow`
+Run the desired Workflow
+
+- `workflow_id` (str): The ID of the workflow to run
+- `message` (str): The message to send to the workflow
+
+### `get_sessions_for_agent`
+Get the list of sessions for the desired Agent
+
+- `agent_id` (str): The ID of the agent to get the sessions for
+- `db_id` (str): The ID of the database to use
+- `user_id` (Optional[str]): The ID of the user to get the sessions for
+- `sort_by` (Optional[str]): The field to sort the sessions by. Defaults to `created_at`
+- `sort_order` (Optional[str]): The order to sort the sessions by. Defaults to `desc`
+
+
+### `get_sessions_for_team`
+Get the list of sessions for the desired Team
+
+- `team_id` (str): The ID of the team to get the sessions for
+- `db_id` (str): The ID of the database to use
+- `user_id` (Optional[str]): The ID of the user to get the sessions for
+- `sort_by` (Optional[str]): The field to sort the sessions by. Defaults to `created_at`
+- `sort_order` (Optional[str]): The order to sort the sessions by. Defaults to `desc`
+
+### `get_sessions_for_workflow`
+Get the list of sessions for the desired Workflow
+
+- `workflow_id` (str): The ID of the workflow to get the sessions for
+- `db_id` (str): The ID of the database to use
+- `user_id` (Optional[str]): The ID of the user to get the sessions for
+- `sort_by` (Optional[str]): The field to sort the sessions by. Defaults to `created_at`
+- `sort_order` (Optional[str]): The order to sort the sessions by. Defaults to `desc`
+
+### `create_memory`
+Create a new user memory
+
+- `db_id` (str): The ID of the database to use
+- `memory` (str): The memory content to store
+- `user_id` (str): The user this memory is about
+- `topics` (Optional[list[str]]): The topics of the memory
+
+### `get_memories_for_user`
+Get the list of memories for the given user
+
+- `user_id` (str): The ID of the user to get the memories for
+- `db_id` (Optional[str]): The ID of the database to use
+- `sort_by` (Optional[str]): The field to sort the memories by. Defaults to `created_at`
+- `sort_order` (Optional[str]): The order to sort the memories by. Defaults to `desc`
+
+### `update_memory`
+Update the desired memory
+
+- `db_id` (str): The ID of the database to use
+- `memory_id` (str): The ID of the memory to update
+- `memory` (str): The memory content to store
+- `user_id` (str): The ID of the user to update the memory for
+
+### `delete_memory`
+Delete the desired memory
+
+- `db_id` (str): The ID of the database to use
+- `memory_id` (str): The ID of the memory to delete
+
+
+
+<<<<<<< Updated upstream
 See here for a [full example](/examples/agent-os/mcp/enable-mcp-example).
+=======
+>>>>>>> Stashed changes

--- a/agent-os/mcp/tools.mdx
+++ b/agent-os/mcp/tools.mdx
@@ -1,14 +1,21 @@
 ---
-title: "AgentOS + MCPTools"
-description: "Learn how to use MCPTools in your AgentOS"
+title: "MCPTools within AgentOS"
+description: "Learn how to use MCPTools in the Agents, Teams and Workflows within your AgentOS"
 mode: wide
 ---
 
-Model Context Protocol (MCP) gives Agents the ability to interact with external systems through a standardized interface. 
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) enables Agents to interact with external systems through a standardized interface.
 
-You can give your agents access to tools from MCP servers using [`MCPTools`](/basics/tools/mcp).
+You can give your Agents access to MCP tools using the `MCPTools` class. Read more about using MCP tools [here](/concepts/tools/mcp).
 
-When using MCPTools within AgentOS, the lifecycle is automatically managed. No need to manually connect or disconnect the `MCPTools` instance.
+Your `MCPTools` will work normally within AgentOS. Their lifecycle is automatically handled, you don't need to handle their connection and disconnection.
+
+<Note>
+If you are using `MCPTools` within AgentOS, you should not use `reload=True` when serving your AgentOS.
+This can break the MCP connection during the FastAPI lifecycle.
+</Note>
+
+## Example
 
 ```python mcp_tools_example.py
 from agno.agent import Agent
@@ -17,7 +24,7 @@ from agno.tools.mcp import MCPTools
 
 # Create MCPTools instance
 mcp_tools = MCPTools(
-    transport="streamable-http", 
+    transport="streamable-http",
     url="https://docs.agno.com/mcp"
 )
 
@@ -42,12 +49,8 @@ if __name__ == "__main__":
 ```
 
 <Note>
-This does not automatically refresh connections that are interrupted or restarted, you can use [`refresh_connection`](/basics/tools/mcp/overview#connection-refresh) to do so.
+Refreshing the connection to MCP servers is **not** automatically handled. You can use [`refresh_connection`](/concepts/tools/mcp/overview#connection-refresh) to manually refresh a connection.
 </Note>
 
-<Note>
-If you are using `MCPTools` within AgentOS, you should not use `reload=True` when serving your AgentOS. 
-This can break the MCP connection during the FastAPI lifecycle.
-</Note>
 
 See here for a [full example](/examples/agent-os/mcp/mcp-tools-example).


### PR DESCRIPTION
- Revisit the `AgentOS > MCP server` page and add a reference to all MCP tools available when exposing the OS as an MCP server
- Minor update for the `AgentOS > MCP tools` page