### PR TITLE
fix: few-shot demo agent print_response should not use message object as inquring param

### DIFF
--- a/context/agent/few-shot-learning.mdx
+++ b/context/agent/few-shot-learning.mdx
@@ -97,10 +97,8 @@ if __name__ == "__main__":
         markdown=True,
     )
 
-    for i, example in enumerate(support_examples, 1):
-        print(f"Example {i}: {example}")
-        print("-" * 50)
-        agent.print_response(example)
+    agent.print_response("My order hasn't arrived yet, what should I do?")
+    agent.print_response("How do I cancel my subscription?")
 ```
 
 ## Usage


### PR DESCRIPTION
## Description

few-shot demo agent print_response should not use message object as inquring param

## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
