### PR TITLE
feat: add structured output examples and documentation for Claude models

### DIFF
--- a/concepts/models/anthropic.mdx
+++ b/concepts/models/anthropic.mdx
@@ -94,6 +94,35 @@ agent = Agent(
 Read more about prompt caching with Agno's `Claude` model [here](/examples/models/anthropic/prompt_caching).
 
 
+## Structured Outputs
+
+Claude models support native structured outputs, allowing you to generate responses that strictly follow a Pydantic schema. This feature is available for `claude-sonnet-4-5-20250929` and newer models.
+
+Structured outputs ensure that the model's response matches your defined schema exactly, eliminating issues like missing fields or invalid values. This is ideal for production systems that need reliable, validated responses.
+
+```python
+from agno.agent import Agent
+from agno.models.anthropic import Claude
+from pydantic import BaseModel
+
+class User(BaseModel):
+    name: str
+    age: int
+    email: str
+
+agent = Agent(
+    model=Claude(id="claude-sonnet-4-5-20250929"),
+    description="Extract user information.",
+    output_schema=User,
+)
+```
+
+Read more about structured outputs with Agno's `Claude` model:
+- [Basic structured outputs](/examples/models/anthropic/structured_output)
+- [Streaming structured outputs](/examples/models/anthropic/structured_output_stream)
+- [Structured outputs with strict tools](/examples/models/anthropic/structured_output_strict_tools)
+
+
 ## Params
 
 | Parameter             | Type                                     | Default                        | Description                                                                                                                      |

--- a/concepts/models/anthropic.mdx
+++ b/concepts/models/anthropic.mdx
@@ -96,9 +96,11 @@ Read more about prompt caching with Agno's `Claude` model [here](/examples/model
 
 ## Structured Outputs
 
-Claude models support native structured outputs, allowing you to generate responses that strictly follow a Pydantic schema. This feature is available for `claude-sonnet-4-5-20250929` and newer models. See Anthropic's [structured outputs documentation](https://docs.anthropic.com/en/build-with-claude/structured-outputs) for more details.
+Structured outputs are used to ensure that the model's response matches a defined schema. 
 
-Structured outputs ensure that the model's response matches your defined schema exactly, eliminating issues like missing fields or invalid values. This is ideal for production systems that need reliable, validated responses.
+This is useful to eliminate issues like missing fields or invalid values. Use it for production systems that need reliable, consistent responses in a specific format.
+
+Agno uses Claude's native support for structured outputs. This feature is available for `claude-sonnet-4-5-20250929` and all newer models. See Anthropic's [structured outputs documentation](https://docs.anthropic.com/en/build-with-claude/structured-outputs) for more details.
 
 ```python
 from agno.agent import Agent

--- a/concepts/models/anthropic.mdx
+++ b/concepts/models/anthropic.mdx
@@ -96,7 +96,7 @@ Read more about prompt caching with Agno's `Claude` model [here](/examples/model
 
 ## Structured Outputs
 
-Claude models support native structured outputs, allowing you to generate responses that strictly follow a Pydantic schema. This feature is available for `claude-sonnet-4-5-20250929` and newer models.
+Claude models support native structured outputs, allowing you to generate responses that strictly follow a Pydantic schema. This feature is available for `claude-sonnet-4-5-20250929` and newer models. See Anthropic's [structured outputs documentation](https://docs.anthropic.com/en/build-with-claude/structured-outputs) for more details.
 
 Structured outputs ensure that the model's response matches your defined schema exactly, eliminating issues like missing fields or invalid values. This is ideal for production systems that need reliable, validated responses.
 

--- a/docs.json
+++ b/docs.json
@@ -2377,6 +2377,8 @@
                   "examples/models/anthropic/skills",
                   "examples/models/anthropic/tool_use",
                   "examples/models/anthropic/structured_output",
+                  "examples/models/anthropic/structured_output_stream",
+                  "examples/models/anthropic/structured_output_strict_tools",
                   "examples/models/anthropic/knowledge",
                   "examples/models/anthropic/file_upload",
                   "examples/models/anthropic/image_input_bytes",

--- a/examples/models/anthropic/structured_output.mdx
+++ b/examples/models/anthropic/structured_output.mdx
@@ -62,14 +62,8 @@ movie_agent.print_response("New York")
   </Step>
 
   <Step title="Run Agent">
-    <CodeGroup>
-    ```bash Mac
+    ```bash
     python structured_output.py
     ```
-
-    ```bash Windows
-    python structured_output.py
-    ```
-    </CodeGroup>
   </Step>
 </Steps>

--- a/examples/models/anthropic/structured_output_stream.mdx
+++ b/examples/models/anthropic/structured_output_stream.mdx
@@ -1,16 +1,15 @@
 ---
-title: Agent with Structured Outputs
+title: Agent with Structured Outputs Streaming
 ---
 
 ## Code
 
-```python structured_output.py
-from typing import List
+```python structured_output_stream.py
+from typing import Dict, List
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent
 from agno.models.anthropic import Claude
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
 
 
 class MovieScript(BaseModel):
@@ -30,18 +29,20 @@ class MovieScript(BaseModel):
     storyline: str = Field(
         ..., description="3 sentence storyline for the movie. Make it exciting!"
     )
+    rating: Dict[str, int] = Field(
+        ...,
+        description="Your own rating of the movie. 1-10. Return a dictionary with the keys 'story' and 'acting'.",
+    )
 
 
-movie_agent = Agent(
+# Agent that uses structured outputs
+structured_output_agent = Agent(
     model=Claude(id="claude-sonnet-4-5-20250929"),
-    description="You help people write movie scripts.",
+    description="You write movie scripts.",
     output_schema=MovieScript,
 )
 
-movie_agent.print_response("New York")
-
-# You can also get the response in a variable:
-# run: RunOutput = movie_agent.run("New York")
+structured_output_agent.print_response("New York", stream=True)
 ```
 
 ## Usage
@@ -64,12 +65,13 @@ movie_agent.print_response("New York")
   <Step title="Run Agent">
     <CodeGroup>
     ```bash Mac
-    python structured_output.py
+    python structured_output_stream.py
     ```
 
     ```bash Windows
-    python structured_output.py
+    python structured_output_stream.py
     ```
     </CodeGroup>
   </Step>
 </Steps>
+

--- a/examples/models/anthropic/structured_output_stream.mdx
+++ b/examples/models/anthropic/structured_output_stream.mdx
@@ -63,15 +63,9 @@ structured_output_agent.print_response("New York", stream=True)
   </Step>
 
   <Step title="Run Agent">
-    <CodeGroup>
-    ```bash Mac
+    ```bash
     python structured_output_stream.py
     ```
-
-    ```bash Windows
-    python structured_output_stream.py
-    ```
-    </CodeGroup>
   </Step>
 </Steps>
 

--- a/examples/models/anthropic/structured_output_strict_tools.mdx
+++ b/examples/models/anthropic/structured_output_strict_tools.mdx
@@ -81,15 +81,9 @@ agent.print_response("What's the weather like in San Francisco?")
   </Step>
 
   <Step title="Run Agent">
-    <CodeGroup>
-    ```bash Mac
+    ```bash
     python structured_output_strict_tools.py
     ```
-
-    ```bash Windows
-    python structured_output_strict_tools.py
-    ```
-    </CodeGroup>
   </Step>
 </Steps>
 

--- a/examples/models/anthropic/structured_output_strict_tools.mdx
+++ b/examples/models/anthropic/structured_output_strict_tools.mdx
@@ -1,0 +1,95 @@
+---
+title: Agent with Structured Outputs and Strict Tools
+---
+
+This example demonstrates how to use strict tool validation with structured outputs. Strict tool use ensures that tool parameters strictly follow the input schema, providing additional validation when using tools alongside structured outputs.
+
+## Code
+
+```python structured_output_strict_tools.py
+from agno.agent import Agent
+from agno.models.anthropic import Claude
+from agno.tools import Function
+from pydantic import BaseModel
+
+
+class WeatherInfo(BaseModel):
+    """Structured output schema for weather information."""
+
+    location: str
+    temperature: float
+    unit: str
+    condition: str
+
+
+def get_weather(location: str, unit: str = "celsius") -> str:
+    temp = 72 if unit == "fahrenheit" else 22
+    return f"Weather in {location}: {temp}°{unit}, Sunny"
+
+
+# Create function with strict mode enabled
+weather_tool = Function(
+    name="get_weather",
+    description="Get current weather information for a location",
+    parameters={
+        "type": "object",
+        "properties": {
+            "location": {
+                "type": "string",
+                "description": "The city and state, e.g. San Francisco, CA",
+            },
+            "unit": {
+                "type": "string",
+                "enum": ["celsius", "fahrenheit"],
+                "description": "Temperature unit",
+            },
+        },
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+    strict=True,  # Enable strict mode for validated tool parameters
+    entrypoint=get_weather,
+)
+
+# Agent with both structured outputs and strict tool
+agent = Agent(
+    model=Claude(id="claude-sonnet-4-5-20250929"),
+    tools=[weather_tool],
+    output_schema=WeatherInfo,
+    description="You help users get weather information.",
+)
+
+# The agent will use strict tool validation and return structured output
+agent.print_response("What's the weather like in San Francisco?")
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export ANTHROPIC_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install libraries">
+    ```bash
+    pip install -U anthropic agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    <CodeGroup>
+    ```bash Mac
+    python structured_output_strict_tools.py
+    ```
+
+    ```bash Windows
+    python structured_output_strict_tools.py
+    ```
+    </CodeGroup>
+  </Step>
+</Steps>
+


### PR DESCRIPTION
- Added new examples for structured outputs, including streaming and strict tools.
- Updated existing documentation to reflect the new structured output capabilities.
- Introduced new files: `structured_output_stream.mdx` and `structured_output_strict_tools.mdx`.
- Enhanced the `structured_output.mdx` with updated code snippets and usage instructions.