### PR TITLE
feat: Add docs for direct GCS and external URL support in Gemini

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1739,6 +1739,9 @@
                               "integrations/models/native/google/usage/audio-input-local-file-upload",
                               "integrations/models/native/google/usage/pdf-input-local",
                               "integrations/models/native/google/usage/pdf-input-url",
+                              "integrations/models/native/google/usage/gcs-file-input",
+                              "integrations/models/native/google/usage/external-url-input",
+                              "integrations/models/native/google/usage/s3-presigned-url-input",
                               "integrations/models/native/google/usage/video-input-bytes-content",
                               "integrations/models/native/google/usage/video-input-file-upload",
                               "integrations/models/native/google/usage/video-input-local-file-upload"

--- a/integrations/models/native/google/overview.mdx
+++ b/integrations/models/native/google/overview.mdx
@@ -157,6 +157,9 @@ See the following examples:
 - [Video input](/integrations/models/native/google/usage/video-input-file-upload)
 - [Audio input](/integrations/models/native/google/usage/audio-input-file-upload)
 - [PDF input](/integrations/models/native/google/usage/pdf-input-url)
+- [GCS file input](/integrations/models/native/google/usage/gcs-file-input) (direct GCS access, up to 2GB)
+- [External URL input](/integrations/models/native/google/usage/external-url-input) (up to 100MB)
+- [S3 pre-signed URL](/integrations/models/native/google/usage/s3-presigned-url-input)
 
 ## Image Generation
 

--- a/integrations/models/native/google/usage/external-url-input.mdx
+++ b/integrations/models/native/google/usage/external-url-input.mdx
@@ -5,6 +5,12 @@ title: Agent with External URL Input
 ## Code
 
 ```python cookbook/11_models/google/gemini/external_url_input.py
+"""External URL input with Gemini.
+
+Pass files from public HTTPS URLs directly without downloading.
+Supports files up to 100MB. Requires Gemini 3.x models.
+"""
+
 from agno.agent import Agent
 from agno.media import File
 from agno.models.google import Gemini

--- a/integrations/models/native/google/usage/external-url-input.mdx
+++ b/integrations/models/native/google/usage/external-url-input.mdx
@@ -2,15 +2,23 @@
 title: Agent with External URL Input
 ---
 
-Pass files from public HTTPS URLs directly to Gemini without downloading them first. Supports files up to 100MB.
-
-<Note>
-External URL support requires Gemini 3.x models (e.g., `gemini-3-flash-preview`). Gemini 2.0 models do not support this feature.
-</Note>
-
 ## Code
 
 ```python cookbook/11_models/google/gemini/external_url_input.py
+"""
+Pass files from public HTTPS URLs directly to Gemini without downloading.
+
+Supports files up to 100MB from:
+- Public URLs (no authentication required)
+- Pre-signed URLs from AWS S3
+- SAS URLs from Azure Blob Storage
+- Any accessible HTTPS URL
+
+Supported formats: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF)
+
+Note: External URL support requires Gemini 3.x models (e.g., gemini-3-flash-preview).
+"""
+
 from agno.agent import Agent
 from agno.media import File
 from agno.models.google import Gemini
@@ -20,7 +28,6 @@ agent = Agent(
     markdown=True,
 )
 
