### PR TITLE
fix: duckduckgo demo but use HackerNewsTools toolkit

### DIFF
--- a/tools/toolkits/search/duckduckgo.mdx
+++ b/tools/toolkits/search/duckduckgo.mdx
@@ -20,9 +20,9 @@ uv pip install -U ddgs
 
 ```python
 from agno.agent import Agent
-from agno.tools.hackernews import HackerNewsTools
+from agno.tools.duckduckgo import DuckDuckGoTools
 
-agent = Agent(tools=[HackerNewsTools()])
+agent = Agent(tools=[DuckDuckGoTools()])
 agent.print_response("Whats happening in France?", markdown=True)
 ```
 


### PR DESCRIPTION
## Description

- duckduckgo demo but use HackerNewsTools toolkit

<img width="1245" height="356" alt="image" src="https://github.com/user-attachments/assets/67effcab-9477-4327-be42-ea7fda5e47ea" />


## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
