### PR TITLE
docs: json output schema

### DIFF
--- a/agent-os/api/usage.mdx
+++ b/agent-os/api/usage.mdx
@@ -71,13 +71,23 @@ curl --location 'http://localhost:7777/agents/story-writer-agent/runs' \
 
 ## Passing Output Schema
 
-You can pass an output schema for a specific agent or team run by passing the `output_schema` parameter as a JSON schema string.
+You can pass an output schema for a specific agent or team run by passing the `output_schema` parameter as a JSON schema string. By default, the schema is converted to a Pydantic model.
 
 ```bash
 curl --location 'http://localhost:7777/agents/story-writer-agent/runs' \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'message=Write a story' \
     --data-urlencode 'output_schema={"type":"object","properties":{"title":{"type":"string"},"content":{"type":"string"}},"required":["title","content"]}'
+```
+
+To keep the output schema as a JSON dict instead of converting to a Pydantic model, set `use_json_schema=true`:
+
+```bash
+curl --location 'http://localhost:7777/agents/story-writer-agent/runs' \
+    --header 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode 'message=Write a story' \
+    --data-urlencode 'output_schema={"type":"json_schema","json_schema":{"name":"StoryOutput","schema":{"type":"object","properties":{"title":{"type":"string"},"content":{"type":"string"}},"required":["title","content"],"additionalProperties":false}}}' \
+    --data-urlencode 'use_json_schema=true'
 ```
 
 ## Cancelling a Run

--- a/basics/input-output/agent/usage/json-schema-output.mdx
+++ b/basics/input-output/agent/usage/json-schema-output.mdx
@@ -1,0 +1,79 @@
+---
+title: JSON Schema Output
+description: Use JSON dict schema for structured agent output
+---
+
+This example demonstrates how to use a JSON dict schema directly instead of a Pydantic model for structured output. This is useful when you need to use provider-specific schema formats.
+
+<Steps>
+
+  <Step title="Add the following code to your Python file">
+    ```python json_schema_output.py
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIChat
+    from rich.pretty import pprint
+
+    person_schema = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "PersonInfo",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Person's full name"},
+                    "age": {"type": "integer", "description": "Person's age"},
+                    "occupation": {"type": "string", "description": "Person's occupation"},
+                },
+                "required": ["name", "age", "occupation"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+    agent = Agent(model=OpenAIChat(id="gpt-4o-mini"), markdown=False)
+
+    response = agent.run(
+        "Tell me about Albert Einstein",
+        output_schema=person_schema,
+        stream=False,
+    )
+
+    pprint(response.content)
+    ```
+  </Step>
+
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install libraries">
+    ```bash
+    pip install -U agno openai rich
+    ```
+  </Step>
+
+  <Step title="Export your OpenAI API key">
+
+    <CodeGroup>
+
+    ```bash Mac/Linux
+      export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+      $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the example">
+    <CodeGroup>
+    ```bash Mac
+    python json_schema_output.py
+    ```
+
+    ```bash Windows
+    python json_schema_output.py
+    ```
+    </CodeGroup>
+  </Step>
+
+</Steps>

--- a/basics/input-output/agent/usage/json-schema-output.mdx
+++ b/basics/input-output/agent/usage/json-schema-output.mdx
@@ -3,7 +3,9 @@ title: JSON Schema Output
 description: Use JSON dict schema for structured agent output
 ---
 
-This example demonstrates how to use a JSON dict schema directly instead of a Pydantic model for structured output. This is useful when you need to use provider-specific schema formats.
+When providing your Agent with a structured output format to follow, you will normally prefer to do so using a Pydantic model. You can read more about structured outputs [here](https://docs.agno.com/examples/getting-started/05-structured-output#structured-output).
+
+If you need to use provider-specific schema formats, you can also use a simple JSON dict as schema, instead of a Pydantic model. For example:
 
 <Steps>
 

--- a/basics/input-output/agent/usage/output-schema-on-run.mdx
+++ b/basics/input-output/agent/usage/output-schema-on-run.mdx
@@ -1,0 +1,69 @@
+---
+title: Output Schema on Run
+description: Pass output schema to a specific agent run
+---
+
+This example demonstrates how to pass an `output_schema` to a specific agent run, allowing you to get structured output without setting a default schema on the agent.
+
+<Steps>
+
+  <Step title="Add the following code to your Python file">
+    ```python output_schema_on_run.py
+    from pydantic import BaseModel
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIChat
+
+
+    class MovieReview(BaseModel):
+        title: str
+        rating: int
+        summary: str
+
+
+    agent = Agent(model=OpenAIChat(id="gpt-4o-mini"))
+
+    response = agent.run(
+        "Review the movie 'Inception'",
+        output_schema=MovieReview,
+        stream=False,
+    )
+
+    print(response.content)
+    ```
+  </Step>
+
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install libraries">
+    ```bash
+    pip install -U agno openai
+    ```
+  </Step>
+
+  <Step title="Export your OpenAI API key">
+
+    <CodeGroup>
+
+    ```bash Mac/Linux
+      export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+      $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the example">
+    <CodeGroup>
+    ```bash Mac
+    python output_schema_on_run.py
+    ```
+
+    ```bash Windows
+    python output_schema_on_run.py
+    ```
+    </CodeGroup>
+  </Step>
+
+</Steps>

