### PR TITLE
docs: add isolate_vector_search documentation

### DIFF
--- a/_snippets/knowledge-reference.mdx
+++ b/_snippets/knowledge-reference.mdx
@@ -6,4 +6,5 @@
 | `contents_db` | `Optional[BaseDb]` | `None` | Database for storing content metadata |
 | `max_results` | `int` | `10` | Maximum number of results to return from searches |
 | `isolate_vector_search` | `bool` | `False` | When `True`, adds `linked_to` metadata during insert and filters by it during search. Enables isolation when multiple Knowledge instances share the same vector database. See [Isolate Vector Search](/knowledge/concepts/isolate-vector-search). |
+| `content_sources` | `Optional[List[BaseStorageConfig]]` | `None` | Cloud storage providers (S3, GCS, SharePoint, GitHub, Azure Blob) for loading remote content. See [Cloud Storage Sources](/knowledge/concepts/cloud-storage). |
 | `readers` | `Optional[Dict[str, Reader]]` | `None` | Dictionary of custom readers for processing content |

--- a/_snippets/knowledge-reference.mdx
+++ b/_snippets/knowledge-reference.mdx
@@ -5,4 +5,5 @@
 | `vector_db` | `Optional[VectorDb]` | `None` | Vector database for storing embeddings |
 | `contents_db` | `Optional[BaseDb]` | `None` | Database for storing content metadata |
 | `max_results` | `int` | `10` | Maximum number of results to return from searches |
+| `isolate_vector_search` | `bool` | `False` | When `True`, adds `linked_to` metadata during insert and filters by it during search. Enables isolation when multiple Knowledge instances share the same vector database. See [Isolate Vector Search](/knowledge/concepts/isolate-vector-search). |
 | `readers` | `Optional[Dict[str, Reader]]` | `None` | Dictionary of custom readers for processing content |

--- a/agent-os/knowledge/manage-knowledge.mdx
+++ b/agent-os/knowledge/manage-knowledge.mdx
@@ -100,6 +100,53 @@ The screenshots below show how you can access and manage your different Knowledg
 <img src="/images/agno_knowledge_db.png" alt="llm-app-aidev-run" />
 <img src="/images/agno_faq_db.png" alt="llm-app-aidev-run" />
 
+## Knowledge ID
+
+Each Knowledge instance registered with AgentOS gets a deterministic `knowledge_id`. This ID is generated from the combination of the instance's `name`, database ID, and table name. The same inputs always produce the same ID, so it is stable across restarts.
+
+Use `knowledge_id` in API calls to target a specific Knowledge instance:
+
+```bash
+# List content sources
+curl http://localhost:7777/v1/knowledge/{knowledge_id}/sources
+
+# Browse files in an S3 source
+curl "http://localhost:7777/v1/knowledge/{knowledge_id}/sources/{source_id}/files?prefix=reports/"
+
+# Upload content
+curl -X POST http://localhost:7777/v1/knowledge/{knowledge_id}/content \
+  -F "file=@report.pdf" \
+  -F "name=Q4 Report"
+```
+
+### Finding your Knowledge ID
+
+The `/knowledge/config` endpoint returns all registered Knowledge instances with their IDs:
+
+```bash
+curl http://localhost:7777/v1/knowledge/config | jq '.knowledge_instances'
+```
+
+```json
+[
+  {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "name": "documents_knowledge",
+    "db_id": "agno_knowledge_db",
+    "table": "agno_knowledge_contents"
+  },
+  {
+    "id": "f9e8d7c6-b5a4-3210-fedc-ba0987654321",
+    "name": "faq_knowledge",
+    "db_id": "agno_faq_db",
+    "table": "agno_faq_contents"
+  }
+]
+```
+
+### Backward compatibility
+
+If you have a single Knowledge instance, you can omit `knowledge_id` from API calls. For multiple instances, you can also use the `db_id` query parameter, but `knowledge_id` is preferred as it uniquely identifies the instance even when multiple instances share the same database.
 
 ## Best Practices
 

