### PR TITLE
docs: add `collect_metrics_on_completion` param for streaming metrics

### DIFF
--- a/integrations/models/native/perplexity/overview.mdx
+++ b/integrations/models/native/perplexity/overview.mdx
@@ -49,10 +49,13 @@ agent.print_response("Share a 2 sentence horror story")
 
 | Parameter    | Type               | Default                        | Description                                                           |
 | ------------ | ------------------ | ------------------------------ | --------------------------------------------------------------------- |
-| `id`         | `str`              | `"llama-3.1-sonar-small-128k-online"` | The id of the Perplexity model to use                          |
+| `id`         | `str`              | `"sonar"`                     | The ID of the Perplexity model to use                          |
 | `name`       | `str`              | `"Perplexity"`                | The name of the model                                                 |
 | `provider`   | `str`              | `"Perplexity"`                | The provider of the model                                             |
 | `api_key`    | `Optional[str]`    | `None`                         | The API key for Perplexity (defaults to PERPLEXITY_API_KEY env var)  |
-| `base_url`   | `str`              | `"https://api.perplexity.ai"` | The base URL for the Perplexity API                                   |
+| `base_url`   | `str`              | `"https://api.perplexity.ai/"` | The base URL for the Perplexity API                                   |
+| `max_tokens` | `int`              | `1024`                         | Maximum number of tokens to generate                                  |
+| `top_k`      | `Optional[float]`  | `None`                         | Number of highest probability tokens to consider for generation       |
+| `collect_metrics_on_completion` | `bool` | `True`              | Collect token metrics only from the final streaming chunk (for providers with cumulative token counts) |
 
 `Perplexity` also supports the params of [OpenAI](/reference/models/openai).

--- a/integrations/models/openai-like.mdx
+++ b/integrations/models/openai-like.mdx
@@ -33,10 +33,11 @@ agent.print_response("Share a 2 sentence horror story.")
 
 | Parameter    | Type               | Default                        | Description                                                           |
 | ------------ | ------------------ | ------------------------------ | --------------------------------------------------------------------- |
-| `id`         | `str`              | `"gpt-4o-mini"`                | The id of the model to use                                            |
+| `id`         | `str`              | `"not-provided"`               | The id of the model to use                                            |
 | `name`       | `str`              | `"OpenAILike"`                 | The name of the model                                                 |
 | `provider`   | `str`              | `"OpenAILike"`                 | The provider of the model                                             |
-| `api_key`    | `Optional[str]`    | `None`                         | The API key for the service (defaults to OPENAI_API_KEY env var)     |
+| `api_key`    | `Optional[str]`    | `"not-provided"`               | The API key for authentication                                        |
 | `base_url`   | `Optional[str]`    | `None`                         | The base URL for the API service                                      |
+| `collect_metrics_on_completion` | `bool` | `False`                 | Collect token metrics only from the final streaming chunk (for providers with cumulative token counts) |
 
 `OpenAILike` extends the OpenAI-compatible interface and supports all parameters from [OpenAIChat](/integrations/models/native/openai/completion/overview). Simply change the `base_url` and `api_key` to point to your preferred OpenAI-compatible service.

--- a/reference/models/openai-like.mdx
+++ b/reference/models/openai-like.mdx
@@ -9,10 +9,11 @@ The OpenAI Like model works as a wrapper for the OpenAILike models.
 
 | Parameter            | Type                               | Default                        | Description                                                                                                      |
 | -------------------- | ---------------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `id`                 | `str`                              | `"gpt-4o"`                     | The id of the model to use                                                                                       |
+| `id`                 | `str`                              | `"not-provided"`               | The id of the model to use                                                                                       |
 | `name`               | `str`                              | `"OpenAILike"`                 | The name of the model                                                                                            |
 | `provider`           | `str`                              | `"OpenAILike"`                 | The provider of the model                                                                                        |
