### PR TITLE
fix: broken agent-os introduction link

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -37,7 +37,7 @@ Agno provides the complete infrastructure for building multi-agent systems that 
 | Component | What it does |
 |-----------|--------------|
 | **Framework** | Build agents and multi-agent teams with learning, tools, knowledge, and guardrails |
-| **Runtime** | Run your system in production using the [AgentOS](/agentos/introduction) |
+| **Runtime** | Run your system in production using the [AgentOS](/agent-os/introduction) |
 | **Control Plane** | Monitor and manage via the [AgentOS UI](https://os.agno.com) |
 
 ## Next Steps


### PR DESCRIPTION
## Description

Fix broken AgentOS link on the SDK Introduction page, under the Production Stack section.

## Type of Change

- [X] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues

<!-- Link any related issues or PRs -->

- Closes #464

## Checklist

- [ ] Content is accurate and up-to-date
- [X] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
