### PR TITLE
fix: reasoning-o3-mini demo should use o3-mini not gpt-5-mini model

### DIFF
--- a/models/providers/native/openai/responses/usage/reasoning-o3-mini.mdx
+++ b/models/providers/native/openai/responses/usage/reasoning-o3-mini.mdx
@@ -10,7 +10,7 @@ from agno.models.openai import OpenAIResponses
 from agno.tools.hackernews import HackerNewsTools
 
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5-mini"),
+    model=OpenAIResponses(id="o3-mini"),
     tools=[HackerNewsTools()],
     markdown=True,
 )


### PR DESCRIPTION
## Description

- reasoning-o3-mini demo should use o3-mini not gpt-5-mini model
<img width="1099" height="406" alt="image" src="https://github.com/user-attachments/assets/ab3c7d0b-3c79-460a-b8b6-34fb870e989e" />


## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
