### PR TITLE
Improve agents section documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,10 @@ When documenting features, check if cookbook examples exist first.
 - Don't include `touch filename.py` steps - they're unnecessary
 - Start directly with the code file step: `<Step title="Create a Python file">`
 - The code block already shows the filename via `\`\`\`python filename.py`
+- Use `uv` for virtual environments and package installation:
+  - Venv: `uv venv --python 3.12` (snippet handles this)
+  - Install: `uv pip install -U agno ...`
+- Step titles: "Set up your virtual environment", "Install dependencies", "Run Agent"
 
 ### Model IDs in Examples
 - Prefer `claude-sonnet-4-5` (Anthropic): `from agno.models.anthropic import Claude`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,28 @@ When documenting features, check if cookbook examples exist first.
 
 ---
 
+## Documentation Structure Patterns
+
+### Section Overview Pages
+- Use `## Next` instead of `## Guides` for linking to related pages (cleaner, action-oriented)
+
+### Sidebar Navigation (docs.json)
+- Call example sections "Examples" not "Recipes" or "Usage"
+- Keep hierarchy flat - don't nest groups like "Basic Flows" / "Core Features" / "Other"
+- List all examples at the same level
+
+### Step-by-Step Examples
+- Don't include `touch filename.py` steps - they're unnecessary
+- Start directly with the code file step: `<Step title="Create a Python file">`
+- The code block already shows the filename via `\`\`\`python filename.py`
+
+### Model IDs in Examples
+- Prefer `claude-sonnet-4-5` (Anthropic): `from agno.models.anthropic import Claude`
+- Use `gpt-5.2` with `OpenAIResponses` (not `OpenAIChat`): `from agno.models.openai import OpenAIResponses`
+- Use simple import paths: `from agno.agent import Agent`
+
+---
+
 ## API Reference
 
 The `reference-api/` folder contains auto-generated OpenAPI documentation. See `README.md` for instructions on regenerating it from a running AgentOS instance.

--- a/_snippets/create-venv-step.mdx
+++ b/_snippets/create-venv-step.mdx
@@ -1,16 +1,15 @@
-<Step title="Create a virtual environment">
-  Open the `Terminal` and create a python virtual environment.
+<Step title="Set up your virtual environment">
 
   <CodeGroup>
 
   ```bash Mac
-  python3 -m venv .venv
+  uv venv --python 3.12
   source .venv/bin/activate
   ```
 
   ```bash Windows
-  python3 -m venv .venv
-  .venv/scripts/activate
+  uv venv --python 3.12
+  .venv\Scripts\activate
   ```
 
   </CodeGroup>

--- a/basics/agents/TODO.md
+++ b/basics/agents/TODO.md
@@ -6,46 +6,36 @@ Improvements for the agents documentation section.
 
 ## overview.mdx
 
-- [ ] Fix card description for "Building Agents" - currently says "Learn how to run your agents" (copy/paste error from Running Agents card)
+- [x] Fix card description for "Building Agents" - changed from "Learn how to run your agents" to "Learn how to build your first agent"
 
 ---
 
 ## building-agents.mdx
 
-- [ ] Remove verbose section comments in code examples (`################ STREAM RESPONSE #################`) - violates clean code guidelines
-- [ ] Consider whether "Run your Agent" section duplicates content from running-agents.mdx - may need consolidation or removal
-- [ ] The second code block shows the same agent definition as the first, just with different run methods - consider simplifying to show only the new concepts
-- [ ] "start simple -- just a model" - consider rephrasing to avoid double hyphen
+- [x] Remove verbose section comments in code examples (`################ STREAM RESPONSE #################`)
+- [x] Simplified second code block to show only streaming concept
+- [x] Fixed "start simple -- just a model" to use colon instead of double hyphen
+- [ ] *(Deferred)* Consider whether "Run your Agent" section duplicates running-agents.mdx
 
 ---
 
 ## debugging-agents.mdx
 
-- [ ] Remove subjective language: "exceptionally well-built debug mode" - just describe what it does
-- [ ] Fix grammar: "a exceptionally" should be "an exceptionally" (or better, remove the claim entirely)
-- [ ] Lead with what debug mode does, not a claim about its quality
-
-**Suggested rewrite for opening:**
-```
-Current:
-"Agno comes with a exceptionally well-built debug mode that helps you understand..."
-
-Better:
-"Debug mode helps you understand the flow of execution and intermediate steps:"
-```
+- [x] Removed subjective language: "exceptionally well-built debug mode"
+- [x] Fixed grammar and led with what debug mode does
+- [x] Cleaned up bullet point formatting (removed trailing periods, simplified)
 
 ---
 
 ## running-agents.mdx
 
