### PR TITLE
docs(jwt): clarify token is always required

### DIFF
--- a/agent-os/middleware/jwt.mdx
+++ b/agent-os/middleware/jwt.mdx
@@ -253,7 +253,7 @@ See the [JWTMiddleware Reference](/reference/agent-os/jwt-middleware) for the co
 | `jwks_file` | Path to a static JWKS file containing public keys. Keys are matched by `kid` from the JWT header. | `JWT_JWKS_FILE` env var |
 | `secret_key` | **(Deprecated)** Use `verification_keys` instead. | - |
 | `algorithm` | JWT algorithm (RS256, HS256, ES256, etc.) | `"RS256"` |
-| `validate` | Enable token validation | `True` |
+| `validate` | Enable JWT signature validation. Token is always required. | `True` |
 
 ### Token Source Options
 


### PR DESCRIPTION
## Summary
- Update JWT middleware docs to clarify that a token is always required
- `validate` only controls signature verification, not token presence

Related: https://github.com/agno-agi/agno/pull/5734