### PR TITLE
fix: refine variable naming to keep semantic constant

### DIFF
--- a/models/providers/native/perplexity/usage/structured-output.mdx
+++ b/models/providers/native/perplexity/usage/structured-output.mdx
@@ -30,7 +30,7 @@ class MovieScript(BaseModel):
     )
 
 # Agent that uses JSON mode
-json_mode_agent = Agent(
+structured_output_response = Agent(
     model=Perplexity(id="sonar-pro"),
     description="You write movie scripts.",
     output_schema=MovieScript,
@@ -38,12 +38,10 @@ json_mode_agent = Agent(
 )
 
 # Get the response in a variable
-# json_mode_response: RunOutput = json_mode_agent.run("New York")
-# pprint(json_mode_response.content)
 # structured_output_response: RunOutput = structured_output_agent.run("New York")
 # pprint(structured_output_response.content)
 
-json_mode_agent.print_response("New York")
+structured_output_response.print_response("New York")
 
 ```
 


### PR DESCRIPTION
## Description

 - refine variable naming to keep semantic constant

<img width="1255" height="432" alt="image" src="https://github.com/user-attachments/assets/90f1fa96-1f55-4049-b06c-d022843aaadd" />


## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