-- [ ] Generally well-structured, lower priority for changes
-- [ ] Consider consolidating the many event type tables into fewer, more scannable sections
-- [ ] The agent definition is repeated in nearly every code example - could reference a single definition and show only the new concepts in subsequent examples
+- [x] Removed em-dash in "Basic Execution" section
+- [x] Fixed subjective language: "exceptional agent experiences" -> "complete visibility... enabling rich UI feedback and debugging"
+- [ ] *(Deferred)* Consider consolidating event type tables
+- [ ] *(Deferred)* Consider reducing repeated agent definitions in code examples
 
 ---
 
-## General Notes
+## Completed: 2025-01-13
 
-- All files use consistent frontmatter format
-- Code examples use correct language hints
-- Consider whether building-agents.mdx and running-agents.mdx have overlapping content that could be deduplicated
+All priority items addressed. Deferred items are structural changes that may be addressed in a future pass.

--- a/basics/agents/building-agents.mdx
+++ b/basics/agents/building-agents.mdx
@@ -6,7 +6,7 @@ keywords: [agent, agents, ai agents, introduction]
 mode: wide
 ---
 
-To build effective agents, start simple -- just a model, tools, and instructions. Once that works, layer in more functionality as needed.
+To build effective agents, start simple: a model, tools, and instructions. Once that works, layer in more functionality as needed.
 
 The key is to start with well-defined tasks like report generation, data extraction, classification, summarization, knowledge search, and document processing. These early wins help you identify what works, validate user needs, and set the stage for advanced systems.
 
@@ -28,16 +28,15 @@ agent.print_response("Trending startups and products.", stream=True)
 
 ## Run your Agent
 
-When developing your agent, run it using the `Agent.print_response()` method. This will print the agent's response in your terminal, in a friendly format.
+When developing your agent, test it using the `Agent.print_response()` method. This will print the agent's response in your terminal in a readable format.
 
 This is only for development purposes and not recommended for production use. In production, use the `Agent.run()` or `Agent.arun()` methods. For example:
 
 ```python
 from typing import Iterator
-from agno.agent import Agent, RunOutput, RunOutputEvent, RunEvent
+from agno.agent import Agent, RunOutputEvent, RunEvent
 from agno.models.anthropic import Claude
 from agno.tools.hackernews import HackerNewsTools
-from agno.utils.pprint import pprint_run_response
 
 agent = Agent(
     model=Claude(id="claude-sonnet-4-5"),
@@ -46,18 +45,11 @@ agent = Agent(
     markdown=True,
 )
 
-# Run the agent and print the response
-agent.print_response("Trending startups and products.")
-
-################ STREAM RESPONSE #################
+# Stream the response
 stream: Iterator[RunOutputEvent] = agent.run("Trending products", stream=True)
 for chunk in stream:
     if chunk.event == RunEvent.run_content:
         print(chunk.content)
-
-################ STREAM AND PRETTY PRINT #################
-stream: Iterator[RunOutputEvent] = agent.run("Trending products", stream=True)
-pprint_run_response(stream, markdown=True)
 ```
 
 ## Next Steps
@@ -66,13 +58,13 @@ After getting familiarized with the basics, continue building your agent by addi
 
 Common questions to consider:
 
-- **How do I run my agent?** -> See the [running agents](/basics/agents/running-agents) documentation.
-- **How do I debug my agent?** -> See the [debugging agents](/basics/agents/debugging-agents) documentation.
-- **How do I manage sessions?** -> See the [agent sessions](/basics/sessions/overview) documentation.
-- **How do I manage input and capture output?** -> See the [input and output](/basics/input-output/overview) documentation.
-- **How do I add tools?** -> See the [tools](/basics/tools/overview) documentation.
-- **How do I give the agent context?** -> See the [context engineering](/basics/context/overview) documentation.
-- **How do I add knowledge?** -> See the [knowledge](/basics/knowledge/overview) documentation.
-- **How do I handle images, audio, video, and files?** -> See the [multimodal](/basics/multimodal/overview) documentation.
-- **How do I add guardrails?** -> See the [guardrails](/basics/guardrails/overview) documentation.
-- **How do I cache model responses during development?** -> See the [response caching](/basics/models/cache-response) documentation.
+- **How do I run my agent?** -> See [running agents](/basics/agents/running-agents).
+- **How do I debug my agent?** -> See [debugging agents](/basics/agents/debugging-agents).
+- **How do I manage sessions?** -> See [agent sessions](/basics/sessions/overview).
+- **How do I manage input and capture output?** -> See [input and output](/basics/input-output/overview).
+- **How do I add tools?** -> See [tools](/basics/tools/overview).
+- **How do I manage the agent's context?** -> See [context engineering](/basics/context/overview).
+- **How do I add knowledge?** -> See [knowledge](/basics/knowledge/overview).
+- **How do I handle images, audio, video, and files?** -> See [multimodal](/basics/multimodal/overview).
+- **How do I add guardrails?** -> See [guardrails](/basics/guardrails/overview).
+- **How do I cache model responses during development?** -> See [response caching](/basics/models/cache-response).