--- a/basics/input-output/team/usage/json-schema-output.mdx
+++ b/basics/input-output/team/usage/json-schema-output.mdx
@@ -3,7 +3,9 @@ title: "JSON Schema Output"
 description: "Use JSON dict schema for structured team output"
 ---
 
-This example demonstrates how to use a JSON dict schema directly instead of a Pydantic model for structured team output. This is useful when you need to use provider-specific schema formats.
+When providing your Team with a structured output format to follow, you will normally prefer to do so using a Pydantic model. You can read more about structured outputs [here](https://docs.agno.com/examples/getting-started/05-structured-output#structured-output).
+
+If you need to use provider-specific schema formats, you can also use a simple JSON dict as schema, instead of a Pydantic model. For example:
 
 <Steps>
 

--- a/basics/input-output/team/usage/json-schema-output.mdx
+++ b/basics/input-output/team/usage/json-schema-output.mdx
@@ -1,0 +1,100 @@
+---
+title: "JSON Schema Output"
+description: "Use JSON dict schema for structured team output"
+---
+
+This example demonstrates how to use a JSON dict schema directly instead of a Pydantic model for structured team output. This is useful when you need to use provider-specific schema formats.
+
+<Steps>
+
+  <Step title="Add the following code to your Python file">
+    ```python json_schema_output.py
+    from agno.agent import Agent
+    from agno.team import Team
+    from agno.models.openai import OpenAIChat
+    from agno.tools.duckduckgo import DuckDuckGoTools
+    from agno.utils.pprint import pprint_run_response
+
+    stock_schema = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "StockAnalysis",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string", "description": "Stock ticker symbol"},
+                    "company_name": {"type": "string", "description": "Company name"},
+                    "analysis": {"type": "string", "description": "Brief analysis"},
+                },
+                "required": ["symbol", "company_name", "analysis"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+    stock_searcher = Agent(
+        name="Stock Searcher",
+        model=OpenAIChat("gpt-4o"),
+        role="Searches for information on stocks and provides price analysis.",
+        tools=[DuckDuckGoTools()],
+    )
+
+    company_info_agent = Agent(
+        name="Company Info Searcher",
+        model=OpenAIChat("gpt-4o"),
+        role="Searches for information about companies and recent news.",
+        tools=[DuckDuckGoTools()],
+    )
+
+    team = Team(
+        name="Stock Research Team",
+        model=OpenAIChat("gpt-4o"),
+        respond_directly=True,
+        members=[stock_searcher, company_info_agent],
+        markdown=True,
+    )
+
+    response = team.run(
+        "What is the current stock price of NVDA?",
+        output_schema=stock_schema,
+    )
+
+    pprint_run_response(response)
+    ```
+  </Step>
+
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install libraries">
+    ```bash
+    pip install -U agno openai ddgs
+    ```
+  </Step>
+
+  <Step title="Export your OpenAI API key">
+
+    <CodeGroup>
+
+    ```bash Mac/Linux
+      export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+      $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the example">
+    <CodeGroup>
+    ```bash Mac
+    python json_schema_output.py
+    ```
+
+    ```bash Windows
+    python json_schema_output.py
+    ```
+    </CodeGroup>
+  </Step>
+
+</Steps>

--- a/basics/input-output/team/usage/output-schema-on-run.mdx
+++ b/basics/input-output/team/usage/output-schema-on-run.mdx
@@ -1,0 +1,70 @@
+---
+title: "Output Schema on Run"
+description: "Pass output schema to a specific team run"
+---
+
+This example demonstrates how to pass an `output_schema` to a specific team run, allowing you to get structured output without setting a default schema on the team.
+
+<Steps>
+
+  <Step title="Add the following code to your Python file">
+    ```python output_schema_on_run.py
+    from pydantic import BaseModel
+    from agno.agent import Agent
+    from agno.team import Team
+    from agno.models.openai import OpenAIChat
+
+
+    class MarketReport(BaseModel):
+        overview: str
+        findings: list[str]
+
+
+    analyst = Agent(name="Analyst", model=OpenAIChat(id="gpt-4o-mini"))
+    team = Team(members=[analyst], model=OpenAIChat(id="gpt-4o-mini"))
+
+    response = team.run(
+        "Analyze the current AI market trends",
+        output_schema=MarketReport,
+        stream=False,
+    )
+
+    print(response.content)
+    ```
+  </Step>
+
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install libraries">
+    ```bash
+    pip install -U agno openai
+    ```
+  </Step>
+
+  <Step title="Export your OpenAI API key">
+
+    <CodeGroup>
+
+    ```bash Mac/Linux
+      export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+      $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the example">
+    <CodeGroup>
+    ```bash Mac
+    python output_schema_on_run.py
+    ```
+
+    ```bash Windows
+    python output_schema_on_run.py
+    ```
+    </CodeGroup>
+  </Step>
+
+</Steps>

--- a/docs.json
+++ b/docs.json
@@ -296,7 +296,9 @@
                           "basics/input-output/agent/usage/parser-model-ollama",
                           "basics/input-output/agent/usage/parser-model-stream",
                           "basics/input-output/agent/usage/response-as-variable",
-                          "basics/input-output/agent/usage/structured-input"
+                          "basics/input-output/agent/usage/structured-input",
+                          "basics/input-output/agent/usage/output-schema-on-run",
+                          "basics/input-output/agent/usage/json-schema-output"
                         ]
                       }
                     ]
