### PR TITLE
fix: missing space in words and set model when use news agent

### DIFF
--- a/tools/overview.mdx
+++ b/tools/overview.mdx
@@ -95,7 +95,7 @@ This will be converted into the following tool definition:
 ```
 
 This tool definition is then sent to the model so that it knows how to call the tool when it is requested.
-You'll notice as well that the `Args` section is automatically stripped from the definition, parsed and used to populate the definitions of individualproperties.
+You'll notice as well that the `Args` section is automatically stripped from the definition, parsed and used to populate the definitions of individual properties.
 
 When using a Pydantic model in an argument of a tool function, Agno will automatically convert the model into the required tool definition format.
 

--- a/tools/usage/team-with-tool-hooks.mdx
+++ b/tools/usage/team-with-tool-hooks.mdx
@@ -49,6 +49,7 @@ news_agent = Agent(
     name="News Agent",
     id="news-agent",
     role="Search HackerNews for information",
+    model=OpenAIResponses(id="gpt-5.2"),
     tools=[HackerNewsTools(cache_results=True)],
     instructions=[
         "Find information about the company on HackerNews",


### PR DESCRIPTION
## Description

- Fix missing space in words 
- Set model when use news agent, if one use but another not will get confusion
<img width="582" height="461" alt="image" src="https://github.com/user-attachments/assets/7a28ad2e-0bd2-49d1-bf3d-7ca4160a42ed" />


## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
