### PR TITLE
docs: clarify DashScope base URL requirement for Mainland China users

### DIFF
--- a/integrations/models/native/dashscope/overview.mdx
+++ b/integrations/models/native/dashscope/overview.mdx
@@ -60,7 +60,7 @@ agent.print_response("Share a 2 sentence horror story.")
 | `name`              | `str`              | `"Qwen"`                                                     | The name of the model                                                 |
 | `provider`          | `str`              | `"Dashscope"`                                                | The provider of the model                                             |
 | `api_key`           | `Optional[str]`    | `None`                                                       | The API key for DashScope (defaults to DASHSCOPE_API_KEY env var)    |
-| `base_url`          | `str`              | `"https://dashscope-intl.aliyuncs.com/compatible-mode/v1"`  | The base URL for the DashScope API                                    |
+| `base_url`          | `str`              | `"https://dashscope-intl.aliyuncs.com/compatible-mode/v1"`  | The base URL for the DashScope API. For users in Mainland China, you must set the base URL to https://dashscope.aliyuncs.com/compatible-mode/v1 to avoid the “invalid API key” error.                                    |
 | `enable_thinking`   | `bool`             | `False`                                                      | Enable thinking process for reasoning models                          |
 | `include_thoughts`  | `Optional[bool]`   | `None`                                                       | Include thinking process in response (alternative parameter)          |
 | `thinking_budget`   | `Optional[int]`    | `None`                                                       | Budget for thinking tokens in reasoning models                        |


### PR DESCRIPTION
docs: update DashScope base URL instructions for Mainland China users

Added a note explaining that users in Mainland China must set the base URL to: https://dashscope.aliyuncs.com/compatible-mode/v1

This prevents the "invalid API key" error that occurs when using the default base URL in the region.

## Description

docs: update DashScope base URL instructions for Mainland China users

Added a note explaining that users in Mainland China must set the base URL to:
https://dashscope.aliyuncs.com/compatible-mode/v1

This prevents the "invalid API key" error that occurs when using the default base URL in the region.


```python
from os import getenv

from agno.agent import Agent
from agno.db.sqlite import SqliteDb
from agno.models.dashscope import DashScope
from agno.os import AgentOS
from agno.tools.mcp import MCPTools
from dotenv import load_dotenv

load_dotenv()
agent = Agent(
    model=DashScope(
        id="qwen-plus",
        api_key=getenv("DASHSCOPE_API_KEY"),
        temperature=0.5,
        provider="dashscope",
        base_url=getenv("BASE_URL", ""),
    ),
    name="agno agent",
    instructions="You are a helpful assistant.",
    markdown=True,
    db=SqliteDb(db_file="agno.db"),
    tools=[MCPTools(transport="streamable-http", url="https://docs.agno.com/mcp")],
    add_history_to_context=True,
)
```


**Note:** Your PR title must follow conventional commit format (e.g., `docs: add auth guide`, `fix: correct broken links`, `style: update formatting`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
