### PR TITLE
docs: add Studio and CEL expressions documentation

### DIFF
--- a/agent-os/studio/agents.mdx
+++ b/agent-os/studio/agents.mdx
@@ -42,7 +42,7 @@ Once your agent is configured:
 
 ## Code Equivalent
 
-An agent built in Studio maps directly to the SDK's `Agent` class:
+Studio agents are directly mapped instances of the SDK 'Agent' class.
 
 ```python
 from agno.agent import Agent

--- a/agent-os/studio/agents.mdx
+++ b/agent-os/studio/agents.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Agents"
-sidebarTitle: "Agents"
 description: "Build and configure agents visually in AgentOS Studio."
 ---
 
-Studio provides a **visual Agent Builder** for creating agents with models, tools, instructions, and structured I/O. Build agents by dragging and configuring components—no code required.
+Build production-grade agents via AgentOS Studio’s visual canvas. Wire up models, tools, 
+and structured I/O into complex agentic workflows. Deploy instantly. No-code required.
 
 ## Creating Agents
 
@@ -20,12 +20,12 @@ Create a new agent by selecting components from your [Registry](/agent-os/studio
 | **Knowledge** | Attach knowledge bases for RAG |
 
 <Tip>
-Use the advanced config editor to provide a JSON configuration for fine-grained control over agent settings.
+Switch to the advanced JSON config editor for fine-grained control over agent settings.
 </Tip>
 
 ## Using Agents
 
-Agents built in Studio can be used in multiple ways:
+Use Studio-built Agents in multiple ways:
 
 - **Chat directly** with the agent via the Chat page
 - **Add to Teams** for multi-agent collaboration
@@ -42,7 +42,7 @@ Once your agent is configured:
 
 ## Code Equivalent
 
-Studio agents are directly mapped instances of the SDK 'Agent' class.
+Agents built in Studio are native instances of the 'Agent' class in the SDK.
 
 ```python
 from agno.agent import Agent