@@ -316,7 +318,9 @@
                           "basics/input-output/team/usage/team-with-output-model",
                           "basics/input-output/team/usage/structured-output-streaming",
                           "basics/input-output/team/usage/async-structured-output-streaming",
-                          "basics/input-output/team/usage/input-schema-on-team"
+                          "basics/input-output/team/usage/input-schema-on-team",
+                          "basics/input-output/team/usage/output-schema-on-run",
+                          "basics/input-output/team/usage/json-schema-output"
                         ]
                       }
                     ]

--- a/reference/agents/agent.mdx
+++ b/reference/agents/agent.mdx
@@ -47,8 +47,8 @@ mode: wide
 | `tool_choice`                      | `Optional[Union[str, Dict[str, Any]]]`                           | `None`     | Controls which (if any) tool is called by the model                                                                                                                                                                              |
 | `max_tool_calls_from_history`      | `Optional[int]`                                                  | `None`     | Maximum number of tool calls from history to keep in context. If None, all tool calls from history are included. If set to N, only the last N tool calls from history are added to the context for memory management             |
 | `tool_hooks`                       | `Optional[List[Callable]]`                                       | `None`     | Functions that will run between tool calls                                                                                                                                                                                       |
-| `pre_hooks`                        | `Optional[Union[List[Callable[..., Any]], List[BaseGuardrail]]]` | `None`     | Functions called right after agent-session is loaded, before processing starts                                                                                                                                                   |
-| `post_hooks`                       | `Optional[Union[List[Callable[..., Any]], List[BaseGuardrail]]]` | `None`     | Functions called after output is generated but before the response is returned                                                                                                                                                   |
+| `pre_hooks`                        | `Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]]` | `None`     | Functions called right after agent-session is loaded, before processing starts                                                                                                                                                   |
+| `post_hooks`                       | `Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]]` | `None`     | Functions called after output is generated but before the response is returned                                                                                                                                                   |
 | `reasoning`                        | `bool`                                                           | `False`    | Enable reasoning by working through the problem step by step                                                                                                                                                                     |
 | `reasoning_model`                  | `Optional[Union[Model, str]]`                                    | `None`     | Model to use for reasoning. Can be a Model object or a model string (`provider:model_id`)                                                                                                                                        |
 | `reasoning_agent`                  | `Optional[Agent]`                                                | `None`     | Agent to use for reasoning                                                                                                                                                                                                       |