-| `api_key`            | `Optional[str]`                    | `None`                         | The API key for authentication (defaults to OPENAI_API_KEY env var)                                             |
+| `api_key`            | `Optional[str]`                    | `"not-provided"`               | The API key for authentication                                                                                   |
+| `collect_metrics_on_completion` | `bool`                  | `False`                        | Collect token metrics only from the final streaming chunk (for providers with cumulative token counts)           |
 | `base_url`           | `str`                              | `"https://api.openai.com/v1"` | The base URL for the API                                                                                         |
 | `supports_native_structured_outputs` | `Optional[bool]`          | `None`                         | Whether the model supports native structured outputs                                                             |
 | `response_format`    | `Optional[str]`                    | `None`                         | The format of the response                                                                                       |

--- a/reference/models/openai.mdx
+++ b/reference/models/openai.mdx
@@ -12,6 +12,7 @@ The OpenAIChat model provides access to OpenAI models like GPT-4o.
 | `id`                         | `str`                          | `"gpt-4o"`             | The id of the OpenAI model to use                                                                       |
 | `name`                       | `str`                          | `"OpenAIChat"`         | The name of the model                                                                                    |
 | `provider`                   | `str`                          | `"OpenAI"`             | The provider of the model                                                                                |
+| `collect_metrics_on_completion` | `bool`                      | `False`                | Collect token metrics only from the final streaming chunk (for providers with cumulative token counts)  |
 | `store`                      | `Optional[bool]`               | `None`                 | Whether to store the conversation for training purposes                                                  |
 | `reasoning_effort`           | `Optional[str]`                | `None`                 | The reasoning effort level for o1 models ("low", "medium", "high")                                      |
 | `verbosity`                  | `Optional[Literal["low", "medium", "high"]]` | `None`     | Controls verbosity level of reasoning models                                                             |

--- a/reference/models/perplexity.mdx
+++ b/reference/models/perplexity.mdx
@@ -9,11 +9,14 @@ The Perplexity model provides access to Perplexity's language models.
 
 | Parameter    | Type               | Default                        | Description                                                           |
 | ------------ | ------------------ | ------------------------------ | --------------------------------------------------------------------- |
-| `id`         | `str`              | `"llama-3.1-sonar-small-128k-online"` | The id of the Perplexity model to use                          |
+| `id`         | `str`              | `"sonar"` | The ID of the Perplexity model to use                          |
 | `name`       | `str`              | `"Perplexity"`                | The name of the model                                                 |
 | `provider`   | `str`              | `"Perplexity"`                | The provider of the model                                             |
 | `api_key`    | `Optional[str]`    | `None`                         | The API key for Perplexity (defaults to PERPLEXITY_API_KEY env var)  |
-| `base_url`   | `str`              | `"https://api.perplexity.ai"` | The base URL for the Perplexity API                                   |
+| `base_url`   | `str`              | `"https://api.perplexity.ai/"` | The base URL for the Perplexity API                                   |
+| `max_tokens` | `int`              | `1024`                         | Maximum number of tokens to generate                                  |
+| `top_k`      | `Optional[float]`  | `None`                         | Number of highest probability tokens to consider for generation       |
+| `collect_metrics_on_completion` | `bool` | `True`              | Collect token metrics only from the final streaming chunk (for providers with cumulative token counts) |
 | `retries`    | `int`              | `0`                            | Number of retries to attempt before raising a ModelProviderError      |
 | `delay_between_retries` | `int`    | `1`                            | Delay between retries, in seconds                                     |
 | `exponential_backoff` | `bool`     | `False`                        | If True, the delay between retries is doubled each time               |


### PR DESCRIPTION
## Description

   - Add collect_metrics_on_completion to OpenAI, OpenAILike, and Perplexity docs                                                  
   - Fix Perplexity defaults: id="sonar", base_url with trailing slash                                                             
   - Add missing Perplexity params: max_tokens, top_k                                                                              
   - Fix OpenAILike defaults: id="not-provided", api_key="not-provided"                                                            
   - Update both reference and integration docs 
   
**Note:** Your PR title must follow conventional commit format (e.g., `docs: add auth guide`, `fix: correct broken links`, `style: update formatting`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#6058

## Checklist

- [x] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