--- a/agent-os/studio/agents.mdx
+++ b/agent-os/studio/agents.mdx
@@ -1,0 +1,65 @@
+---
+title: "Agents"
+sidebarTitle: "Agents"
+description: "Build and configure agents visually in AgentOS Studio."
+---
+
+Studio provides a **visual Agent Builder** for creating agents with models, tools, instructions, and structured I/O. Build agents by dragging and configuring components—no code required.
+
+## Creating Agents
+
+Create a new agent by selecting components from your [Registry](/agent-os/studio/registry) and configuring them in the properties panel:
+
+| Setting | Description |
+|---------|-------------|
+| **Model** | Select from registered models |
+| **Tools** | Attach registered tools and toolkits |
+| **Instructions** | System-level instructions for the agent |
+| **Input/Output Schema** | Structured I/O using registered Pydantic schemas |
+| **Memory** | Enable memory for multi-turn conversations |
+| **Knowledge** | Attach knowledge bases for RAG |
+
+<Tip>
+Use the advanced config editor to provide a JSON configuration for fine-grained control over agent settings.
+</Tip>
+
+## Using Agents
+
+Agents built in Studio can be used in multiple ways:
+
+- **Chat directly** with the agent via the Chat page
+- **Add to Teams** for multi-agent collaboration
+- **Use in Workflows** as step executors for automation pipelines
+
+## Save and Run
+
+Once your agent is configured:
+
+1. **Save** your agent to persist it to the registry
+2. Navigate to the **Chat page** to interact with your agent
+3. Send messages and receive responses in real-time
+4. View tool calls, reasoning, and outputs as the agent works
+
+## Code Equivalent
+
+An agent built in Studio maps directly to the SDK's `Agent` class:
+
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.websearch import WebSearchTools
+
+agent = Agent(
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-5-mini"),
+    tools=[WebSearchTools()],
+    instructions="Research topics thoroughly using web search.",
+    markdown=True,
+)
+```
+
+## Developer Resources
+
+- [Agent reference](/reference/agents/agent)
+- [Building agents](/agents/building-agents)
+- [Studio Registry](/agent-os/studio/registry)

--- a/agent-os/studio/cel-expressions.mdx
+++ b/agent-os/studio/cel-expressions.mdx
@@ -1,0 +1,269 @@
+---
+title: "CEL Expressions"
+sidebarTitle: "CEL Expressions"
+description: "Use CEL expressions as evaluators, end conditions, and selectors in workflow steps."
+---
+
+[CEL (Common Expression Language)](https://github.com/google/cel-spec) lets you write evaluators, end conditions, and selectors as strings instead of Python functions. CEL expressions are fully serializable, making them editable in Studio and storable in the database.
+
+```bash
+pip install cel-python
+```
+
+## Overview
+
+Three step types accept CEL expressions:
+
+| Step Type | Parameter | Must Return | Description |
+|-----------|-----------|-------------|-------------|
+| `Condition` | `evaluator` | `bool` | `True` runs `steps`, `False` runs `else_steps` |
+| `Loop` | `end_condition` | `bool` | `True` exits the loop |
+| `Router` | `selector` | `string` | Name of the step to execute from `choices` |
+
+Each step type exposes different context variables to the expression:
+
+| Variable | Type | Condition | Router | Loop |
+|----------|------|:---------:|:------:|:----:|
+| `input` | `string` | ✓ | ✓ | |
+| `previous_step_content` | `string` | ✓ | ✓ | |
+| `previous_step_outputs` | `map` | ✓ | ✓ | |
+| `additional_data` | `map` | ✓ | ✓ | |
+| `session_state` | `map` | ✓ | ✓ | |
+| `step_choices` | `list` | | ✓ | |
+| `current_iteration` | `int` | | | ✓ |
+| `max_iterations` | `int` | | | ✓ |
+| `all_success` | `bool` | | | ✓ |
+| `last_step_content` | `string` | | | ✓ |
+| `step_outputs` | `map` | | | ✓ |
+
+## Conditions
+
+Condition evaluators receive step input context and must return a boolean. `True` runs `steps`, `False` runs `else_steps`.
+
+### Route on input content
+
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.workflow import Condition, Step, Workflow
+
+urgent_handler = Agent(
+    name="Urgent Handler",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="Handle urgent requests with high priority.",
+)
+
+normal_handler = Agent(
+    name="Normal Handler",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="Handle normal requests thoroughly.",
+)
+
+workflow = Workflow(
+    name="CEL Input Routing",
+    steps=[
+        Condition(
+            name="Urgent Check",
+            evaluator='input.contains("urgent")',
+            steps=[Step(name="Handle Urgent", agent=urgent_handler)],
+            else_steps=[Step(name="Handle Normal", agent=normal_handler)],
+        ),
+    ],
+)
+
+workflow.print_response("This is an urgent request - please help immediately!")
+```
+
+### Branch on previous step output
+
+Run a classifier first, then route based on its output:
+
+```python
+classifier = Agent(
+    name="Classifier",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="Classify the request as TECHNICAL or GENERAL. Respond with one word.",
+)
+
+workflow = Workflow(
+    name="Classify and Route",
+    steps=[
+        Step(name="Classify", agent=classifier),
+        Condition(
+            name="Route by Classification",
+            evaluator='previous_step_content.contains("TECHNICAL")',
+            steps=[Step(name="Technical Help", agent=technical_agent)],
+            else_steps=[Step(name="General Help", agent=general_agent)],
+        ),
+    ],
+)
+```
+
+### Branch on additional data
+
+```python
+workflow = Workflow(
+    name="Priority Routing",
+    steps=[
+        Condition(
+            name="Priority Gate",
+            evaluator="additional_data.priority > 5",
+            steps=[Step(name="High Priority", agent=high_priority_agent)],
+            else_steps=[Step(name="Low Priority", agent=low_priority_agent)],
+        ),
+    ],
+)
+
+workflow.print_response("Review this report.", additional_data={"priority": 8})
+```
+
+### Branch on session state
+
+```python
+workflow = Workflow(
+    name="Retry Logic",
+    steps=[
+        Step(name="Increment", executor=increment_retry),
+        Condition(
+            name="Retry Check",
+            evaluator="session_state.retry_count <= 3",
+            steps=[Step(name="Attempt", agent=retry_agent)],
+            else_steps=[Step(name="Give Up", agent=fallback_agent)],
+        ),
+    ],
+    session_state={"retry_count": 0},
+)
+```
+
+## Loops
+
+Loop end conditions receive loop output context and must return a boolean. `True` exits the loop.
+
+### Exit after N iterations
+
+```python
+from agno.workflow import Loop, Step, Workflow
+
+workflow = Workflow(
+    name="Iteration Limit",
+    steps=[
+        Loop(
+            name="Writing Loop",
+            max_iterations=10,
+            end_condition="current_iteration >= 2",
+            steps=[Step(name="Write", agent=writer)],
+        ),
+    ],
+)
+```
+
+### Exit on output keyword
+
+```python
+editor = Agent(
+    name="Editor",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="Edit the text. When polished, include the word DONE at the end.",
+)
+
+workflow = Workflow(
+    name="Content Keyword Loop",
+    steps=[
+        Loop(
+            name="Editing Loop",
+            max_iterations=5,
+            end_condition='last_step_content.contains("DONE")',
+            steps=[Step(name="Edit", agent=editor)],
+        ),
+    ],
+)
+```
+
+### Compound exit condition
+
+```python
+workflow = Workflow(
+    name="Compound Exit",
+    steps=[
+        Loop(
+            name="Research Loop",
+            max_iterations=5,
+            end_condition="all_success && current_iteration >= 2",
+            steps=[
+                Step(name="Research", agent=researcher),
+                Step(name="Review", agent=reviewer),
+            ],
+        ),
+    ],
+)
+```
+
+## Routers
+
+Router selectors receive step input context and must return a string matching a step name from `choices`.
+
+### Route on session state
+
+```python
+from agno.workflow import Step, Workflow
+from agno.workflow.router import Router
+
+workflow = Workflow(
+    name="Style Router",
+    steps=[
+        Router(
+            name="Analysis Style",
+            selector="session_state.preferred_handler",
+            choices=[
+                Step(name="Detailed Analyst", agent=detailed_agent),
+                Step(name="Brief Analyst", agent=brief_agent),
+            ],
+        ),
+    ],
+    session_state={"preferred_handler": "Brief Analyst"},
+)
+```
+
+### Ternary routing on input
+
+```python
+workflow = Workflow(
+    name="Media Router",
+    steps=[
+        Router(
+            name="Media Router",
+            selector='input.contains("video") ? "Video Handler" : "Image Handler"',
+            choices=[
+                Step(name="Video Handler", agent=video_agent),
+                Step(name="Image Handler", agent=image_agent),
+            ],
+        ),
+    ],
+)
+```
+
+### Route using step_choices index
+
+Reference steps by position instead of hardcoding names:
+
+```python
+workflow = Workflow(
+    name="Index Router",
+    steps=[
+        Router(
+            name="Analysis Router",
+            selector='input.contains("quick") ? step_choices[0] : step_choices[1]',
+            choices=[
+                Step(name="Quick Analysis", agent=quick_analyzer),
+                Step(name="Detailed Analysis", agent=detailed_analyzer),
+            ],
+        ),
+    ],
+)
+```
+
+## Developer Resources
+
+- [CEL specification](https://github.com/google/cel-spec)
+- [Workflow reference](/reference/workflows/workflow)
+- [Studio Workflows](/agent-os/studio/workflows)

--- a/agent-os/studio/cel-expressions.mdx
+++ b/agent-os/studio/cel-expressions.mdx
@@ -4,7 +4,9 @@ sidebarTitle: "CEL Expressions"
 description: "Use CEL expressions as evaluators, end conditions, and selectors in workflow steps."
 ---
 
-[CEL (Common Expression Language)](https://github.com/google/cel-spec) lets you write evaluators, end conditions, and selectors as strings instead of Python functions. CEL expressions are fully serializable, making them editable in Studio and storable in the database.
+[CEL (Common Expression Language)](https://github.com/google/cel-spec) lets you write evaluators, 
+end conditions, and selectors as strings instead of Python functions. CEL expressions are fully serializable, 
+making them editable in Studio and storable in the database.
 
 ```bash
 pip install cel-python

--- a/agent-os/studio/introduction.mdx
+++ b/agent-os/studio/introduction.mdx
@@ -7,16 +7,16 @@ Drag, drop, and orchestrate Agents, Teams, and Workflows on a live canvas to dep
 
 ## Concepts
 
-| Concept | Description |
-|-----------|-------------|
-| [Agents](/agent-os/studio/agents) | Build and configure agents with models, tools, and instructions |
-| [Teams](/agent-os/studio/teams) | Compose multi-agent teams with coordination modes |
+| Concept                                 | Description                                                                         |
+| --------------------------------------- | ----------------------------------------------------------------------------------- |
+| [Agents](/agent-os/studio/agents)       | Build and configure agents with models, tools, and instructions                     |
+| [Teams](/agent-os/studio/teams)         | Compose multi-agent teams with coordination modes                                   |
 | [Workflows](/agent-os/studio/workflows) | Design step-based workflows with conditions, loops, routers, and parallel execution |
-| [Registry](/agent-os/studio/registry) | Browse and manage registered tools, models, databases, and schemas |
+| [Registry](/agent-os/studio/registry)   | Browse and manage registered tools, models, databases, and schemas                  |
 
 ## How It Works
 
-Studio connects to your running AgentOS instance and uses a Registry to populate available components. 
+Studio connects to your running AgentOS instance and uses a Registry to populate available components.
 Build visually, test interactively, and publish when ready.
 
 1. Register your components in a `Registry`
@@ -64,14 +64,15 @@ Once saved, test your draft in the AgentOS Control Plane:
 - **Debug Mode**: Enable verbose logging to troubleshoot issues
 
 <Warning>
-  Before publishing, test and make sure your agent handles edge cases and unexpected inputs gracefully.
+  Before publishing, test and make sure your agent handles edge cases and
+  unexpected inputs gracefully.
 </Warning>
 
 ### 4. Publish
 
 Move from draft to production with one click. Publish the visual blueprint of your agentic system after verification.
-Manage multiple versions of your system blueprint. Every published version is immediately 
-accessible via a unique API endpoint. Set any version as *Current* to make it the default for your production API.
+Manage multiple versions of your system blueprint. Every published version is immediately
+accessible via a unique API endpoint. Set any version as _Current_ to make it the default for your production API.
 
 ### 5. Manage Versions
 
@@ -82,14 +83,15 @@ Access the full version history for any agent, team, or workflow:
 - **Delete**: Remove old versions you no longer need
 
 <Tip>
-Use descriptive version labels like `v1.2-improved-instructions` or `before-refactor` to make it easy to identify versions later.
+  Use descriptive version labels like `v1.2-improved-instructions` or
+  `before-refactor` to make it easy to identify versions later.
 </Tip>
 
 ## Next Steps
 
-| Task | Guide |
-|------|-------|
-| Build an agent | [Studio Agents](/agent-os/studio/agents) |
-| Create a workflow | [Studio Workflows](/agent-os/studio/workflows) |
-| Compose a team | [Studio Teams](/agent-os/studio/teams) |
-| Set up the registry | [Studio Registry](/concept/registry) |
+| Task                | Guide                                          |
+| ------------------- | ---------------------------------------------- |
+| Build an agent      | [Studio Agents](/agent-os/studio/agents)       |
+| Create a workflow   | [Studio Workflows](/agent-os/studio/workflows) |
+| Compose a team      | [Studio Teams](/agent-os/studio/teams)         |
+| Set up the registry | [Studio Registry](/agent-os/studio/registry)   |

--- a/agent-os/studio/introduction.mdx
+++ b/agent-os/studio/introduction.mdx
@@ -63,15 +63,15 @@ Once saved, test your draft in the AgentOS Control Plane:
 - **View Traces**: Inspect tool calls, model responses, and reasoning for each run
 - **Debug Mode**: Enable verbose logging to troubleshoot issues
 
-<Tip>
-Test with edge cases and unexpected inputs to ensure your agent handles them gracefully before publishing.
-</Tip>
+<Warning>
+  Before publishing, test and make sure your agent handles edge cases and unexpected inputs gracefully.
+</Warning>
 
 ### 4. Publish
 
-When you're confident in your draft, publish it to make it live. Published versions are accessible via the API and can be set as the current version.
-
-You can have multiple draft and published versions. Iterate with drafts, then publish when ready for production.
+Move from draft to production with one click. Publish the visual blueprint of your agentic system after verification.
+Manage multiple versions of your system blueprint. Every published version is immediately 
+accessible via a unique API endpoint. Set any version as *Current* to make it the default for your production API.
 
 ### 5. Manage Versions
 

--- a/agent-os/studio/introduction.mdx
+++ b/agent-os/studio/introduction.mdx
@@ -1,0 +1,130 @@
+---
+title: "Studio"
+sidebarTitle: "Studio"
+description: "Visual editor for building Agents, Teams, and Workflows in AgentOS."
+---
+
+**AgentOS Studio is a visual editor for building Agents, Teams, and Workflows**
+
+## Concepts
+
+| Concept | Description |
+|-----------|-------------|
+| [Agents](/agent-os/studio/agents) | Build and configure agents with models, tools, and instructions |
+| [Teams](/agent-os/studio/teams) | Compose multi-agent teams with coordination modes |
+| [Workflows](/agent-os/studio/workflows) | Design step-based workflows with conditions, loops, routers, and parallel execution |
+| [Registry](/agent-os/studio/registry) | Browse and manage registered tools, models, databases, and schemas |
+
+## How It Works
+
+Studio connects to your running AgentOS instance and uses the Registry to populate available components. Build visually, test interactively, and publish when ready.
+
+1. Register your components (tools, models, databases) in a `Registry`
+2. Pass the registry to `AgentOS`
+3. Open Studio in the control plane to start building
+
+```python
+from agno.os import AgentOS
+from agno.registry import Registry
+from agno.models.openai import OpenAIChat
+from agno.tools.websearch import WebSearchTools
+
+registry = Registry(
+    name="My Registry",
+    tools=[WebSearchTools()],
+    models=[OpenAIChat(id="gpt-5-mini")],
+)
+
+agent_os = AgentOS(
+    id="my-app",
+    registry=registry,
+)
+
+app = agent_os.get_app()
+```
+
+## Development Lifecycle
+
+Studio provides a complete development lifecycle for your agents, teams, and workflows:
+
+### 1. Build
+
+Create your agent, team, or workflow using the visual builder. Drag components from the Registry, configure properties, and wire everything together. Every change you make is auto-saved as a **draft**.
+
+### 2. Save Versions
+
+When you're ready to checkpoint your work, **save a version**:
+
+- Click **Save Version** in the toolbar
+- Add a version label (e.g., `v1.0`, `beta`, `experiment-rag`)
+- Optionally add notes describing the changes
+
+Versions are immutable snapshots of your configuration. You can create as many versions as you need during development.
+
+<Tip>
+Use descriptive version labels like `v1.2-improved-instructions` or `before-refactor` to make it easy to identify versions later.
+</Tip>
+
+### 3. Update Versions
+
+Continue iterating on your draft after saving a version:
+
+- Make changes to your agent, team, or workflow
+- Test the changes (see below)
+- Save a new version when ready
+
+You can also **restore** any previous version to continue working from that point. This makes it safe to experiment—you can always roll back.
+
+| Action | Description |
+|--------|-------------|
+| **Save Version** | Create a new immutable snapshot |
+| **Restore Version** | Load a previous version into the editor as a new draft |
+| **Compare Versions** | View diff between two versions |
+| **Delete Version** | Remove an old version (published versions cannot be deleted) |
+
+### 4. Test
+
+Before publishing, test your work directly in Studio:
+
+- **Chat Page**: Interact with your agent or team in real-time
+- **Run Workflow**: Execute workflows with sample inputs and watch step-by-step execution
+- **View Traces**: Inspect tool calls, model responses, and reasoning for each run
+- **Debug Mode**: Enable verbose logging to troubleshoot issues
+
+<Tip>
+Test with edge cases and unexpected inputs to ensure your agent handles them gracefully before publishing.
+</Tip>
+
+### 5. Publish
+
+Once you're confident in your version, **publish** it to make it available for production use:
+
+- Select the version you want to publish
+- Click **Publish**
+- Confirm the publish action
+
+Published versions become available via the AgentOS API and can be used by other applications. Only one version can be published at a time per agent, team, or workflow.
+
+| Status | Description |
+|--------|-------------|
+| **Draft** | Work in progress, auto-saved, not accessible via API |
+| **Saved Version** | Immutable snapshot, can be restored or published |
+| **Published** | Live version accessible via API and other applications |
+
+### Version History
+
+Access the full version history for any agent, team, or workflow:
+
+- View all saved versions with timestamps and labels
+- See which version is currently published
+- Restore, compare, or delete versions
+- Track who made changes and when (with team accounts)
+
+## Next Steps
+
+| Task | Guide |
+|------|-------|
+| Build an agent | [Studio Agents](/agent-os/studio/agents) |
+| Create a workflow | [Studio Workflows](/agent-os/studio/workflows) |
+| Compose a team | [Studio Teams](/agent-os/studio/teams) |
+| Set up the registry | [Studio Registry](/agent-os/studio/registry) |

--- a/agent-os/studio/introduction.mdx
+++ b/agent-os/studio/introduction.mdx
@@ -49,45 +49,17 @@ Studio provides a complete development lifecycle for your agents, teams, and wor
 
 ### 1. Build
 
-Create your agent, team, or workflow using the visual builder. Drag components from the Registry, configure properties, and wire everything together. Every change you make is auto-saved as a **draft**.
+Create your agent, team, or workflow using the visual builder. Drag components from the Registry, configure properties, and wire everything together.
 
-### 2. Save Versions
+### 2. Save Draft
 
-When you're ready to checkpoint your work, **save a version**:
+Save your work as a draft version. Drafts are not accessible via the API but can be tested, restored, and published later. You can save multiple draft versions to checkpoint your progress.
 
-- Click **Save Version** in the toolbar
-- Add a version label (e.g., `v1.0`, `beta`, `experiment-rag`)
-- Optionally add notes describing the changes
+### 3. Test
 
-Versions are immutable snapshots of your configuration. You can create as many versions as you need during development.
+Once saved, test your draft in the AgentOS Control Plane:
 
-<Tip>
-Use descriptive version labels like `v1.2-improved-instructions` or `before-refactor` to make it easy to identify versions later.
-</Tip>
-
-### 3. Update Versions
-
-Continue iterating on your draft after saving a version:
-
-- Make changes to your agent, team, or workflow
-- Test the changes (see below)
-- Save a new version when ready
-
-You can also **restore** any previous version to continue working from that point. This makes it safe to experiment—you can always roll back.
-
-| Action | Description |
-|--------|-------------|
-| **Save Version** | Create a new immutable snapshot |
-| **Restore Version** | Load a previous version into the editor as a new draft |
-| **Compare Versions** | View diff between two versions |
-| **Delete Version** | Remove an old version (published versions cannot be deleted) |
-
-### 4. Test
-
-Before publishing, test your work directly in Studio:
-
-- **Chat Page**: Interact with your agent or team in real-time
-- **Run Workflow**: Execute workflows with sample inputs and watch step-by-step execution
+- **Chat Page**: Interact with your agent, team, or workflow in real-time
 - **View Traces**: Inspect tool calls, model responses, and reasoning for each run
 - **Debug Mode**: Enable verbose logging to troubleshoot issues
 
@@ -95,30 +67,23 @@ Before publishing, test your work directly in Studio:
 Test with edge cases and unexpected inputs to ensure your agent handles them gracefully before publishing.
 </Tip>
 
-### 5. Publish
+### 4. Publish
 
-Once you're confident in your version, **publish** it to make it available for production use:
+When you're confident in your draft, publish it to make it live. Published versions are accessible via the API and can be set as the current version.
 
-- Select the version you want to publish
-- Click **Publish**
-- Confirm the publish action
+You can have multiple draft and published versions. Iterate with drafts, then publish when ready for production.
 
-Published versions become available via the AgentOS API and can be used by other applications. Only one version can be published at a time per agent, team, or workflow.
-
-| Status | Description |
-|--------|-------------|
-| **Draft** | Work in progress, auto-saved, not accessible via API |
-| **Saved Version** | Immutable snapshot, can be restored or published |
-| **Published** | Live version accessible via API and other applications |
-
-### Version History
+### 5. Manage Versions
 
 Access the full version history for any agent, team, or workflow:
 
-- View all saved versions with timestamps and labels
-- See which version is currently published
-- Restore, compare, or delete versions
-- Track who made changes and when (with team accounts)
+- **Restore**: Load any previous version into the editor
+- **Set Current**: Choose which published version is used by default when running via the API
+- **Delete**: Remove old versions you no longer need
+
+<Tip>
+Use descriptive version labels like `v1.2-improved-instructions` or `before-refactor` to make it easy to identify versions later.
+</Tip>
 
 ## Next Steps
 

--- a/agent-os/studio/introduction.mdx
+++ b/agent-os/studio/introduction.mdx
@@ -1,10 +1,9 @@
 ---
-title: "Studio"
-sidebarTitle: "Studio"
-description: "Visual editor for building Agents, Teams, and Workflows in AgentOS."
+title: "Overview"
+description: "A visual editor in AgentOS to build Agents, Teams, and Workflows."
 ---
 
-**AgentOS Studio is a visual editor for building Agents, Teams, and Workflows**
+Drag, drop, and orchestrate Agents, Teams, and Workflows on a live canvas to deploy production-ready agentic systems with AgentOS Studio.
 
 ## Concepts
 
@@ -17,9 +16,10 @@ description: "Visual editor for building Agents, Teams, and Workflows in AgentOS
 
 ## How It Works
 
-Studio connects to your running AgentOS instance and uses the Registry to populate available components. Build visually, test interactively, and publish when ready.
+Studio connects to your running AgentOS instance and uses a Registry to populate available components. 
+Build visually, test interactively, and publish when ready.
 
-1. Register your components (tools, models, databases) in a `Registry`
+1. Register your components in a `Registry`
 2. Pass the registry to `AgentOS`
 3. Open Studio in the control plane to start building
 
@@ -45,7 +45,7 @@ app = agent_os.get_app()
 
 ## Development Lifecycle
 
-Studio provides a complete development lifecycle for your agents, teams, and workflows:
+Studio manages the full development lifecycle from building to deploying complex agentic systems with AgentOS components.
 
 ### 1. Build
 
@@ -92,4 +92,4 @@ Use descriptive version labels like `v1.2-improved-instructions` or `before-refa
 | Build an agent | [Studio Agents](/agent-os/studio/agents) |
 | Create a workflow | [Studio Workflows](/agent-os/studio/workflows) |
 | Compose a team | [Studio Teams](/agent-os/studio/teams) |
-| Set up the registry | [Studio Registry](/agent-os/studio/registry) |
+| Set up the registry | [Studio Registry](/concept/registry) |

--- a/agent-os/studio/registry.mdx
+++ b/agent-os/studio/registry.mdx
@@ -1,0 +1,84 @@
+---
+title: "Registry"
+sidebarTitle: "Registry"
+description: "Register tools, models, databases, and schemas for use in AgentOS Studio."
+---
+
+**The Registry manages non-serializable components (tools, models, databases, schemas, functions) that Studio depends on.**
+
+```python
+from agno.db.postgres import PostgresDb
+from agno.models.openai import OpenAIChat
+from agno.models.anthropic import Claude
+from agno.os import AgentOS
+from agno.registry import Registry
+from agno.tools.calculator import CalculatorTools
+from agno.tools.websearch import WebSearchTools
+from agno.vectordb.pgvector import PgVector
+from pydantic import BaseModel
+
+class InputSchema(BaseModel):
+    input: str
+    description: str
+
+def custom_evaluator(input: str) -> bool:
+    return "urgent" in input.lower()
+
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai", id="postgres_db")
+
+registry = Registry(
+    name="My Registry",
+    tools=[CalculatorTools(), WebSearchTools()],
+    models=[OpenAIChat(id="gpt-5-mini"), Claude(id="claude-sonnet-4-5")],
+    dbs=[db],
+    vector_dbs=[PgVector(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai", table_name="embeddings")],
+    schemas=[InputSchema],
+    functions=[custom_evaluator],
+)
+
+agent_os = AgentOS(id="my-app", registry=registry, db=db)
+app = agent_os.get_app()
+```
+
+## Component Types
+
+| Type | Field | Description |
+|------|-------|-------------|
+| Tools | `tools` | `Toolkit` instances, `Function` objects, or plain callables |
+| Models | `models` | Model provider instances (OpenAI, Anthropic, etc.) |
+| Databases | `dbs` | `BaseDb` instances for storage |
+| Vector DBs | `vector_dbs` | `VectorDb` instances for knowledge bases |
+| Schemas | `schemas` | Pydantic `BaseModel` subclasses for structured I/O |
+| Functions | `functions` | Python callables used as workflow evaluators, selectors, or executors |
+
+## Registry API
+
+The registry exposes a `GET /registry` endpoint through AgentOS with filtering and pagination.
+
+### Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `component_type` | `string` | `None` | Filter by type: `TOOL`, `MODEL`, `DB`, `VECTOR_DB`, `SCHEMA`, `FUNCTION` |
+| `name` | `string` | `None` | Partial name match (case-insensitive) |
+| `page` | `int` | `1` | Page number |
+| `limit` | `int` | `20` | Items per page (1-100) |
+
+### Response Metadata
+
+Each component in the response includes type-specific metadata:
+
+| Component Type | Metadata Fields |
+|---------------|-----------------|
+| Tool | `class_path`, `parameters`, `signature`, toolkit `functions` |
+| Model | `provider`, `model_id` |
+| Database | `db_id` |
+| Vector DB | `collection`, `table_name` |
+| Schema | JSON schema definition |
+| Function | `signature`, `parameters` |
+
+## Developer Resources
+
+- [Registry reference](/reference/agent-os/agent-os)
+- [Studio overview](/agent-os/studio/introduction)
+- [Workflow serialization](/agent-os/studio/workflows)

--- a/agent-os/studio/teams.mdx
+++ b/agent-os/studio/teams.mdx
@@ -1,0 +1,77 @@
+---
+title: "Teams"
+sidebarTitle: "Teams"
+description: "Compose multi-agent teams visually in AgentOS Studio."
+---
+
+Studio provides a **visual Team Builder** for composing multi-agent teams with coordination modes. Drag agents onto the canvas, configure coordination, and run teams—no code required.
+
+## Creating Teams
+
+Create a new team by dragging agents from your [Registry](/agent-os/studio/registry) and configuring the team settings:
+
+| Setting | Description |
+|---------|-------------|
+| **Members** | Drag and drop agents to include in the team |
+| **Mode** | Coordination mode: `coordinate`, `route`, or `collaborate` |
+| **Instructions** | Team-level instructions for the leader agent |
+| **Success Criteria** | Define when the team's task is complete |
+
+<Tip>
+Agents can be created directly in Studio or registered via code—both are available for team composition.
+</Tip>
+
+## Using Teams
+
+Teams built in Studio can be used in multiple ways:
+
+- **Chat directly** with the team via the Chat page
+- **Use in Workflows** as step executors for complex automation
+
+## Save and Run
+
+Once your team is configured:
+
+1. **Save** your team to persist it to the registry
+2. Navigate to the **Chat page** to interact with your team
+3. Send tasks and watch agents collaborate in real-time
+4. View individual agent contributions and coordination flow
+
+## Code Equivalent
+
+A team built in Studio maps to the SDK's `Team` class:
+
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.team import Team
+from agno.tools.hackernews import HackerNewsTools
+from agno.tools.websearch import WebSearchTools
+
+researcher = Agent(
+    name="Researcher",
+    model=OpenAIChat(id="gpt-5-mini"),
+    tools=[WebSearchTools()],
+    instructions="Research topics thoroughly.",
+)
+
+hn_analyst = Agent(
+    name="HN Analyst",
+    model=OpenAIChat(id="gpt-5-mini"),
+    tools=[HackerNewsTools()],
+    instructions="Find relevant HackerNews discussions.",
+)
+
+team = Team(
+    name="Research Team",
+    mode="coordinate",
+    members=[researcher, hn_analyst],
+    instructions="Coordinate research across web and HackerNews.",
+)
+```
+
+## Developer Resources
+
+- [Team reference](/reference/teams/team)
+- [Building teams](/teams/building-teams)
+- [Studio Agents](/agent-os/studio/agents)

--- a/agent-os/studio/teams.mdx
+++ b/agent-os/studio/teams.mdx
@@ -39,7 +39,7 @@ Once your team is configured:
 
 ## Code Equivalent
 
-A team built in Studio maps to the SDK's `Team` class:
+A team instance created in Studio directly maps to the SDK `Team` class:
 
 ```python
 from agno.agent import Agent

--- a/agent-os/studio/teams.mdx
+++ b/agent-os/studio/teams.mdx
@@ -4,7 +4,8 @@ sidebarTitle: "Teams"
 description: "Compose multi-agent teams visually in AgentOS Studio."
 ---
 
-Studio provides a **visual Team Builder** for composing multi-agent teams with coordination modes. Drag agents onto the canvas, configure coordination, and run teams—no code required.
+Studio provides a **visual Team Builder** for composing multi-agent teams with coordination modes. 
+No code required. Drag agents onto the canvas, configure coordination, and run teams.
 
 ## Creating Teams
 

--- a/agent-os/studio/workflows.mdx
+++ b/agent-os/studio/workflows.mdx
@@ -1,6 +1,5 @@
 ---
-title: "Workflows"
-sidebarTitle: "Workflows"
+title: "Overview"
 description: "Design step-based workflows visually in AgentOS Studio."
 ---
 

--- a/agent-os/studio/workflows.mdx
+++ b/agent-os/studio/workflows.mdx
@@ -1,0 +1,80 @@
+---
+title: "Workflows"
+sidebarTitle: "Workflows"
+description: "Design step-based workflows visually in AgentOS Studio."
+---
+
+Studio provides a **drag-and-drop Workflow Builder** for designing multi-step workflows visually. Create complex automation pipelines without writing code by dragging components onto the canvas and connecting them together.
+
+## Creating Steps
+
+Drag a step onto the canvas and configure its executor type in the properties panel. Each step can use one of the following executors:
+
+| Executor Type | Description |
+|---------------|-------------|
+| **Agent** | Execute the step using a registered agent from your OS |
+| **Team** | Delegate the step to a multi-agent team for collaborative execution |
+| **Custom Executor** | Use a custom function or script for specialized logic |
+
+## Step Types
+
+Beyond basic steps, you can build complex workflows using these step types:
+
+| Step Type | Description |
+|-----------|-------------|
+| `Step` | Single agent, team, or custom executor execution |
+| `Steps` | Group of steps executed sequentially |
+| `Condition` | Branch based on an evaluator function or CEL expression |
+| `Loop` | Repeat steps until an end condition is met |
+| `Router` | Select a step based on a selector function or CEL expression |
+| `Parallel` | Execute multiple steps concurrently |
+
+These step types can be nested and composed together to build sophisticated automation pipelines while maintaining visual clarity.
+
+### Configuring Complex Steps
+
+Step types like `Condition`, `Router`, and `Loop` require logic to control their behavior—either a Python function or a CEL expression. For example, you can use a CEL expression to evaluate if the input contains the word "apple":
+
+```python
+from agno.workflow import Condition, Step, Workflow
+
+condition = Condition(
+    name="apple_condition",
+    evaluator="input.contains('apple')",
+)
+```
+
+Alternatively, you can use a function to evaluate the condition.
+```python
+from agno.workflow import Condition, Step, Workflow
+
+def is_apple(step_input) -> bool:
+    return "apple" in step_input.input
+
+condition = Condition(
+    name="apple_condition",
+    evaluator=is_apple,
+)
+```
+
+## CEL Expressions
+
+Workflow steps support [CEL (Common Expression Language)](https://github.com/google/cel-spec) as an alternative to Python functions for evaluators, end conditions, and selectors. CEL expressions are strings that can be serialized and edited directly in Studio without code.
+
+See [CEL Expressions](/agent-os/studio/cel-expressions) for full usage, context variables, and examples.
+
+## Save and Run
+
+Once your workflow is designed:
+
+1. **Save** your workflow to persist it to the registry
+2. Navigate to the **Chat page** to run your workflow interactively
+3. Provide input and watch the workflow execute step-by-step
+4. View results and logs for each step in real-time
+
+## Developer Resources
+
+- [Workflow reference](/reference/workflows/workflow)
+- [Building workflows](/workflows/building-workflows)
+- [Workflow patterns](/workflows/workflow-patterns/overview)
+- [Studio Registry](/agent-os/studio/registry)

--- a/agno-docs-style/styles/config/vocabularies/AgnoStyle/accept.txt
+++ b/agno-docs-style/styles/config/vocabularies/AgnoStyle/accept.txt
@@ -444,6 +444,7 @@ search_query
 search_session_history
 searchscraper
 Searxng
+serializable
 Serpapi
 serverless
 Serverless
@@ -474,6 +475,7 @@ step_name
 step_started
 steps_execution_completed
 steps_execution_started
+storable
 store_events
 store_member_responses
 stream_events

--- a/docs.json
+++ b/docs.json
@@ -3548,6 +3548,29 @@
                 ]
               },
               {
+                "group": "Components",
+                "pages": [
+                  "reference-api/schema/components/list-components",
+                  "reference-api/schema/components/create-component",
+                  "reference-api/schema/components/get-component",
+                  "reference-api/schema/components/update-component",
+                  "reference-api/schema/components/delete-component",
+                  "reference-api/schema/components/list-configs",
+                  "reference-api/schema/components/create-config",
+                  "reference-api/schema/components/get-current-config",
+                  "reference-api/schema/components/get-config-version",
+                  "reference-api/schema/components/update-config",
+                  "reference-api/schema/components/delete-config-version",
+                  "reference-api/schema/components/set-current-config"
+                ]
+              },
+              {
+                "group": "Registry",
+                "pages": [
+                  "reference-api/schema/registry/list-registry"
+                ]
+              },
+              {
                 "group": "Metrics",
                 "pages": [
                   "reference-api/schema/metrics/get-agentos-metrics",

--- a/docs.json
+++ b/docs.json
@@ -2784,6 +2784,17 @@
                   "agent-os/knowledge/filter-knowledge"
                 ]
               },
+              {
+                "group": "Studio",
+                "pages": [
+                  "agent-os/studio/introduction",
+                  "agent-os/studio/agents",
+                  "agent-os/studio/teams",
+                  "agent-os/studio/workflows",
+                  "agent-os/studio/cel-expressions",
+                  "agent-os/studio/registry"
+                ]
+              },
               "agent-os/config",
               "agent-os/background-tasks/overview",
               "agent-os/lifespan",

--- a/docs.json
+++ b/docs.json
@@ -2790,8 +2790,13 @@
                   "agent-os/studio/introduction",
                   "agent-os/studio/agents",
                   "agent-os/studio/teams",
-                  "agent-os/studio/workflows",
-                  "agent-os/studio/cel-expressions",
+                  {
+                    "group": "Workflows",
+                    "pages": [
+                      "agent-os/studio/workflows",
+                      "agent-os/studio/cel-expressions"
+                    ]
+                  },
                   "agent-os/studio/registry"
                 ]
               },

