### PR TITLE
fix: exa tool demo should import ExaTools not HackerNewsTools

### DIFF
--- a/tools/toolkits/search/exa.mdx
+++ b/tools/toolkits/search/exa.mdx
@@ -22,7 +22,7 @@ The following agent will search Exa for AAPL news and print the response.
 
 ```python cookbook/14_tools/exa_tools.py
 from agno.agent import Agent
-from agno.tools.hackernews import HackerNewsTools
+from agno.tools.exa import ExaTools
 
 agent = Agent(
     tools=[ExaTools(


### PR DESCRIPTION
## Description

exa tool using demo should import ExaTools not HackerNewsTools

## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
