### PR TITLE
fix: duplicate refer XAI tool-use page in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1149,7 +1149,6 @@
                                   "models/providers/native/xai/usage/tool-use",
                                   "models/providers/native/xai/usage/basic-async",
                                   "models/providers/native/xai/usage/basic-async-stream",
-                                  "models/providers/native/xai/usage/tool-use",
                                   "models/providers/native/xai/usage/tool-use-stream",
                                   "models/providers/native/xai/usage/async-tool-use",
                                   "models/providers/native/xai/usage/structured-output",


### PR DESCRIPTION
## Description

Remove duplicate page reference in docs.json

<img width="309" height="455" alt="image" src="https://github.com/user-attachments/assets/6d82ca91-153a-4af9-89a6-69fd1e4a2c1e" />


## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