--- a/reference-api/schema/components/create-component.mdx
+++ b/reference-api/schema/components/create-component.mdx
@@ -1,0 +1,39 @@
+---
+title: "Create Component"
+sidebarTitle: "Create Component"
+description: "Create a new component (agent, team, or workflow)."
+api: "POST /components"
+---
+
+## Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | Yes | Display name for the component |
+| `component_id` | `string` | No | Unique ID (auto-generated from name if omitted) |
+| `component_type` | `string` | Yes | One of: `agent`, `team`, `workflow` |
+| `description` | `string` | No | Description of the component |
+| `metadata` | `dict` | No | Additional metadata |
+| `config` | `dict` | No | Initial configuration |
+| `label` | `string` | No | Version label |
+| `stage` | `string` | No | Version stage (default: `draft`) |
+| `notes` | `string` | No | Version notes |
+| `set_current` | `bool` | No | Set this version as current |
+
+```json
+{
+  "name": "Research Agent",
+  "component_type": "agent",
+  "description": "An agent that researches topics",
+  "config": {
+    "model": "gpt-5-mini",
+    "tools": ["WebSearchTools"],
+    "instructions": "Research topics thoroughly."
+  },
+  "stage": "draft"
+}
+```
+
+## Response `201`
+
+Returns a `ComponentResponse` with the created component.