-# Pass public URL directly - Gemini fetches the content
 agent.print_response(
     "Summarize this document.",
     files=[
@@ -45,7 +52,7 @@ agent.print_response(
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U google-genai agno
+    pip install -U google-genai agno
     ```
   </Step>
 
@@ -55,12 +62,3 @@ agent.print_response(
     ```
   </Step>
 </Steps>
-
-## Key Points
-
-- **Direct fetch**: Gemini fetches the file directly from the URL. No download to your machine.
-- **File size limit**: Supports files up to 100MB.
-- **Requires mime_type**: You must specify the `mime_type` parameter.
-- **Model requirement**: Requires Gemini 3.x models.
-- **Supported sources**: Public URLs, pre-signed S3 URLs, Azure SAS URLs, any accessible HTTPS URL.
-- **Supported formats**: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF).

--- a/integrations/models/native/google/usage/external-url-input.mdx
+++ b/integrations/models/native/google/usage/external-url-input.mdx
@@ -1,0 +1,66 @@
+---
+title: Agent with External URL Input
+---
+
+Pass files from public HTTPS URLs directly to Gemini without downloading them first. Supports files up to 100MB.
+
+<Note>
+External URL support requires Gemini 3.x models (e.g., `gemini-3-flash-preview`). Gemini 2.0 models do not support this feature.
+</Note>
+
+## Code
+
+```python cookbook/11_models/google/gemini/external_url_input.py
+from agno.agent import Agent
+from agno.media import File
+from agno.models.google import Gemini
+
+agent = Agent(
+    model=Gemini(id="gemini-3-flash-preview"),
+    markdown=True,
+)
+
+# Pass public URL directly - Gemini fetches the content
+agent.print_response(
+    "Summarize this document.",
+    files=[
+        File(
+            url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf",
+            mime_type="application/pdf",
+        )
+    ],
+)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U google-genai agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/11_models/google/gemini/external_url_input.py
+    ```
+  </Step>
+</Steps>
+
+## Key Points
+
+- **Direct fetch**: Gemini fetches the file directly from the URL. No download to your machine.
+- **File size limit**: Supports files up to 100MB.
+- **Requires mime_type**: You must specify the `mime_type` parameter.
+- **Model requirement**: Requires Gemini 3.x models.
+- **Supported sources**: Public URLs, pre-signed S3 URLs, Azure SAS URLs, any accessible HTTPS URL.
+- **Supported formats**: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF).

--- a/integrations/models/native/google/usage/external-url-input.mdx
+++ b/integrations/models/native/google/usage/external-url-input.mdx
@@ -5,20 +5,6 @@ title: Agent with External URL Input
 ## Code
 
 ```python cookbook/11_models/google/gemini/external_url_input.py
-"""
-Pass files from public HTTPS URLs directly to Gemini without downloading.
-
-Supports files up to 100MB from:
-- Public URLs (no authentication required)
-- Pre-signed URLs from AWS S3
-- SAS URLs from Azure Blob Storage
-- Any accessible HTTPS URL
-
-Supported formats: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF)
-
-Note: External URL support requires Gemini 3.x models (e.g., gemini-3-flash-preview).
-"""
-
 from agno.agent import Agent
 from agno.media import File
 from agno.models.google import Gemini

--- a/integrations/models/native/google/usage/gcs-file-input.mdx
+++ b/integrations/models/native/google/usage/gcs-file-input.mdx
@@ -5,20 +5,6 @@ title: Agent with GCS File Input
 ## Code
 
 ```python cookbook/11_models/google/gemini/gcs_file_input.py
-"""
-Pass files directly from Google Cloud Storage to Gemini without downloading.
-
-GCS URIs support files up to 2GB and require Vertex AI authentication.
-API keys do not support GCS access.
-
-Requirements:
-- Run: gcloud auth application-default login
-- Set: GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION env vars
-- Your GCS bucket must be accessible to your credentials
-
-Supported formats: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF)
-"""
-
 from agno.agent import Agent
 from agno.media import File
 from agno.models.google import Gemini

--- a/integrations/models/native/google/usage/gcs-file-input.mdx
+++ b/integrations/models/native/google/usage/gcs-file-input.mdx
@@ -2,20 +2,27 @@
 title: Agent with GCS File Input
 ---
 
-Pass files directly from Google Cloud Storage to Gemini without downloading them first. GCS URIs support files up to 2GB.
-
-<Note>
-GCS URIs require Vertex AI authentication. API keys do not support GCS access.
-</Note>
-
 ## Code
 
 ```python cookbook/11_models/google/gemini/gcs_file_input.py
+"""
+Pass files directly from Google Cloud Storage to Gemini without downloading.
+
+GCS URIs support files up to 2GB and require Vertex AI authentication.
+API keys do not support GCS access.
+
+Requirements:
+- Run: gcloud auth application-default login
+- Set: GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION env vars
+- Your GCS bucket must be accessible to your credentials
+
+Supported formats: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF)
+"""
+
 from agno.agent import Agent
 from agno.media import File
 from agno.models.google import Gemini
 
-# GCS requires Vertex AI (OAuth credentials), not API keys
 agent = Agent(
     model=Gemini(
         id="gemini-2.0-flash",
@@ -24,7 +31,6 @@ agent = Agent(
     markdown=True,
 )
 
-# Pass GCS URI directly - no download or re-upload needed
 agent.print_response(
     "Summarize this document and extract key insights.",
     files=[
@@ -42,7 +48,6 @@ agent.print_response(
   <Snippet file="create-venv-step.mdx" />
 
   <Step title="Set up Vertex AI">
-    GCS URIs require Vertex AI authentication:
     ```bash
     gcloud auth application-default login
     export GOOGLE_CLOUD_PROJECT="your-project-id"
@@ -52,7 +57,7 @@ agent.print_response(
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U google-genai agno
+    pip install -U google-genai agno
     ```
   </Step>
 
@@ -62,11 +67,3 @@ agent.print_response(
     ```
   </Step>
 </Steps>
-
-## Key Points
-
-- **Direct access**: Files are read directly by Gemini from GCS. No download to your machine.
-- **Large files**: Supports files up to 2GB.
-- **Requires mime_type**: You must specify the `mime_type` parameter.
-- **Vertex AI only**: GCS URIs require OAuth credentials, not API keys.
-- **Supported formats**: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF).

--- a/integrations/models/native/google/usage/gcs-file-input.mdx
+++ b/integrations/models/native/google/usage/gcs-file-input.mdx
@@ -5,6 +5,12 @@ title: Agent with GCS File Input
 ## Code
 
 ```python cookbook/11_models/google/gemini/gcs_file_input.py
+"""GCS file input with Gemini.
+
+Pass files directly from Google Cloud Storage (gs://) without downloading.
+Supports files up to 2GB. Requires Vertex AI authentication.
+"""
+
 from agno.agent import Agent
 from agno.media import File
 from agno.models.google import Gemini

--- a/integrations/models/native/google/usage/gcs-file-input.mdx
+++ b/integrations/models/native/google/usage/gcs-file-input.mdx
@@ -1,0 +1,72 @@
+---
+title: Agent with GCS File Input
+---
+
+Pass files directly from Google Cloud Storage to Gemini without downloading them first. GCS URIs support files up to 2GB.
+
+<Note>
+GCS URIs require Vertex AI authentication. API keys do not support GCS access.
+</Note>
+
+## Code
+
+```python cookbook/11_models/google/gemini/gcs_file_input.py
+from agno.agent import Agent
+from agno.media import File
+from agno.models.google import Gemini
+
+# GCS requires Vertex AI (OAuth credentials), not API keys
+agent = Agent(
+    model=Gemini(
+        id="gemini-2.0-flash",
+        vertexai=True,
+    ),
+    markdown=True,
+)
+
+# Pass GCS URI directly - no download or re-upload needed
+agent.print_response(
+    "Summarize this document and extract key insights.",
+    files=[
+        File(
+            url="gs://cloud-samples-data/generative-ai/pdf/2312.11805v3.pdf",
+            mime_type="application/pdf",
+        )
+    ],
+)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set up Vertex AI">
+    GCS URIs require Vertex AI authentication:
+    ```bash
+    gcloud auth application-default login
+    export GOOGLE_CLOUD_PROJECT="your-project-id"
+    export GOOGLE_CLOUD_LOCATION="us-central1"
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U google-genai agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/11_models/google/gemini/gcs_file_input.py
+    ```
+  </Step>
+</Steps>
+
+## Key Points
+
+- **Direct access**: Files are read directly by Gemini from GCS. No download to your machine.
+- **Large files**: Supports files up to 2GB.
+- **Requires mime_type**: You must specify the `mime_type` parameter.
+- **Vertex AI only**: GCS URIs require OAuth credentials, not API keys.
+- **Supported formats**: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF).