@@ -83,7 +83,7 @@ mode: wide
 | `delay_between_retries`            | `int`                                                            | `1`        | Delay between retries (in seconds)                                                                                                                                                                                               |
 | `exponential_backoff`              | `bool`                                                           | `False`    | If True, the delay between retries is doubled each time                                                                                                                                                                          |
 | `input_schema`                     | `Optional[Type[BaseModel]]`                                      | `None`     | Provide an input schema to validate the input                                                                                                                                                                                    |
-| `output_schema`                    | `Optional[Type[BaseModel]]`                                      | `None`     | Provide a response model to get the response as a Pydantic model                                                                                                                                                                 |
+| `output_schema`                    | `Optional[Union[Type[BaseModel], Dict[str, Any]]]`               | `None`     | Provide a response model to get the response as a Pydantic model or a JSON schema                                                                                                                                                                 |
 | `parser_model`                     | `Optional[Union[Model, str]]`                                    | `None`     | Provide a secondary model to parse the response from the primary model. Can be a Model object or a model string (`provider:model_id`)                                                                                            |
 | `parser_model_prompt`              | `Optional[str]`                                                  | `None`     | Provide a prompt for the parser model                                                                                                                                                                                            |
 | `output_model`                     | `Optional[Union[Model, str]]`                                    | `None`     | Provide an output model to structure the response from the main model. Can be a Model object or a model string (`provider:model_id`)                                                                                             |
@@ -126,7 +126,7 @@ Run the agent.
 - `add_session_state_to_context` (Optional[bool]): Whether to add session state to context
 - `dependencies` (Optional[Dict[str, Any]]): Dependencies to use for this run
 - `metadata` (Optional[Dict[str, Any]]): Metadata to use for this run
-- `output_schema` (Optional[Type[BaseModel]]): Output schema to use for this run
+- `output_schema` (Optional[Union[Type[BaseModel], Dict[str, Any]]]): Output schema to use for this run. Can be a Pydantic model or a JSON schema.
 - `debug_mode` (Optional[bool]): Whether to enable debug mode
 
 ### `arun`
@@ -152,7 +152,7 @@ Run the agent asynchronously.
 - `add_session_state_to_context` (Optional[bool]): Whether to add session state to context
 - `dependencies` (Optional[Dict[str, Any]]): Dependencies to use for this run
 - `metadata` (Optional[Dict[str, Any]]): Metadata to use for this run
-- `output_schema` (Optional[Type[BaseModel]]): Output schema to use for this run
+- `output_schema` (Optional[Union[Type[BaseModel], Dict[str, Any]]]): Output schema to use for this run. Can be a Pydantic model or a JSON schema.
 - `debug_mode` (Optional[bool]): Whether to enable debug mode
 
 **Returns:**