--- a/basics/agents/debugging-agents.mdx
+++ b/basics/agents/debugging-agents.mdx
@@ -5,10 +5,11 @@ description: Learn how to debug Agno Agents.
 mode: wide
 ---
 
-Agno comes with a exceptionally well-built debug mode that helps you understand the flow of execution and the intermediate steps. For example:
-- Inspect the messages sent to the model and the response it generates.
-- Trace intermediate steps and monitor metrics like token usage, execution time, etc.
-- Inspect tool calls, errors, and their results. This can help you identify issues with your tools.
+Debug mode helps you understand the flow of execution and intermediate steps:
+
+- Inspect the messages sent to the model and the response it generates
+- Trace intermediate steps and monitor metrics like token usage and execution time
+- Inspect tool calls, errors, and their results
 
 ## Debug Mode
 

--- a/basics/agents/overview.mdx
+++ b/basics/agents/overview.mdx
@@ -7,10 +7,10 @@ mode: wide
 
 **Agents are AI programs where a language model controls the flow of execution.**
 
-The core of an agent is a model that uses tools in a loop, guided by instructions.
+The core of an agent is a model that uses tools in a loop, programmed by instructions.
 
-- **Model:** controls the flow of execution. It decides whether to reason, use tools or respond.
-- **Instructions:** guides the model on how to use tools and respond.
+- **Model:** controls the flow of execution. It decides whether to reason, respond or use tools.
+- **Instructions:** program the model on how to use tools and respond.
 - **Tools:** enable the model to take actions and interact with external systems.
 
 With Agno, you can also give your Agents memory, knowledge, storage and the ability to reason:
@@ -24,7 +24,7 @@ With Agno, you can also give your Agents memory, knowledge, storage and the abil
 If this is your first time using Agno, you can [start here](/get-started/quickstart) before diving into advanced concepts.
 </Tip>
 
-## Guides
+## Next
 
 Learn how to build, run and debug your Agents with the following guides.
 
@@ -35,7 +35,7 @@ Learn how to build, run and debug your Agents with the following guides.
     iconType="duotone"
     href="/basics/agents/building-agents"
   >
-    Learn how to run your agents.
+    Learn how to build your first agent.
   </Card>
   <Card
     title="Running Agents"
@@ -57,11 +57,11 @@ Learn how to build, run and debug your Agents with the following guides.
 
 ## From Agents to Multi-Agent Systems
 
-Agno provides two higher level abstractions for building beyond single agents:
+Agno also provides two higher level abstractions for building beyond single agents:
 
-- [**Team**](/basics/teams/overview): a collection of agents (or sub-teams) that work together. Each team member can have different expertise, tools and instructions, allowing for specialized problem-solving approaches.
+- [**Team**](/basics/teams/overview): a collection of agents (or sub-teams) that work together. Each team member can have different expertise, tools and instructions, allowing for advanced problem-solving via collaboration.
 
-- [**Workflow**](/basics/workflows/overview): orchestrate agents, teams and functions through a series of defined steps. Workflows provide structured automation with predictable behavior, ideal for tasks that need reliable, repeatable processes.
+- [**Workflow**](/basics/workflows/overview): orchestrate agents, teams and functions through a series of defined steps. Workflows provide structured automation and predictable behavior, ideal for tasks that can be broken into repeatable steps.
 
 
 ## Developer Resources

--- a/basics/agents/running-agents.mdx
+++ b/basics/agents/running-agents.mdx
@@ -15,7 +15,7 @@ Run your Agent by calling `Agent.run()` or `Agent.arun()`. Here's how they work:
 
 ## Basic Execution
 
-The `Agent.run()` function runs the agent and returns the output — either as a `RunOutput` object or as a stream of `RunOutputEvent` objects (when `stream=True`). For example:
+The `Agent.run()` function runs the agent and returns the output as a `RunOutput` object, or as a stream of `RunOutputEvent` objects when `stream=True`. For example:
 
 ```python
 from agno.agent import Agent, RunOutput
@@ -116,7 +116,7 @@ for chunk in stream:
 For asynchronous streaming, see this [example](/basics/agents/usage/streaming).
 </Tip>
 
-## Streaming Internal Events
+## Streaming Events
 
 By default, when you stream a response, only the events that contain a response from the model (i.e. `RunContent` events) are streamed.
 
@@ -160,7 +160,7 @@ for chunk in stream:
 ```
 
 <Check>
-`RunEvents` make it possible to build exceptional agent experiences, by giving you complete information about the agent's internal processes.
+`RunEvents` give you complete visibility into the agent's internal processes, enabling rich UI feedback and debugging.
 </Check>
 
 ## Event Types