--- a/integrations/models/native/google/usage/s3-presigned-url-input.mdx
+++ b/integrations/models/native/google/usage/s3-presigned-url-input.mdx
@@ -5,6 +5,12 @@ title: Agent with S3 Pre-signed URL Input
 ## Code
 
 ```python cookbook/11_models/google/gemini/s3_url_file_input.py
+"""S3 pre-signed URL input with Gemini.
+
+Pass files from S3 using pre-signed URLs without downloading.
+Supports files up to 100MB. Requires Gemini 3.x models.
+"""
+
 import boto3
 from agno.agent import Agent
 from agno.media import File

--- a/integrations/models/native/google/usage/s3-presigned-url-input.mdx
+++ b/integrations/models/native/google/usage/s3-presigned-url-input.mdx
@@ -5,21 +5,6 @@ title: Agent with S3 Pre-signed URL Input
 ## Code
 
 ```python cookbook/11_models/google/gemini/s3_url_file_input.py
-"""
-Pass files from AWS S3 using pre-signed URLs directly to Gemini.
-
-Generate a pre-signed URL and pass it to Gemini without downloading.
-Supports files up to 100MB.
-
-Requirements:
-- AWS credentials configured (via environment variables or ~/.aws/credentials)
-- boto3 installed: pip install boto3
-
-Supported formats: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF)
-
-Note: External URL support requires Gemini 3.x models (e.g., gemini-3-flash-preview).
-"""
-
 import boto3
 from agno.agent import Agent
 from agno.media import File

