### PR TITLE
fix(docs): keep same pattern when use vector db with setting embedder

### DIFF
--- a/knowledge/agents/overview.mdx
+++ b/knowledge/agents/overview.mdx
@@ -242,6 +242,7 @@ Let's build a **RAG Agent** that answers questions from a PDF.
     import asyncio
     from agno.agent import Agent
     from agno.models.openai import OpenAIResponses
+    from agno.knowledge.embedder.openai import OpenAIEmbedder
     from agno.knowledge.knowledge import Knowledge
     from agno.vectordb.pgvector import PgVector
 
@@ -257,6 +258,7 @@ Let's build a **RAG Agent** that answers questions from a PDF.
         vector_db=PgVector(
             table_name="recipes",
             db_url=db_url,
+            embedder=OpenAIEmbedder(),
         )
     )
 


### PR DESCRIPTION
## Description

Demo code should keep same pattern, when use vector db with setting embedder. Should not one set, but other not.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [X] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