--- a/basics/agents/usage/TODO.md
+++ b/basics/agents/usage/TODO.md
@@ -1,0 +1,43 @@
+# TODO: basics/agents/usage (Recipes)
+
+Improvements for the agent recipes section.
+
+---
+
+## Completed: 2025-01-13
+
+### docs.json
+- [x] Changed `"group": "Usage"` to `"group": "Recipes"`
+
+### Missing Descriptions - All Added
+- [x] run-response-events.mdx
+- [x] intermediate-steps.mdx
+- [x] agent-run-metadata.mdx
+- [x] cancel-a-run.mdx
+- [x] debug-level.mdx
+- [x] scenario-testing.mdx
+- [x] tool-call-limit.mdx
+
+### Model IDs - Standardized
+- [x] OpenAI files: `gpt-5-mini` → `gpt-5.2`
+- [x] Claude files: older IDs → `claude-sonnet-4-5`
+
+### Code Cleanup
+- [x] scenario-testing.mdx: Fixed install command (`scenario` → `langwatch-scenario`)
+- [x] tool-call-limit.mdx: Removed "cookbook" docstring
+- [x] debug-level.mdx: Removed redundant docstring, fixed imports
+- [x] agent-with-memory.mdx: Fixed import path
+
+---
+
+## Remaining (Deferred)
+
+### Low Priority
+- [ ] Mac and Windows "Run Agent" steps are identical - consider consolidating
+- [ ] instructions.mdx has emojis in example instructions (intentional demo)
+- [ ] agent-with-storage.mdx and agent-with-knowledge.mdx have emojis (part of recipe demo)
+- [ ] cancel-a-run.mdx has emojis in print statements (visual feedback demo)
+
+### Structural Considerations
+- [ ] agent-with-storage.mdx and agent-with-knowledge.mdx are nearly identical (both Thai recipe) - consider differentiating
+- [ ] Consider whether some "Other" recipes belong in different categories

--- a/basics/agents/usage/agent-run-metadata.mdx
+++ b/basics/agents/usage/agent-run-metadata.mdx
@@ -1,5 +1,6 @@
 ---
 title: Agent Run Metadata
+description: Attach custom metadata to agent runs for tracking and analytics.
 ---
 
 This example demonstrates how to attach custom metadata to agent runs. This is useful for tracking business context, request types, and operational information for monitoring and analytics.
@@ -7,22 +8,15 @@ This example demonstrates how to attach custom metadata to agent runs. This is u
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch agent_run_metadata.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python agent_run_metadata.py
     from datetime import datetime
 
     from agno.agent import Agent
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
     from agno.tools.duckduckgo import DuckDuckGoTools
 
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
         tools=[DuckDuckGoTools()],
         instructions="You are a customer support agent. You help process customer inquiries efficiently.",
         markdown=True,

--- a/basics/agents/usage/agent-run-metadata.mdx
+++ b/basics/agents/usage/agent-run-metadata.mdx
@@ -43,9 +43,9 @@ This example demonstrates how to attach custom metadata to agent runs. This is u
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai ddgs
+    uv pip install -U agno openai ddgs
     ```
   </Step>
 

--- a/basics/agents/usage/agent-with-knowledge.mdx
+++ b/basics/agents/usage/agent-with-knowledge.mdx
@@ -112,9 +112,9 @@ Example prompts to try:
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install openai lancedb tantivy pypdf ddgs agno
+    uv pip install openai lancedb tantivy pypdf ddgs agno
     ```
   </Step>
 

--- a/basics/agents/usage/agent-with-knowledge.mdx
+++ b/basics/agents/usage/agent-with-knowledge.mdx
@@ -17,20 +17,13 @@ Example prompts to try:
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch agent_with_knowledge.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python agent_with_knowledge.py
     from textwrap import dedent
 
     from agno.agent import Agent
     from agno.knowledge.embedder.openai import OpenAIEmbedder
     from agno.knowledge.knowledge import Knowledge
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
     from agno.tools.duckduckgo import DuckDuckGoTools
     from agno.vectordb.lancedb import LanceDb, SearchType
 