--- a/integrations/models/native/google/usage/s3-presigned-url-input.mdx
+++ b/integrations/models/native/google/usage/s3-presigned-url-input.mdx
@@ -1,0 +1,82 @@
+---
+title: Agent with S3 Pre-signed URL Input
+---
+
+Pass files from AWS S3 using pre-signed URLs directly to Gemini without downloading them first. Supports files up to 100MB.
+
+<Note>
+External URL support requires Gemini 3.x models (e.g., `gemini-3-flash-preview`). Gemini 2.0 models do not support this feature.
+</Note>
+
+## Code
+
+```python cookbook/11_models/google/gemini/s3_url_file_input.py
+import boto3
+from agno.agent import Agent
+from agno.media import File
+from agno.models.google import Gemini
+
+# Generate a pre-signed URL for your S3 object
+s3_client = boto3.client("s3")
+presigned_url = s3_client.generate_presigned_url(
+    "get_object",
+    Params={
+        "Bucket": "agno-public",
+        "Key": "recipes/ThaiRecipes.pdf",
+    },
+    ExpiresIn=3600,  # URL valid for 1 hour
+)
+
+agent = Agent(
+    model=Gemini(id="gemini-3-flash-preview"),
+    markdown=True,
+)
+
+# Pass pre-signed URL directly - Gemini fetches the content
+agent.print_response(
+    "What is this document about? Answer in one sentence.",
+    files=[
+        File(
+            url=presigned_url,
+            mime_type="application/pdf",
+        )
+    ],
+)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your credentials">
+    Set your Google API key and AWS credentials:
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    export AWS_ACCESS_KEY_ID=xxx
+    export AWS_SECRET_ACCESS_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U google-genai agno boto3
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/11_models/google/gemini/s3_url_file_input.py
+    ```
+  </Step>
+</Steps>
+
+## Key Points
+
+- **No intermediate download**: Gemini fetches directly from S3. Your machine never downloads the file.
+- **File size limit**: Supports files up to 100MB.
+- **Requires mime_type**: You must specify the `mime_type` parameter.
+- **Model requirement**: Requires Gemini 3.x models.
+- **URL expiration**: Set `ExpiresIn` to control how long the URL remains valid.
+- **Private buckets**: Works with private S3 buckets since the pre-signed URL includes temporary credentials.
+- **Supported formats**: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF).

--- a/integrations/models/native/google/usage/s3-presigned-url-input.mdx
+++ b/integrations/models/native/google/usage/s3-presigned-url-input.mdx
@@ -2,21 +2,29 @@
 title: Agent with S3 Pre-signed URL Input
 ---
 