--- a/reference-api/schema/components/create-config.mdx
+++ b/reference-api/schema/components/create-config.mdx
@@ -1,0 +1,28 @@
+---
+title: "Create Config Version"
+sidebarTitle: "Create Config Version"
+description: "Create a new config version for a component."
+api: "POST /components/{component_id}/configs"
+---
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component_id` | `string` | The component ID |
+
+## Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `config` | `dict` | Yes | The configuration data |
+| `version` | `int` | No | Version number (auto-incremented if omitted) |
+| `label` | `string` | No | Version label (e.g., `v1.0`, `beta`) |
+| `stage` | `string` | No | Version stage (default: `draft`) |
+| `notes` | `string` | No | Version notes |
+| `links` | `list` | No | Links to child components |
+| `set_current` | `bool` | No | Set this version as current |
+
+## Response `201`
+
+Returns a `ComponentConfigResponse` with the created config version.

--- a/reference-api/schema/components/delete-component.mdx
+++ b/reference-api/schema/components/delete-component.mdx
@@ -1,0 +1,16 @@
+---
+title: "Delete Component"
+sidebarTitle: "Delete Component"
+description: "Delete a component and all its config versions."
+api: "DELETE /components/{component_id}"
+---
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component_id` | `string` | The component ID |
+
+## Response `204`
+
+No content. The component and all its config versions are deleted.