@@ -49,7 +42,7 @@ Example prompts to try:
 
     # Create a Recipe Expert Agent with knowledge of Thai recipes
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
         instructions=dedent("""\
             You are a passionate and knowledgeable Thai cuisine expert! 🧑‍🍳
             Think of yourself as a combination of a warm, encouraging cooking instructor,

--- a/basics/agents/usage/agent-with-memory.mdx
+++ b/basics/agents/usage/agent-with-memory.mdx
@@ -68,9 +68,9 @@ To enable this, set `enable_user_memories=True` in the Agent config.
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai psycopg rich
+    uv pip install -U agno openai psycopg rich
     ```
   </Step>
 

--- a/basics/agents/usage/agent-with-memory.mdx
+++ b/basics/agents/usage/agent-with-memory.mdx
@@ -13,19 +13,12 @@ To enable this, set `enable_user_memories=True` in the Agent config.
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch agent_with_memory.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python agent_with_memory.py
     from uuid import uuid4
 
-    from agno.agent.agent import Agent
+    from agno.agent import Agent
     from agno.db.postgres import PostgresDb
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
     from rich.pretty import pprint
 
     db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
@@ -38,7 +31,7 @@ To enable this, set `enable_user_memories=True` in the Agent config.
     john_doe_id = "john_doe@example.com"
 
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
         db=db,
         enable_user_memories=True,
     )

--- a/basics/agents/usage/agent-with-storage.mdx
+++ b/basics/agents/usage/agent-with-storage.mdx
@@ -18,13 +18,6 @@ Example prompts to try:
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch agent_with_storage.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python agent_with_storage.py
     from textwrap import dedent
     from typing import List, Optional
@@ -35,7 +28,7 @@ Example prompts to try:
     from agno.db.sqlite import SqliteDb
     from agno.knowledge.embedder.openai import OpenAIEmbedder
     from agno.knowledge.knowledge import Knowledge
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
     from agno.session import AgentSession
     from agno.tools.duckduckgo import DuckDuckGoTools
     from agno.vectordb.lancedb import LanceDb, SearchType
@@ -75,7 +68,7 @@ Example prompts to try:
         agent = Agent(
             user_id=user,
             session_id=session_id,
-            model=OpenAIChat(id="gpt-5-mini"),
+            model=OpenAIResponses(id="gpt-5.2"),
             instructions=dedent("""\
                 You are a passionate and knowledgeable Thai cuisine expert! 🧑‍🍳
                 Think of yourself as a combination of a warm, encouraging cooking instructor,

--- a/basics/agents/usage/agent-with-storage.mdx
+++ b/basics/agents/usage/agent-with-storage.mdx
@@ -151,9 +151,9 @@ Example prompts to try:
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install openai lancedb tantivy pypdf ddgs sqlalchemy typer rich agno
+    uv pip install openai lancedb tantivy pypdf ddgs sqlalchemy typer rich agno
     ```
   </Step>
 

--- a/basics/agents/usage/basic-async.mdx
+++ b/basics/agents/usage/basic-async.mdx
@@ -10,22 +10,15 @@ This example demonstrates how to use `Agent.arun()` or `Agent.aprint_response()`
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch basic_async.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python basic_async.py
     import asyncio
 
     from agno.agent import Agent
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
     from agno.utils.pprint import apprint_run_response
 
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
     )
 
     async def basic():

--- a/basics/agents/usage/basic-async.mdx
+++ b/basics/agents/usage/basic-async.mdx
@@ -39,9 +39,9 @@ This example demonstrates how to use `Agent.arun()` or `Agent.aprint_response()`
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai
+    uv pip install -U agno openai
     ```
   </Step>
 

--- a/basics/agents/usage/basic.mdx
+++ b/basics/agents/usage/basic.mdx
@@ -24,9 +24,9 @@ mode: wide
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai
+    uv pip install -U agno openai
     ```
   </Step>
 

--- a/basics/agents/usage/basic.mdx
+++ b/basics/agents/usage/basic.mdx
@@ -8,19 +8,12 @@ mode: wide
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch basic.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python basic.py
     from agno.agent import Agent
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
 
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
         instructions="You are a helpful assistant. All your responses must be brief and concise.",
     )
 

--- a/basics/agents/usage/cancel-a-run.mdx
+++ b/basics/agents/usage/cancel-a-run.mdx
@@ -203,9 +203,9 @@ This example demonstrates how to cancel a running agent execution using multi-th
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai
+    uv pip install -U agno openai
     ```
   </Step>
 

--- a/basics/agents/usage/cancel-a-run.mdx
+++ b/basics/agents/usage/cancel-a-run.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cancel Agent Run
+description: Cancel a running agent execution using multi-threading.
 ---
 
 This example demonstrates how to cancel a running agent execution using multi-threading, showing how to start a long-running task and cancel it from another thread.
@@ -7,13 +8,6 @@ This example demonstrates how to cancel a running agent execution using multi-th
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch cancel_a_run.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python cancel_a_run.py
     """
     Example demonstrating how to cancel a running agent execution.
@@ -28,7 +22,7 @@ This example demonstrates how to cancel a running agent execution using multi-th
     import time
 
     from agno.agent import Agent
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
     from agno.run.agent import RunEvent
     from agno.run.base import RunStatus
 
@@ -141,7 +135,7 @@ This example demonstrates how to cancel a running agent execution using multi-th
         # Initialize the agent with a model
         agent = Agent(
             name="StorytellerAgent",
-            model=OpenAIChat(id="gpt-5-mini"),  # Use a model that can generate long responses
+            model=OpenAIResponses(id="gpt-5.2"),  # Use a model that can generate long responses
             description="An agent that writes detailed stories",
         )
 

--- a/basics/agents/usage/debug-level.mdx
+++ b/basics/agents/usage/debug-level.mdx
@@ -1,5 +1,6 @@
 ---
 title: Debug Level
+description: Set different debug levels to control the verbosity of agent output.
 ---
 
 This example demonstrates how to set different debug levels for an agent. The debug level controls the amount of debug information displayed, helping you troubleshoot and understand agent behavior at different levels of detail.
@@ -7,32 +8,14 @@ This example demonstrates how to set different debug levels for an agent. The de
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch debug_level.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python debug_level.py
-    """
-    This example shows how to set the debug level of an agent.
-
-    The debug level is a number between 1 and 2.
-
-    1: Basic debug information
-    2: Detailed debug information
-
-    The default debug level is 1.
-    """
-
-    from agno.agent.agent import Agent
-    from agno.models.anthropic.claude import Claude
+    from agno.agent import Agent
+    from agno.models.anthropic import Claude
     from agno.tools.duckduckgo import DuckDuckGoTools
 
     # Basic debug information
     agent = Agent(
-        model=Claude(id="claude-3-5-sonnet-20240620"),
+        model=Claude(id="claude-sonnet-4-5"),
         tools=[DuckDuckGoTools()],
         debug_mode=True,
         debug_level=1,
@@ -42,7 +25,7 @@ This example demonstrates how to set different debug levels for an agent. The de
 
     # Verbose debug information
     agent = Agent(
-        model=Claude(id="claude-3-5-sonnet-20240620"),
+        model=Claude(id="claude-sonnet-4-5"),
         tools=[DuckDuckGoTools()],
         debug_mode=True,
         debug_level=2,

--- a/basics/agents/usage/debug-level.mdx
+++ b/basics/agents/usage/debug-level.mdx
@@ -37,9 +37,9 @@ This example demonstrates how to set different debug levels for an agent. The de
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno anthropic ddgs
+    uv pip install -U agno anthropic ddgs
     ```
   </Step>
 

--- a/basics/agents/usage/debug.mdx
+++ b/basics/agents/usage/debug.mdx
@@ -33,9 +33,9 @@ This example demonstrates how to enable debug mode, to get more verbose output a
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai
+    uv pip install -U agno openai
     ```
   </Step>
 

--- a/basics/agents/usage/debug.mdx
+++ b/basics/agents/usage/debug.mdx
@@ -10,20 +10,13 @@ This example demonstrates how to enable debug mode, to get more verbose output a
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch debug.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python debug.py
     from agno.agent import Agent
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
 
     # You can set the debug mode on the agent for all runs to have more verbose output
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
         debug_mode=True,
     )
 
@@ -32,7 +25,7 @@ This example demonstrates how to enable debug mode, to get more verbose output a
 
     # You can also set the debug mode on a single run
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
     )
     agent.print_response(input="Tell me a joke.", debug_mode=True)
     ```

--- a/basics/agents/usage/instructions.mdx
+++ b/basics/agents/usage/instructions.mdx
@@ -12,21 +12,14 @@ We will create a news reporter agent that can report on news stories happening i
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch instructions.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python instructions.py
     from textwrap import dedent
 
     from agno.agent import Agent
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
 
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
         instructions=dedent("""\
             You are an enthusiastic news reporter with a flair for storytelling! 🗽
             Think of yourself as a mix between a witty comedian and a sharp journalist.

--- a/basics/agents/usage/instructions.mdx
+++ b/basics/agents/usage/instructions.mdx
@@ -42,9 +42,9 @@ We will create a news reporter agent that can report on news stories happening i
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai
+    uv pip install -U agno openai
     ```
   </Step>
 

--- a/basics/agents/usage/intermediate-steps.mdx
+++ b/basics/agents/usage/intermediate-steps.mdx
@@ -33,9 +33,9 @@ This example demonstrates how to stream intermediate steps during agent executio
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai ddgs rich
+    uv pip install -U agno openai ddgs rich
     ```
   </Step>
 

--- a/basics/agents/usage/intermediate-steps.mdx
+++ b/basics/agents/usage/intermediate-steps.mdx
@@ -1,5 +1,6 @@
 ---
 title: Agent Intermediate Steps Streaming
+description: Stream intermediate steps during agent execution for debugging and visibility.
 ---
 
 This example demonstrates how to stream intermediate steps during agent execution, providing visibility into tool calls and execution events.
@@ -7,23 +8,16 @@ This example demonstrates how to stream intermediate steps during agent executio
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch intermediate_steps.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python intermediate_steps.py
     from typing import Iterator
 
     from agno.agent import Agent, RunOutputEvent
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
     from agno.tools.duckduckgo import DuckDuckGoTools
     from rich.pretty import pprint
 
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
         tools=[DuckDuckGoTools(stock_price=True)],
         markdown=True,
     )

