### PR TITLE
docs: show_member_responses on print methods

### DIFF
--- a/concepts/agents/state.mdx
+++ b/concepts/agents/state.mdx
@@ -82,7 +82,7 @@ print(f"Final session state: {agent.get_session_state()}")
 A big advantage of **sessions** is the ability to maintain state across multiple runs within the same session. For example, let's say the agent is helping a user keep track of their shopping list.
 
 <Tip>
-  You have to configure your storage via the `db` parameter for state to be persisted across runs. See [Storage](/concepts/storage/overview) for more information.
+  You have to configure your storage via the `db` parameter for state to be persisted across runs. See [Storage](/concepts/db/overview) for more information.
 </Tip>
 
 

--- a/concepts/models/anthropic.mdx
+++ b/concepts/models/anthropic.mdx
@@ -91,7 +91,7 @@ agent = Agent(
 )
 ```
 
-Read more about prompt caching with Agno's `Claude` model [here](/examples/models/anthropic/betas/prompt_caching).
+Read more about prompt caching with Agno's `Claude` model [here](/examples/models/anthropic/prompt_caching).
 
 
 ## Params

--- a/concepts/teams/debugging-teams.mdx
+++ b/concepts/teams/debugging-teams.mdx
@@ -36,7 +36,7 @@ team = Team(
 )
 
 # Run team and print response to the terminal
-team.print_response("What is the weather in Tokyo?")
+team.print_response("What is the weather in Tokyo?", show_member_responses=True)
 ```
 
 <Tip>

--- a/reference/teams/team.mdx
+++ b/reference/teams/team.mdx
@@ -194,6 +194,7 @@ Run the team and print the response.
 - `add_session_state_to_context` (Optional[bool]): Whether to add session state to context
 - `metadata` (Optional[Dict[str, Any]]): Metadata to use for this run
 - `debug_mode` (Optional[bool]): Whether to enable debug mode
+- `show_member_responses` (Optional[bool]): Whether to show member responses
 
 ### `aprint_response`
 
@@ -224,6 +225,7 @@ Run the team and print the response asynchronously.
 - `add_session_state_to_context` (Optional[bool]): Whether to add session state to context
 - `metadata` (Optional[Dict[str, Any]]): Metadata to use for this run
 - `debug_mode` (Optional[bool]): Whether to enable debug mode
+- `show_member_responses` (Optional[bool]): Whether to show member responses
 
 ### `cli_app`
 


### PR DESCRIPTION
## Description

Added show_member_responses on print methods and fixed broken links

## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#5435

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