--- a/reference/teams/team.mdx
+++ b/reference/teams/team.mdx
@@ -61,10 +61,10 @@ mode: wide
 | `tool_call_limit`                  | `Optional[int]`                                                  | `None`     | Maximum number of tool calls allowed                                                                                                                                                                                 |
 | `max_tool_calls_from_history`      | `Optional[int]`                                                  | `None`     | Maximum number of tool calls from history to keep in context. If None, all tool calls from history are included. If set to N, only the last N tool calls from history are added to the context for memory management |
 | `tool_hooks`                       | `Optional[List[Callable]]`                                       | `None`     | A list of hooks to be called before and after the tool call                                                                                                                                                          |
-| `pre_hooks`                        | `Optional[Union[List[Callable[..., Any]], List[BaseGuardrail]]]` | `None`     | Functions called right after team session is loaded, before processing starts                                                                                                                                        |
-| `post_hooks`                       | `Optional[Union[List[Callable[..., Any]], List[BaseGuardrail]]]` | `None`     | Functions called after output is generated but before the response is returned                                                                                                                                       |
+| `pre_hooks`                        | `Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]]` | `None`     | Functions called right after team session is loaded, before processing starts                                                                                                                                        |
+| `post_hooks`                       | `Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]]` | `None`     | Functions called after output is generated but before the response is returned                                                                                                                                       |
 | `input_schema`                     | `Optional[Type[BaseModel]]`                                      | `None`     | Input schema for validating input                                                                                                                                                                                    |
-| `output_schema`                    | `Optional[Type[BaseModel]]`                                      | `None`     | Output schema for the team response                                                                                                                                                                                  |
+| `output_schema`                    | `Optional[Union[Type[BaseModel], Dict[str, Any]]]`               | `None`     | Output schema for the team response. Can be a Pydantic model or a JSON schema                                                                                                                                                                                  |
 | `parser_model`                     | `Optional[Union[Model, str]]`                                    | `None`     | Provide a secondary model to parse the response from the primary model. Can be a Model object or a model string (`provider:model_id`)                                                                                |
 | `parser_model_prompt`              | `Optional[str]`                                                  | `None`     | Provide a prompt for the parser model                                                                                                                                                                                |
 | `output_model`                     | `Optional[Union[Model, str]]`                                    | `None`     | Provide an output model to parse the response from the team. Can be a Model object or a model string (`provider:model_id`)                                                                                           |
@@ -133,7 +133,7 @@ Run the team.
 - `add_session_state_to_context` (Optional[bool]): Whether to add session state to context
 - `dependencies` (Optional[Dict[str, Any]]): Dependencies to use for this run
 - `metadata` (Optional[Dict[str, Any]]): Metadata to use for this run
-- `output_schema` (Optional[Type[BaseModel]]): Output schema to use for this run
+- `output_schema` (Optional[Union[Type[BaseModel], Dict[str, Any]]]): Output schema to use for this run. Can be a Pydantic model or a JSON schema.
 - `debug_mode` (Optional[bool]): Whether to enable debug mode
 - `yield_run_response` (bool): Whether to yield the run response (only for streaming)
 
@@ -164,7 +164,7 @@ Run the team asynchronously.
 - `add_session_state_to_context` (Optional[bool]): Whether to add session state to context
 - `dependencies` (Optional[Dict[str, Any]]): Dependencies to use for this run
 - `metadata` (Optional[Dict[str, Any]]): Metadata to use for this run
-- `output_schema` (Optional[Type[BaseModel]]): Output schema to use for this run
+- `output_schema` (Optional[Union[Type[BaseModel], Dict[str, Any]]]): Output schema to use for this run. Can be a Pydantic model or a JSON schema.
 - `debug_mode` (Optional[bool]): Whether to enable debug mode
 - `yield_run_response` (bool): Whether to yield the run response (only for streaming)
 


### PR DESCRIPTION
## Description


  - Add usage example for output_schema on run() method for agents and teams
  - Add JSON schema output examples for agents and teams
  - Update output_schema type to support both Pydantic models and JSON schemas
  - Update pre/post hooks types to include BaseEval
  
**Note:** Your PR title must follow conventional commit format (e.g., `docs: add auth guide`, `fix: correct broken links`, `style: update formatting`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#5728

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