--- a/basics/agents/usage/run-response-events.mdx
+++ b/basics/agents/usage/run-response-events.mdx
@@ -49,9 +49,9 @@ This example demonstrates how to handle different types of events during agent r
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno anthropic ddgs
+    uv pip install -U agno anthropic ddgs
     ```
   </Step>
 

--- a/basics/agents/usage/run-response-events.mdx
+++ b/basics/agents/usage/run-response-events.mdx
@@ -1,5 +1,6 @@
 ---
 title: Run Response Events
+description: Handle different event types during agent run streaming.
 ---
 
 This example demonstrates how to handle different types of events during agent run streaming. It shows how to capture and process content events, tool call started events, and tool call completed events.
@@ -7,13 +8,6 @@ This example demonstrates how to handle different types of events during agent r
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch run_response_events.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python run_response_events.py
     from typing import Iterator, List
 
@@ -28,7 +22,7 @@ This example demonstrates how to handle different types of events during agent r
     from agno.tools.duckduckgo import DuckDuckGoTools
 
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5"),
         tools=[DuckDuckGoTools()],
         markdown=True,
     )

--- a/basics/agents/usage/scenario-testing.mdx
+++ b/basics/agents/usage/scenario-testing.mdx
@@ -13,7 +13,7 @@ This example demonstrates how to use the Scenario testing library to test an age
     This is an example that uses the [scenario](https://github.com/langwatch/scenario) testing library to test an agent.
 
     Prerequisites:
-    - Install scenario: `uv add langwatch-scenario OR pip install langwatch-scenario`
+    - Install scenario: `uv pip install langwatch-scenario`
     """
 
     import pytest
@@ -83,9 +83,9 @@ This example demonstrates how to use the Scenario testing library to test an age
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai langwatch-scenario pytest
+    uv pip install -U agno openai langwatch-scenario pytest
     ```
   </Step>
 

