### PR TITLE
fix: web search should use DuckDuckGoTools not DuckDbTools

### DIFF
--- a/context/team/overview.mdx
+++ b/context/team/overview.mdx
@@ -305,6 +305,7 @@ from agno.agent import Agent
 from agno.team import Team
 from agno.models.langdb import LangDB
 from agno.tools.duckdb import DuckDbTools
+from agno.tools.duckduckgo import DuckDuckGoTools
 
 duckdb_tools = DuckDbTools(
     create_tables=False, export_tables=False, summarize_tables=False
@@ -317,7 +318,7 @@ duckdb_tools.create_table_from_path(
 web_researcher = Agent(
     name="Web Researcher",
     role="You are a web researcher that can find information on the web.",
-    tools=[DuckDbTools()],
+    tools=[DuckDuckGoTools()],
     instructions=[
         "Use your web search tool to find information on the web.",
         "Provide a summary of the information found.",


### PR DESCRIPTION
## Description

If agent need to web search could use DuckDuckGoTools but not DuckDbTools

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