--- a/reference-api/schema/components/delete-config-version.mdx
+++ b/reference-api/schema/components/delete-config-version.mdx
@@ -1,0 +1,17 @@
+---
+title: "Delete Config Version"
+sidebarTitle: "Delete Config Version"
+description: "Delete a specific config version."
+api: "DELETE /components/{component_id}/configs/{version}"
+---
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component_id` | `string` | The component ID |
+| `version` | `int` | The version number |
+
+## Response `204`
+
+No content. The config version is deleted.

--- a/reference-api/schema/components/get-component.mdx
+++ b/reference-api/schema/components/get-component.mdx
@@ -1,0 +1,29 @@
+---
+title: "Get Component"
+sidebarTitle: "Get Component"
+description: "Get details of a specific component by ID."
+api: "GET /components/{component_id}"
+---
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component_id` | `string` | The component ID |
+
+## Response `200`
+
+Returns a `ComponentResponse`.
+
+```json
+{
+  "component_id": "my-research-agent",
+  "component_type": "agent",
+  "name": "Research Agent",
+  "description": "An agent that researches topics",
+  "current_version": 3,
+  "metadata": {},
+  "created_at": "2025-01-15T10:30:00Z",
+  "updated_at": "2025-01-16T14:20:00Z"
+}
+```

