### PR TITLE
fix: add missing run_context parameter to pre-hooks and post-hooks reference

### DIFF
--- a/reference/hooks/post-hooks.mdx
+++ b/reference/hooks/post-hooks.mdx
@@ -12,9 +12,7 @@ Running a post-hook is handled automatically during the Agent or Team run. These
 | `team`             | `Team`                       | Required                      | The Team that is running the post-hook. Only present in Team runs.                                          |
 | `run_output`       | `RunOutput` or `TeamRunOutput`| Required                      | The output of the current Agent or Team run.                                            |
 | `session`          | `AgentSession`               | Required                      | The `AgentSession` or `TeamSession` object representing the current session.                                    |
-| `session_state`    | `Optional[Dict[str, Any]]`   | `None`                        | The session state of the current session.                                                                   |
-| `dependencies`     | `Optional[Dict[str, Any]]`   | `None`                        | The dependencies of the current run.                                                                   |
-| `metadata`         | `Optional[Dict[str, Any]]`   | `None`                        | The metadata of the current run.                                                                   |
+| `run_context`      | `RunContext`                 | Required                      | The current run context. See [Run Context](/reference/run/run-context).                                    |
 | `user_id`          | `Optional[str]`              | `None`                        | The contextual user ID, if any.                                                                   |
 | `debug_mode`       | `Optional[bool]`             | `None`                        | Whether the debug mode is enabled.                                                                |
 

--- a/reference/hooks/pre-hooks.mdx
+++ b/reference/hooks/pre-hooks.mdx
@@ -12,9 +12,7 @@ Running a pre-hook is handled automatically during the Agent or Team run. These 
 | `team`             | `Team`                       | Required                      | The Team that is running the pre-hook. Only present in Team runs.                                          |
 | `run_input`        | `RunInput`                   | Required                      | The input provided to the Agent or Team when invoking the run.                                            |
 | `session`          | `AgentSession`               | Required                      | The `AgentSession` or `TeamSession` object representing the current session.                                    |
-| `session_state`    | `Optional[Dict[str, Any]]`   | `None`                        | The session state of the current session.                                                                   |
-| `dependencies`     | `Optional[Dict[str, Any]]`   | `None`                        | The dependencies of the current run.                                                                   |
-| `metadata`         | `Optional[Dict[str, Any]]`   | `None`                        | The metadata of the current run.                                                                   |
+| `run_context`      | `RunContext`                 | Required                      | The current run context. See [Run Context](/reference/run/run-context).                                    |
 | `user_id`          | `Optional[str]`              | `None`                        | The contextual user ID, if any.                                                                   |
 | `debug_mode`       | `Optional[bool]`             | `None`                        | Whether the debug mode is enabled.                                                                |
 


### PR DESCRIPTION
## Description

The reference pages for pre-hooks and post-hooks listed `session_state`, `dependencies`, and `metadata` as directly injectable parameters, but the SDK never injects them. These values are only accessible via `run_context.session_state`, `run_context.dependencies`, and `run_context.metadata`.

Additionally, `run_context` (which is actually injected) was missing from both parameter tables.

This fix removes the three incorrect parameters and adds `run_context` with a link to the Run Context reference, aligning the reference pages with:
- The [overview page](https://docs.agno.com/hooks/overview) (which already correctly lists `run_context`)
- The SDK code in [`agno/agent/_hooks.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/agent/_hooks.py) and [`agno/team/_hooks.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/team/_hooks.py)

Verified against SDK v2.5.0 (commit ddd1292) and current `main`.

## Files changed

- `reference/hooks/pre-hooks.mdx` - Removed `session_state`, `dependencies`, `metadata`; added `run_context`
- `reference/hooks/post-hooks.mdx` - Removed `session_state`, `dependencies`, `metadata`; added `run_context`

## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: ____

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [ ] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)