--- a/basics/agents/usage/scenario-testing.mdx
+++ b/basics/agents/usage/scenario-testing.mdx
@@ -1,5 +1,6 @@
 ---
 title: Scenario Testing
+description: Test agents with defined success and failure criteria using the Scenario library.
 ---
 
 This example demonstrates how to use the Scenario testing library to test an agent with defined success and failure criteria. It shows how to implement automated testing for agent behavior and responses.
@@ -7,13 +8,6 @@ This example demonstrates how to use the Scenario testing library to test an age
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch scenario_testing.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python scenario_testing.py
     """
     This is an example that uses the [scenario](https://github.com/langwatch/scenario) testing library to test an agent.
@@ -61,7 +55,7 @@ This example demonstrates how to use the Scenario testing library to test an age
 
     # Example agent implementation
     from agno.agent import Agent  # noqa: E402
-    from agno.models.openai import OpenAIChat  # noqa: E402
+    from agno.models.openai import OpenAIResponses  # noqa: E402
 
 
     class VegetarianRecipeAgent:
@@ -73,7 +67,7 @@ This example demonstrates how to use the Scenario testing library to test an age
             self.history.append({"role": "user", "content": message})
 
             agent = Agent(
-                model=OpenAIChat(id="gpt-5-mini"),
+                model=OpenAIResponses(id="gpt-5.2"),
                 markdown=True,
                 instructions="You are a vegetarian recipe agent",
             )
@@ -91,7 +85,7 @@ This example demonstrates how to use the Scenario testing library to test an age
 
   <Step title="Install libraries">
     ```bash
-    pip install -U agno openai scenario pytest
+    pip install -U agno openai langwatch-scenario pytest
     ```
   </Step>
 

--- a/basics/agents/usage/streaming.mdx
+++ b/basics/agents/usage/streaming.mdx
@@ -35,9 +35,9 @@ This is useful when you want to process or show the response in real-time, as it
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai
+    uv pip install -U agno openai
     ```
   </Step>
 

--- a/basics/agents/usage/streaming.mdx
+++ b/basics/agents/usage/streaming.mdx
@@ -12,20 +12,13 @@ This is useful when you want to process or show the response in real-time, as it
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch streaming.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python streaming.py
     from agno.agent import Agent
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
     from agno.run.agent import RunEvent
 
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
         instructions="You are a helpful assistant. All your responses must be brief and concise.",
     )
 

--- a/basics/agents/usage/tool-call-limit.mdx
+++ b/basics/agents/usage/tool-call-limit.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tool Call Limit
+description: Limit the number of tool calls an agent can make in a single run.
 ---
 
 This example demonstrates how to use tool call limits to control the number of tool calls an agent can make. This is useful for preventing excessive API usage or limiting agent behavior in specific scenarios.
@@ -7,24 +8,13 @@ This example demonstrates how to use tool call limits to control the number of t
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch tool_call_limit.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python tool_call_limit.py
-    """
-    This cookbook shows how to use tool call limit to control the number of tool calls an agent can make.
-    """
-
     from agno.agent import Agent
     from agno.models.anthropic import Claude
     from agno.tools.duckduckgo import DuckDuckGoTools
 
     agent = Agent(
-        model=Claude(id="claude-3-5-haiku-20241022"),
+        model=Claude(id="claude-sonnet-4-5"),
         tools=[DuckDuckGoTools(company_news=True, cache_results=True)],
         tool_call_limit=1,
     )

--- a/basics/agents/usage/tool-call-limit.mdx
+++ b/basics/agents/usage/tool-call-limit.mdx
@@ -29,9 +29,9 @@ This example demonstrates how to use tool call limits to control the number of t
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno anthropic ddgs
+    uv pip install -U agno anthropic ddgs
     ```
   </Step>
 

--- a/basics/agents/usage/tools.mdx
+++ b/basics/agents/usage/tools.mdx
@@ -11,20 +11,13 @@ Our agent will now be able to use these tools to search the web for information:
 <Steps>
 
   <Step title="Create a Python file">
-    ```bash
-    touch tools.py
-    ```
-  </Step>
-
-
-  <Step title="Add the following code to your Python file">
     ```python tools.py
     from agno.agent import Agent
-    from agno.models.openai import OpenAIChat
+    from agno.models.openai import OpenAIResponses
     from agno.tools.duckduckgo import DuckDuckGoTools
 
     agent = Agent(
-        model=OpenAIChat(id="gpt-5-mini"),
+        model=OpenAIResponses(id="gpt-5.2"),
         tools=[DuckDuckGoTools()],
         markdown=True,
     )

--- a/basics/agents/usage/tools.mdx
+++ b/basics/agents/usage/tools.mdx
@@ -29,9 +29,9 @@ Our agent will now be able to use these tools to search the web for information:
 
   <Snippet file="create-venv-step.mdx" />
 
-  <Step title="Install libraries">
+  <Step title="Install dependencies">
     ```bash
-    pip install -U agno openai ddgs
+    uv pip install -U agno openai ddgs
     ```
   </Step>
 

--- a/docs.json
+++ b/docs.json
@@ -96,39 +96,24 @@
                   "basics/agents/running-agents",
                   "basics/agents/debugging-agents",
                   {
-                    "group": "Usage",
+                    "group": "Examples",
                     "pages": [
-                      {
-                        "group": "Basic Flows",
-                        "pages": [
-                          "basics/agents/usage/basic",
-                          "basics/agents/usage/basic-async",
-                          "basics/agents/usage/streaming",
-                          "basics/agents/usage/instructions",
-                          "basics/agents/usage/tools",
-                          "basics/agents/usage/debug"
-                        ]
-                      },
-                      {
-                        "group": "Core Features",
-                        "pages": [
-                          "basics/agents/usage/agent-with-storage",
-                          "basics/agents/usage/agent-with-memory",
-                          "basics/agents/usage/agent-with-knowledge"
-                        ]
-                      },
-                      {
-                        "group": "Other",
-                        "pages": [
-                          "basics/agents/usage/run-response-events",
-                          "basics/agents/usage/intermediate-steps",
-                          "basics/agents/usage/agent-run-metadata",
-                          "basics/agents/usage/cancel-a-run",
-                          "basics/agents/usage/debug-level",
-                          "basics/agents/usage/scenario-testing",
-                          "basics/agents/usage/tool-call-limit"
-                        ]
-                      }
+                        "basics/agents/usage/basic",
+                        "basics/agents/usage/basic-async",
+                        "basics/agents/usage/streaming",
+                        "basics/agents/usage/instructions",
+                        "basics/agents/usage/tools",
+                        "basics/agents/usage/debug",
+                        "basics/agents/usage/agent-with-storage",
+                        "basics/agents/usage/agent-with-memory",
+                        "basics/agents/usage/agent-with-knowledge",
+                        "basics/agents/usage/run-response-events",
+                        "basics/agents/usage/intermediate-steps",
+                        "basics/agents/usage/agent-run-metadata",
+                        "basics/agents/usage/cancel-a-run",
+                        "basics/agents/usage/debug-level",
+                        "basics/agents/usage/scenario-testing",
+                        "basics/agents/usage/tool-call-limit"
                     ]
                   }
                 ]


### PR DESCRIPTION
## Summary

- Fix subjective language ("exceptionally well-built") and em-dashes in core agent docs
- Add missing `description` frontmatter to 7 example files
- Standardize model IDs: `claude-sonnet-4-5` (preferred), `gpt-5.2` with `OpenAIResponses`
- Remove unnecessary `touch filename.py` steps from all examples
- Clean up verbose code comments and docstrings
- Rename sidebar "Usage" → "Examples" with flat hierarchy (no nested groups)
- Update CLAUDE.md with documentation structure patterns

## Test plan

- [ ] Verify sidebar shows "Examples" with flat list
- [ ] Spot check a few example files render correctly
- [ ] Confirm code examples use correct model imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)