--- a/reference-api/schema/components/get-config-version.mdx
+++ b/reference-api/schema/components/get-config-version.mdx
@@ -1,0 +1,17 @@
+---
+title: "Get Config Version"
+sidebarTitle: "Get Config Version"
+description: "Get a specific config version for a component."
+api: "GET /components/{component_id}/configs/{version}"
+---
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component_id` | `string` | The component ID |
+| `version` | `int` | The version number |
+
+## Response `200`
+
+Returns the `ComponentConfigResponse` for the specified version.

--- a/reference-api/schema/components/get-current-config.mdx
+++ b/reference-api/schema/components/get-current-config.mdx
@@ -1,0 +1,33 @@
+---
+title: "Get Current Config"
+sidebarTitle: "Get Current Config"
+description: "Get the current (active) config version for a component."
+api: "GET /components/{component_id}/configs/current"
+---
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component_id` | `string` | The component ID |
+
+## Response `200`
+
+Returns the `ComponentConfigResponse` for the current active version.
+
+```json
+{
+  "component_id": "my-research-agent",
+  "version": 3,
+  "label": "v1.2",
+  "stage": "published",
+  "config": {
+    "model": "gpt-5-mini",
+    "tools": ["WebSearchTools"],
+    "instructions": "Research topics thoroughly using web search."
+  },
+  "notes": "Improved instructions",
+  "created_at": "2025-01-16T14:20:00Z",
+  "updated_at": "2025-01-16T14:20:00Z"
+}
+```

