### PR TITLE
fix(docs): aysnc cassandra insert maybe should use ainsert method

### DIFF
--- a/knowledge/vector-stores/cassandra/usage/async-cassandra-db.mdx
+++ b/knowledge/vector-stores/cassandra/usage/async-cassandra-db.mdx
@@ -46,7 +46,7 @@ agent = Agent(
 
 if __name__ == "__main__":
     asyncio.run(
-        knowledge.insert(url="https://docs.agno.com/introduction/agents.md")
+        knowledge.ainsert(url="https://docs.agno.com/introduction/agents.md")
     )
 
     asyncio.run(


### PR DESCRIPTION
## Description

when async insert maybe should use ainsert but not insert.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