-Pass files from AWS S3 using pre-signed URLs directly to Gemini without downloading them first. Supports files up to 100MB.
-
-<Note>
-External URL support requires Gemini 3.x models (e.g., `gemini-3-flash-preview`). Gemini 2.0 models do not support this feature.
-</Note>
-
 ## Code
 
 ```python cookbook/11_models/google/gemini/s3_url_file_input.py
+"""
+Pass files from AWS S3 using pre-signed URLs directly to Gemini.
+
+Generate a pre-signed URL and pass it to Gemini without downloading.
+Supports files up to 100MB.
+
+Requirements:
+- AWS credentials configured (via environment variables or ~/.aws/credentials)
+- boto3 installed: pip install boto3
+
+Supported formats: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF)
+
+Note: External URL support requires Gemini 3.x models (e.g., gemini-3-flash-preview).
+"""
+
 import boto3
 from agno.agent import Agent
 from agno.media import File
 from agno.models.google import Gemini
 
-# Generate a pre-signed URL for your S3 object
 s3_client = boto3.client("s3")
 presigned_url = s3_client.generate_presigned_url(
     "get_object",
@@ -24,7 +32,7 @@ presigned_url = s3_client.generate_presigned_url(
         "Bucket": "agno-public",
         "Key": "recipes/ThaiRecipes.pdf",
     },
-    ExpiresIn=3600,  # URL valid for 1 hour
+    ExpiresIn=3600,
 )
 
 agent = Agent(
@@ -32,7 +40,6 @@ agent = Agent(
     markdown=True,
 )
 
-# Pass pre-signed URL directly - Gemini fetches the content
 agent.print_response(
     "What is this document about? Answer in one sentence.",
     files=[
@@ -50,7 +57,6 @@ agent.print_response(
   <Snippet file="create-venv-step.mdx" />
 
   <Step title="Set your credentials">
-    Set your Google API key and AWS credentials:
     ```bash
     export GOOGLE_API_KEY=xxx
     export AWS_ACCESS_KEY_ID=xxx
@@ -60,7 +66,7 @@ agent.print_response(
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U google-genai agno boto3
+    pip install -U google-genai agno boto3
     ```
   </Step>
 
@@ -70,13 +76,3 @@ agent.print_response(
     ```
   </Step>
 </Steps>
-
-## Key Points
-
-- **No intermediate download**: Gemini fetches directly from S3. Your machine never downloads the file.
-- **File size limit**: Supports files up to 100MB.
-- **Requires mime_type**: You must specify the `mime_type` parameter.
-- **Model requirement**: Requires Gemini 3.x models.
-- **URL expiration**: Set `ExpiresIn` to control how long the URL remains valid.
-- **Private buckets**: Works with private S3 buckets since the pre-signed URL includes temporary credentials.
-- **Supported formats**: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF).


### PR DESCRIPTION
## Summary

Documents the new Gemini direct file access capabilities from [agno-agi/agno#5997](https://github.com/agno-agi/agno/pull/5997):

- **GCS file input** (`gs://` URIs) - Direct access to Google Cloud Storage files up to 2GB via Vertex AI
- **External URL input** - Direct access to HTTPS URLs up to 100MB (requires Gemini 3.x models)
- **S3 pre-signed URLs** - Example using boto3 to generate and use pre-signed URLs

These features enable processing large files without downloading them to the local machine first.

## Changes

| File | Description |
|------|-------------|
| `gcs-file-input.mdx` | New page for GCS URI input with Vertex AI setup |
| `external-url-input.mdx` | New page for public HTTPS URL input |
| `s3-presigned-url-input.mdx` | New page with boto3 pre-signed URL example |
| `overview.mdx` | Added links to new pages in Multimodal Input section |
| `docs.json` | Added new pages to navigation |

## Test plan

- [ ] Verify pages render correctly at `/integrations/models/native/google/usage/gcs-file-input`
- [ ] Verify pages render correctly at `/integrations/models/native/google/usage/external-url-input`
- [ ] Verify pages render correctly at `/integrations/models/native/google/usage/s3-presigned-url-input`
- [ ] Verify links work in the Google overview page
- [ ] Verify navigation shows new pages under Google > Usage