--- a/reference-api/schema/components/list-components.mdx
+++ b/reference-api/schema/components/list-components.mdx
@@ -1,0 +1,42 @@
+---
+title: "List Components"
+sidebarTitle: "List Components"
+description: "List all components with optional filtering and pagination."
+api: "GET /components"
+---
+
+## Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `component_type` | `string` | `None` | Filter by type: `agent`, `team`, `workflow` |
+| `page` | `int` | `1` | Page number (≥ 1) |
+| `limit` | `int` | `20` | Items per page (1-100) |
+
+## Response `200`
+
+Returns a `PaginatedResponse[ComponentResponse]`.
+
+```json
+{
+  "data": [
+    {
+      "component_id": "my-research-agent",
+      "component_type": "agent",
+      "name": "Research Agent",
+      "description": "An agent that researches topics",
+      "current_version": 3,
+      "metadata": {},
+      "created_at": "2025-01-15T10:30:00Z",
+      "updated_at": "2025-01-16T14:20:00Z"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 20,
+    "total_pages": 1,
+    "total_count": 1,
+    "search_time_ms": 5
+  }
+}
+```

--- a/reference-api/schema/components/list-configs.mdx
+++ b/reference-api/schema/components/list-configs.mdx
@@ -1,0 +1,47 @@
+---
+title: "List Config Versions"
+sidebarTitle: "List Config Versions"
+description: "List all config versions for a component."
+api: "GET /components/{component_id}/configs"
+---
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component_id` | `string` | The component ID |
+
+## Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `include_config` | `bool` | `true` | Include the full config dict in the response |
+
+## Response `200`
+
+Returns a `List[ComponentConfigResponse]`.
+
+```json
+[
+  {
+    "component_id": "my-research-agent",
+    "version": 1,
+    "label": "v1.0",
+    "stage": "published",
+    "config": { ... },
+    "notes": "Initial version",
+    "created_at": "2025-01-15T10:30:00Z",
+    "updated_at": "2025-01-15T10:30:00Z"
+  },
+  {
+    "component_id": "my-research-agent",
+    "version": 2,
+    "label": "v1.1-improved-instructions",
+    "stage": "draft",
+    "config": { ... },
+    "notes": "Updated instructions",
+    "created_at": "2025-01-16T14:20:00Z",
+    "updated_at": "2025-01-16T14:20:00Z"
+  }
+]
+```

--- a/reference-api/schema/components/set-current-config.mdx
+++ b/reference-api/schema/components/set-current-config.mdx
@@ -1,0 +1,17 @@
+---
+title: "Set Current Config"
+sidebarTitle: "Set Current Config"
+description: "Set a specific config version as the current active version."
+api: "POST /components/{component_id}/configs/{version}/set-current"
+---
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component_id` | `string` | The component ID |
+| `version` | `int` | The version number to set as current |
+
+## Response `200`
+
+Returns the updated `ComponentResponse` with the new `current_version`.