--- a/docs.json
+++ b/docs.json
@@ -502,7 +502,8 @@
                       "knowledge/concepts/chunking/overview",
                       "knowledge/concepts/embedder/overview",
                       "knowledge/concepts/filters/overview",
-                      "knowledge/concepts/isolate-vector-search"
+                      "knowledge/concepts/isolate-vector-search",
+                      "knowledge/concepts/cloud-storage"
                     ]
                   },
                   {

--- a/docs.json
+++ b/docs.json
@@ -501,7 +501,8 @@
                       "knowledge/concepts/readers/overview",
                       "knowledge/concepts/chunking/overview",
                       "knowledge/concepts/embedder/overview",
-                      "knowledge/concepts/filters/overview"
+                      "knowledge/concepts/filters/overview",
+                      "knowledge/concepts/isolate-vector-search"
                     ]
                   },
                   {

--- a/knowledge/concepts/cloud-storage.mdx
+++ b/knowledge/concepts/cloud-storage.mdx
@@ -1,0 +1,260 @@
+---
+title: Cloud Storage Sources
+description: Load content from S3, GCS, SharePoint, GitHub, and Azure Blob into a knowledge base.
+keywords: [knowledge, cloud storage, s3, gcs, sharepoint, github, azure blob]
+---
+
+Register cloud storage providers on a Knowledge instance with `content_sources`. Each provider has `.file()` and `.folder()` methods that create content references you pass to `knowledge.insert()`.
+
+```python
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.remote_content import S3Config
+
+knowledge = Knowledge(
+    vector_db=vector_db,
+    contents_db=contents_db,
+    content_sources=[
+        S3Config(
+            id="company-docs",
+            name="Company Documents",
+            bucket_name="my-docs-bucket",
+            region="us-east-1",
+        ),
+    ],
+)
+
+# Insert a single file
+knowledge.insert(
+    name="Q4 Report",
+    remote_content=knowledge.content_sources[0].file("reports/q4-2025.pdf"),
+)
+
+# Insert an entire folder
+knowledge.insert(
+    name="Engineering Specs",
+    remote_content=knowledge.content_sources[0].folder("specs/"),
+)
+```
+
+## Supported Providers
+
+| Provider | Config Class | Install |
+|----------|-------------|---------|
+| Amazon S3 | `S3Config` | `pip install boto3` |
+| Google Cloud Storage | `GcsConfig` | `pip install google-cloud-storage` |
+| SharePoint | `SharePointConfig` | `pip install msal requests` |
+| GitHub | `GitHubConfig` | `pip install requests` |
+| Azure Blob Storage | `AzureBlobConfig` | `pip install azure-identity azure-storage-blob` |
+
+All configs are importable from `agno.knowledge.remote_content`.
+
+## Provider Configuration
+
+### S3Config
+
+```python
+from agno.knowledge.remote_content import S3Config
+
+s3 = S3Config(
+    id="s3-docs",
+    name="S3 Documents",
+    bucket_name="my-bucket",
+    region="us-east-1",
+    aws_access_key_id="...",       # optional, falls back to default credential chain
+    aws_secret_access_key="...",   # optional, falls back to default credential chain
+    prefix="documents/",           # optional, default prefix for browsing
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | `str` | required | Unique identifier for this source |
+| `name` | `str` | required | Display name |
+| `bucket_name` | `str` | required | S3 bucket name |
+| `region` | `Optional[str]` | `None` | AWS region |
+| `aws_access_key_id` | `Optional[str]` | `None` | AWS access key. Falls back to default credential chain. |
+| `aws_secret_access_key` | `Optional[str]` | `None` | AWS secret key. Falls back to default credential chain. |
+| `prefix` | `Optional[str]` | `None` | Default prefix for browsing and listing |
+
+### GcsConfig
+
+```python
+from agno.knowledge.remote_content import GcsConfig
+
+gcs = GcsConfig(
+    id="gcs-docs",
+    name="GCS Documents",
+    bucket_name="my-gcs-bucket",
+    project="my-gcp-project",
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | `str` | required | Unique identifier |
+| `name` | `str` | required | Display name |
+| `bucket_name` | `str` | required | GCS bucket name |
+| `project` | `Optional[str]` | `None` | GCP project ID |
+| `credentials_path` | `Optional[str]` | `None` | Path to GCP credentials file |
+| `prefix` | `Optional[str]` | `None` | Default prefix |
+
+### GitHubConfig
+
+```python
+from agno.knowledge.remote_content import GitHubConfig
+
+github = GitHubConfig(
+    id="my-repo",
+    name="My Repository",
+    repo="owner/repo",
+    token="ghp_...",
+    branch="main",
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | `str` | required | Unique identifier |
+| `name` | `str` | required | Display name |
+| `repo` | `str` | required | Repository in `owner/repo` format |
+| `token` | `Optional[str]` | `None` | GitHub personal access token (needs Contents: read) |
+| `branch` | `Optional[str]` | `None` | Branch name |
+| `path` | `Optional[str]` | `None` | Default path filter |
+
+### SharePointConfig
+
+```python
+from agno.knowledge.remote_content import SharePointConfig
+
+sharepoint = SharePointConfig(
+    id="sharepoint-docs",
+    name="SharePoint Documents",
+    tenant_id="...",
+    client_id="...",
+    client_secret="...",
+    hostname="contoso.sharepoint.com",
+    site_path="/sites/Engineering",
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | `str` | required | Unique identifier |
+| `name` | `str` | required | Display name |
+| `tenant_id` | `str` | required | Azure AD tenant ID |
+| `client_id` | `str` | required | Azure AD application client ID |
+| `client_secret` | `str` | required | Azure AD application client secret |
+| `hostname` | `str` | required | SharePoint hostname |
+| `site_path` | `Optional[str]` | `None` | Site path (e.g., `/sites/Engineering`) |
+| `site_id` | `Optional[str]` | `None` | Full site ID |
+| `folder_path` | `Optional[str]` | `None` | Default folder path |
+
+### AzureBlobConfig
+
+```python
+from agno.knowledge.remote_content import AzureBlobConfig
+
+azure = AzureBlobConfig(
+    id="azure-docs",
+    name="Azure Blob Documents",
+    tenant_id="...",
+    client_id="...",
+    client_secret="...",
+    storage_account="mystorageaccount",
+    container="documents",
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | `str` | required | Unique identifier |
+| `name` | `str` | required | Display name |
+| `tenant_id` | `str` | required | Azure AD tenant ID |
+| `client_id` | `str` | required | Azure AD application client ID |
+| `client_secret` | `str` | required | Azure AD application client secret |
+| `storage_account` | `str` | required | Azure storage account name |
+| `container` | `str` | required | Blob container name |
+| `prefix` | `Optional[str]` | `None` | Default prefix |
+
+Requires the Storage Blob Data Reader (or Contributor) role on the storage account.
+
+## Inserting Content
+
+Each config has `.file()` and `.folder()` methods that return content references for `knowledge.insert()`.
+
+```python
+# Single file
+knowledge.insert(
+    name="Architecture Doc",
+    remote_content=s3.file("docs/architecture.pdf"),
+)
+
+# Entire folder
+knowledge.insert(
+    name="All Specs",
+    remote_content=gcs.folder("specs/"),
+)
+
+# GitHub file from a specific branch
+knowledge.insert(
+    name="README",
+    remote_content=github.file("README.md", branch="develop"),
+)
+
+# SharePoint file from a specific site
+knowledge.insert(
+    name="Policy",
+    remote_content=sharepoint.file("Shared Documents/policy.pdf", site_path="/sites/HR"),
+)
+```
+
+## Browsing S3 Files
+
+`S3Config` supports paginated file listing with `list_files()`. This is useful for building file pickers or exploring bucket contents before ingesting.
+
+```python
+result = s3.list_files(prefix="reports/", limit=50, page=1)
+
+for folder in result.folders:
+    print(f"Folder: {folder['name']}")
+
+for file in result.files:
+    print(f"File: {file['name']} ({file['size']} bytes)")
+
+print(f"Page {result.page} of {result.total_pages}")
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `prefix` | `Optional[str]` | `None` | Path prefix filter. Overrides the config's `prefix`. |
+| `delimiter` | `str` | `"/"` | Folder delimiter |
+| `limit` | `int` | `100` | Files per page (1-1000) |
+| `page` | `int` | `1` | Page number (1-indexed) |
+
+An async variant `alist_files()` is also available with the same signature.
+
+## Multiple Sources
+
+Register multiple providers on a single Knowledge instance.
+
+```python
+knowledge = Knowledge(
+    vector_db=vector_db,
+    contents_db=contents_db,
+    content_sources=[s3, gcs, github, sharepoint, azure],
+)
+
+# Insert from different sources
+knowledge.insert(name="S3 Doc", remote_content=s3.file("doc.pdf"))
+knowledge.insert(name="GitHub Doc", remote_content=github.file("README.md"))
+```
+
+When running with [AgentOS](/agent-os/overview), registered sources are exposed via the `/knowledge/{id}/sources` API endpoint for listing and browsing.
+
+## Next Steps
+
+| Task | Guide |
+|------|-------|
+| Content types overview | [Content Types](/knowledge/concepts/content-types) |
+| Filter search results | [Filtering](/knowledge/concepts/filters/overview) |
+| Set up a vector database | [Vector Databases](/knowledge/concepts/vector-db) |

--- a/knowledge/concepts/content-types.mdx
+++ b/knowledge/concepts/content-types.mdx
@@ -12,7 +12,7 @@ Content can be added to knowledge from different sources.
 | Url              | Direct links to files or other sites                                       |
 | Text             | Raw text content                                                           |
 | Topic            | Search topics from repositories like Arxiv or Wikipedia                    |
-| Remote Content   | Content stored in remote repositories like S3 or Google Cloud Storage      |
+| Remote Content   | Content from [cloud storage providers](/knowledge/concepts/cloud-storage) like S3, GCS, SharePoint, GitHub, and Azure Blob |
 
 Knowledge content needs to be read and chunked before it can be passed to any VectorDB for embedding, storage and ultimately, retrieval.
 When content is added to Knowledge, a default reader is selected. Readers are used to parse content from the origin and then chunk it into smaller

--- a/knowledge/concepts/isolate-vector-search.mdx
+++ b/knowledge/concepts/isolate-vector-search.mdx
@@ -85,9 +85,9 @@ eng_agent = Agent(knowledge=engineering_knowledge, search_knowledge=True)
 
 Documents indexed before this flag existed do not have `linked_to` in their vector database metadata. When you enable `isolate_vector_search=True`, searches filter for `linked_to=<name>`. Documents without this metadata field will not match and will be invisible to the isolated search.
 
-<Warning>
-Enabling `isolate_vector_search=True` on a Knowledge instance with existing data will cause those documents to disappear from search results. You must re-index or manually update the metadata to restore them.
-</Warning>
+<Tip>
+Enabling `isolate_vector_search=True` with vector databases that don't have existing `linked_to` metadata will cause those documents to disappear from search results. You must re-index or manually update the metadata to restore them.
+</Tip>
 
 ## Combining with Manual Filters
 

--- a/knowledge/concepts/isolate-vector-search.mdx
+++ b/knowledge/concepts/isolate-vector-search.mdx
@@ -89,38 +89,6 @@ Documents indexed before this flag existed do not have `linked_to` in their vect
 Enabling `isolate_vector_search=True` on a Knowledge instance with existing data will cause those documents to disappear from search results. You must re-index or manually update the metadata to restore them.
 </Warning>
 
-### Migrating existing data
-
-You have two options:
-
-**Option 1: Re-index your data**
-
-Re-insert all content with `isolate_vector_search=True` enabled. This adds `linked_to` metadata to every document.
-
-```python
-knowledge = Knowledge(
-    name="support-docs",
-    vector_db=vector_db,
-    isolate_vector_search=True,
-)
-
-# Re-insert all content. New documents will include linked_to="support-docs".
-knowledge.insert(path="support-documents/")
-```
-
-**Option 2: Update metadata directly in the vector database**
-
-If re-indexing is expensive, update the `linked_to` field directly in your vector database. Set it to the Knowledge instance's `name` for all relevant rows.
-
-```sql
--- Example for PgVector (PostgreSQL)
-UPDATE shared_vectors
-SET meta_data = jsonb_set(meta_data, '{linked_to}', '"support-docs"')
-WHERE meta_data->>'linked_to' IS NULL;
-```
-
-The exact query depends on your vector database. The key is that each document's metadata must contain `"linked_to": "<knowledge-instance-name>"` to be found by isolated searches.
-
 ## Combining with Manual Filters
 
 When `isolate_vector_search=True`, the `linked_to` filter is merged with any filters you pass explicitly:

--- a/knowledge/concepts/isolate-vector-search.mdx
+++ b/knowledge/concepts/isolate-vector-search.mdx
@@ -1,0 +1,195 @@
+---
+title: Isolate Vector Search
+description: Scope searches to a single Knowledge instance when multiple instances share the same vector database.
+keywords: [knowledge, isolation, vector search, linked_to, multi-tenant]
+---
+
+When multiple `Knowledge` instances share the same vector database, searches return results from all instances by default. Set `isolate_vector_search=True` to scope each instance's searches to its own data.
+
+```python
+from agno.knowledge.knowledge import Knowledge
+from agno.vectordb.pgvector import PgVector
+
+vector_db = PgVector(
+    table_name="shared_vectors",
+    db_url="postgresql+psycopg://ai:ai@localhost:5532/ai",
+)
+
+# Only returns results from documents this instance inserted
+knowledge = Knowledge(
+    name="support-docs",
+    vector_db=vector_db,
+    isolate_vector_search=True,
+)
+```
+
+## How It Works
+
+When `isolate_vector_search=True`:
+1. **Insert**: Each document gets `linked_to` metadata set to the Knowledge instance's `name`.
+2. **Search**: A `linked_to` filter is automatically injected, so only matching documents are returned.
+
+When `isolate_vector_search=False` (default):
+1. **Insert**: No `linked_to` metadata is added.
+2. **Search**: No `linked_to` filter is applied. Searches return results from all documents in the vector database.
+
+## When to Use
+
+| Scenario | `isolate_vector_search` |
+|----------|------------------------|
+| Single Knowledge instance | `False` (default) |
+| Multiple instances, each with its own vector database | `False` (default) |
+| Multiple instances sharing one vector database, need isolation | `True` |
+
+## Example: Shared Database, Isolated Searches
+
+```python
+from agno.agent import Agent
+from agno.knowledge.knowledge import Knowledge
+from agno.vectordb.pgvector import PgVector
+
+vector_db = PgVector(
+    table_name="shared_vectors",
+    db_url="postgresql+psycopg://ai:ai@localhost:5532/ai",
+)
+
+# Two knowledge instances sharing the same vector database
+hr_knowledge = Knowledge(
+    name="hr-docs",
+    vector_db=vector_db,
+    isolate_vector_search=True,
+)
+
+engineering_knowledge = Knowledge(
+    name="engineering-docs",
+    vector_db=vector_db,
+    isolate_vector_search=True,
+)
+
+# Insert into each instance
+hr_knowledge.insert(path="hr-policies/")
+engineering_knowledge.insert(path="engineering-docs/")
+
+# This agent only searches HR documents
+hr_agent = Agent(knowledge=hr_knowledge, search_knowledge=True)
+
+# This agent only searches engineering documents
+eng_agent = Agent(knowledge=engineering_knowledge, search_knowledge=True)
+```
+
+## Backwards Compatibility
+
+`isolate_vector_search` defaults to `False`. Existing Knowledge instances behave exactly as before.
+
+### Existing data does not have `linked_to` metadata
+
+Documents indexed before this flag existed do not have `linked_to` in their vector database metadata. When you enable `isolate_vector_search=True`, searches filter for `linked_to=<name>`. Documents without this metadata field will not match and will be invisible to the isolated search.
+
+<Warning>
+Enabling `isolate_vector_search=True` on a Knowledge instance with existing data will cause those documents to disappear from search results. You must re-index or manually update the metadata to restore them.
+</Warning>
+
+### Migrating existing data
+
+You have two options:
+
+**Option 1: Re-index your data**
+
+Re-insert all content with `isolate_vector_search=True` enabled. This adds `linked_to` metadata to every document.
+
+```python
+knowledge = Knowledge(
+    name="support-docs",
+    vector_db=vector_db,
+    isolate_vector_search=True,
+)
+
+# Re-insert all content. New documents will include linked_to="support-docs".
+knowledge.insert(path="support-documents/")
+```
+
+**Option 2: Update metadata directly in the vector database**
+
+If re-indexing is expensive, update the `linked_to` field directly in your vector database. Set it to the Knowledge instance's `name` for all relevant rows.
+
+```sql
+-- Example for PgVector (PostgreSQL)
+UPDATE shared_vectors
+SET meta_data = jsonb_set(meta_data, '{linked_to}', '"support-docs"')
+WHERE meta_data->>'linked_to' IS NULL;
+```
+
+The exact query depends on your vector database. The key is that each document's metadata must contain `"linked_to": "<knowledge-instance-name>"` to be found by isolated searches.
+
+## Combining with Manual Filters
+
+When `isolate_vector_search=True`, the `linked_to` filter is merged with any filters you pass explicitly:
+
+```python
+# Searches for documents with linked_to="hr-docs" AND department="legal"
+results = hr_knowledge.search(
+    query="vacation policy",
+    filters={"department": "legal"},
+)
+```
+
+If you use list-based filters (e.g., `EQ`, `IN`), the `linked_to` filter is **not** automatically injected. Add it manually:
+
+```python
+from agno.filters import EQ
+
+results = hr_knowledge.search(
+    query="vacation policy",
+    filters=[EQ("linked_to", "hr-docs"), EQ("department", "legal")],
+)
+```
+
+## Instance Uniqueness
+
+Each Knowledge instance must have a unique combination of `name`, database, and table. Two instances with the same name pointing to the same contents database and table will raise a `ValueError` at startup.
+
+```python
+from agno.db.postgres import PostgresDb
+from agno.knowledge.knowledge import Knowledge
+from agno.vectordb.pgvector import PgVector
+
+contents_db = PostgresDb(
+    db_url="postgresql+psycopg://ai:ai@localhost:5532/ai",
+    knowledge_table="knowledge_contents",
+)
+
+vector_db = PgVector(
+    table_name="shared_vectors",
+    db_url="postgresql+psycopg://ai:ai@localhost:5532/ai",
+)
+
+# These two instances will conflict because they share the same
+# name, contents_db, and table
+knowledge_a = Knowledge(
+    name="my-docs",
+    contents_db=contents_db,
+    vector_db=vector_db,
+)
+
+knowledge_b = Knowledge(
+    name="my-docs",          # same name
+    contents_db=contents_db,  # same database and table
+    vector_db=vector_db,
+)
+# ValueError: Duplicate knowledge instances detected
+```
+
+To fix this, give each instance a unique `name`, or point them to different contents databases or tables.
+
+## Requirements
+
+- The Knowledge instance must have a `name` set. Without a name, no `linked_to` metadata is added and no filter is applied, even when `isolate_vector_search=True`.
+- The vector database must support metadata filtering. See [Filtering](/knowledge/concepts/filters/overview) for supported databases.
+
+## Next Steps
+
+| Task | Guide |
+|------|-------|
+| Filter by other metadata | [Filtering](/knowledge/concepts/filters/overview) |
+| Set up a vector database | [Vector Databases](/knowledge/concepts/vector-db) |
+| Track content metadata | [Contents DB](/knowledge/concepts/contents-db) |

--- a/knowledge/concepts/isolate-vector-search.mdx
+++ b/knowledge/concepts/isolate-vector-search.mdx
@@ -91,25 +91,26 @@ Enabling `isolate_vector_search=True` with vector databases that don't have exis
 
 ## Combining with Manual Filters
 
-When `isolate_vector_search=True`, the `linked_to` filter is merged with any filters you pass explicitly:
+When `isolate_vector_search=True`, the `linked_to` filter is automatically merged with any filters you pass, regardless of filter format:
 
 ```python
-# Searches for documents with linked_to="hr-docs" AND department="legal"
+# Dict-based filters: linked_to is merged automatically
 results = hr_knowledge.search(
     query="vacation policy",
     filters={"department": "legal"},
 )
+# Searches for: linked_to="hr-docs" AND department="legal"
 ```
 
-If you use list-based filters (e.g., `EQ`, `IN`), the `linked_to` filter is **not** automatically injected. Add it manually:
-
 ```python
+# List-based filters (FilterExpr): linked_to is also injected automatically
 from agno.filters import EQ
 
 results = hr_knowledge.search(
     query="vacation policy",
-    filters=[EQ("linked_to", "hr-docs"), EQ("department", "legal")],
+    filters=[EQ("department", "legal")],
 )
+# Searches for: linked_to="hr-docs" AND department="legal"
 ```
 
 ## Instance Uniqueness


### PR DESCRIPTION
## Summary

Documents new Knowledge class features introduced in recent Agno PRs:

- `isolate_vector_search` flag ([agno#6463](https://github.com/agno-agi/agno/pull/6463), [agno#6519](https://github.com/agno-agi/agno/pull/6519))
- Cloud storage content sources ([agno#6584](https://github.com/agno-agi/agno/pull/6584))
- Knowledge ID for API targeting ([agno#6584](https://github.com/agno-agi/agno/pull/6584))

### Changes

**New page: `knowledge/concepts/isolate-vector-search.mdx`**
- `isolate_vector_search` flag (`True` vs `False` behavior)
- Decision table for single vs shared vector database scenarios
- Full example with two isolated Knowledge instances sharing a vector DB
- Backwards compatibility: existing data in vector DBs does not have `linked_to` metadata
- Combining with manual filters (dict and list-based)
- Instance uniqueness: each Knowledge instance needs a unique `(name, database, table)` combination

**New page: `knowledge/concepts/cloud-storage.mdx`**
- Cloud content source configs: S3Config, GcsConfig, SharePointConfig, GitHubConfig, AzureBlobConfig
- Field reference tables for each provider
- `content_sources` parameter on Knowledge
- `.file()` and `.folder()` factory methods for creating content references
- S3 file browsing with `list_files()` / `alist_files()`
- Multiple sources on a single Knowledge instance

**Updated: `agent-os/knowledge/manage-knowledge.mdx`**
- Added Knowledge ID section: what it is, how it's generated, how to use it in API calls
- Finding your Knowledge ID via `/knowledge/config`
- Backward compatibility (single instance, `db_id` fallback)

**Updated: `_snippets/knowledge-reference.mdx`**
- Added `isolate_vector_search` and `content_sources` parameters to the Knowledge reference table

**Updated: `docs.json`**
- Added both new pages to Knowledge > Concepts navigation

**Updated: `knowledge/concepts/content-types.mdx`**
- Updated Remote Content row to link to the new cloud storage page

## Test plan

- [ ] Verify `mintlify dev` renders both new pages correctly
- [ ] Verify navigation shows both pages under Knowledge > Concepts
- [ ] Verify the Knowledge reference table includes both new parameters
- [ ] Verify Knowledge ID section renders on manage-knowledge page
- [ ] Check all internal links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)