--- a/reference-api/schema/components/update-component.mdx
+++ b/reference-api/schema/components/update-component.mdx
@@ -1,0 +1,28 @@
+---
+title: "Update Component"
+sidebarTitle: "Update Component"
+description: "Update a component's metadata."
+api: "PATCH /components/{component_id}"
+---
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component_id` | `string` | The component ID |
+
+## Request Body
+
+All fields are optional.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Updated display name |
+| `description` | `string` | Updated description |
+| `component_type` | `string` | Updated type |
+| `metadata` | `dict` | Updated metadata |
+| `current_version` | `int` | Set the current version number |
+
+## Response `200`
+
+Returns the updated `ComponentResponse`.

--- a/reference-api/schema/components/update-config.mdx
+++ b/reference-api/schema/components/update-config.mdx
@@ -1,0 +1,29 @@
+---
+title: "Update Config Version"
+sidebarTitle: "Update Config Version"
+description: "Update a specific config version."
+api: "PATCH /components/{component_id}/configs/{version}"
+---
+
+## Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component_id` | `string` | The component ID |
+| `version` | `int` | The version number |
+
+## Request Body
+
+All fields are optional.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `config` | `dict` | Updated configuration data |
+| `label` | `string` | Updated version label |
+| `stage` | `string` | Updated stage (`draft`, `published`) |
+| `notes` | `string` | Updated notes |
+| `links` | `list` | Updated child component links |
+
+## Response `200`
+
+Returns the updated `ComponentConfigResponse`.

--- a/reference-api/schema/registry/list-registry.mdx
+++ b/reference-api/schema/registry/list-registry.mdx
@@ -1,0 +1,73 @@
+---
+title: "List Registry"
+sidebarTitle: "List Registry"
+description: "List all registered components (tools, models, databases, schemas, functions) with filtering and pagination."
+api: "GET /registry"
+---
+
+## Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `component_type` | `string` | `None` | Filter by type: `TOOL`, `MODEL`, `DB`, `VECTOR_DB`, `SCHEMA`, `FUNCTION` |
+| `name` | `string` | `None` | Partial name match (case-insensitive) |
+| `page` | `int` | `1` | Page number (≥ 1) |
+| `limit` | `int` | `20` | Items per page (1-100) |
+
+## Response `200`
+
+Returns a `PaginatedResponse[RegistryContentResponse]`.
+
+Each item includes type-specific metadata:
+
+| Component Type | Metadata Fields |
+|---------------|-----------------|
+| `TOOL` | `class_path`, `parameters`, `signature`, toolkit `functions` |
+| `MODEL` | `class_path`, `provider`, `model_id` |
+| `DB` | `class_path`, `db_id` |
+| `VECTOR_DB` | `class_path`, `collection`, `table_name` |
+| `SCHEMA` | `json_schema` |
+| `FUNCTION` | `name`, `signature`, `parameters` |
+
+```json
+{
+  "data": [
+    {
+      "name": "WebSearchTools",
+      "type": "TOOL",
+      "description": "Tools for searching the web",
+      "metadata": {
+        "class_path": "agno.tools.websearch.WebSearchTools",
+        "has_entrypoint": true,
+        "parameters": {},
+        "functions": [
+          {
+            "name": "web_search",
+            "description": "Search the web for a query",
+            "parameters": {
+              "query": {"type": "string"}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OpenAIChat",
+      "type": "MODEL",
+      "description": null,
+      "metadata": {
+        "class_path": "agno.models.openai.OpenAIChat",
+        "provider": "OpenAI",
+        "model_id": "gpt-5-mini"
+      }
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 20,
+    "total_pages": 1,
+    "total_count": 2,
+    "search_time_ms": 3
+  }
+}
+```

--- a/reference-api/schema/registry/list-registry.mdx
+++ b/reference-api/schema/registry/list-registry.mdx
@@ -9,7 +9,7 @@ api: "GET /registry"
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `component_type` | `string` | `None` | Filter by type: `TOOL`, `MODEL`, `DB`, `VECTOR_DB`, `SCHEMA`, `FUNCTION` |
+| `component_type` | `string` | `None` | Filter by registry item type: `tool`, `model`, `db`, `vector_db`, `schema`, `function` |
 | `name` | `string` | `None` | Partial name match (case-insensitive) |
 | `page` | `int` | `1` | Page number (≥ 1) |
 | `limit` | `int` | `20` | Items per page (1-100) |
@@ -22,19 +22,19 @@ Each item includes type-specific metadata:
 
 | Component Type | Metadata Fields |
 |---------------|-----------------|
-| `TOOL` | `class_path`, `parameters`, `signature`, toolkit `functions` |
-| `MODEL` | `class_path`, `provider`, `model_id` |
-| `DB` | `class_path`, `db_id` |
-| `VECTOR_DB` | `class_path`, `collection`, `table_name` |
-| `SCHEMA` | `json_schema` |
-| `FUNCTION` | `name`, `signature`, `parameters` |
+| `tool` | `class_path`, `parameters`, `signature`, toolkit `functions` |
+| `model` | `class_path`, `provider`, `model_id` |
+| `db` | `class_path`, `db_id` |
+| `vector_db` | `class_path`, `collection`, `table_name` |
+| `schema` | `json_schema` |
+| `function` | `name`, `signature`, `parameters` |
 
 ```json
 {
   "data": [
     {
       "name": "WebSearchTools",
-      "type": "TOOL",
+      "type": "tool",
       "description": "Tools for searching the web",
       "metadata": {
         "class_path": "agno.tools.websearch.WebSearchTools",
@@ -53,7 +53,7 @@ Each item includes type-specific metadata:
     },
     {
       "name": "OpenAIChat",
-      "type": "MODEL",
+      "type": "model",
       "description": null,
       "metadata": {
         "class_path": "agno.models.openai.OpenAIChat",


### PR DESCRIPTION
## Summary

- Add Studio section under AgentOS with pages for Agents, Teams, Workflows, Registry, and CEL Expressions
- Add Studio navigation group to docs.json

**New pages:**
- `agent-os/studio/introduction.mdx` - Studio overview and setup
- `agent-os/studio/agents.mdx` - Agent Builder configuration
- `agent-os/studio/teams.mdx` - Team Builder with coordination modes
- `agent-os/studio/workflows.mdx` - Workflow Builder with step types
- `agent-os/studio/cel-expressions.mdx` - CEL expressions for Conditions, Loops, and Routers
- `agent-os/studio/registry.mdx` - Registry setup and API

## Related Issues/PRs

- Related SDK PR: agno-agi/agno#6101 (workflow serialization, CEL expressions, registry refactor)

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified
- [x] Spelling and grammar checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)