### PR TITLE
fix: replace get_learning_machine() with learning_machine

### DIFF
--- a/first-agent.mdx
+++ b/first-agent.mdx
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    lm = agent.get_learning_machine()
+    lm = agent.learning_machine
     lm.user_profile_store.print(user_id=user_id)
     lm.user_memory_store.print(user_id=user_id)
 
@@ -144,7 +144,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    lm = agent.get_learning_machine()
+    lm = agent.learning_machine
     lm.user_profile_store.print(user_id=user_id)
     lm.user_memory_store.print(user_id=user_id)
 
@@ -208,7 +208,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    lm = agent.get_learning_machine()
+    lm = agent.learning_machine
     lm.learned_knowledge_store.print(query="cloud")
 
     # Session 2: User 2 benefits from the learning

--- a/learning/overview.mdx
+++ b/learning/overview.mdx
@@ -60,7 +60,7 @@ Some stores support configurable sharing scope via `namespace`:
 
 The Curator keeps memories healthy:
 ```python
-lm = agent.get_learning_machine()
+lm = agent.learning_machine
 
 # Remove memories older than 90 days
 lm.curator.prune(user_id="alice", max_age_days=90)

--- a/learning/stores/decision-log.mdx
+++ b/learning/stores/decision-log.mdx
@@ -40,7 +40,7 @@ agent.print_response(
 )
 
 # View logged decisions
-lm = agent.get_learning_machine()
+lm = agent.learning_machine
 lm.decision_log_store.print(agent_id="my-agent", limit=5)
 ```
 
@@ -105,7 +105,7 @@ Tradeoff: logs every tool call, may generate noise.
 
 Update decisions with what actually happened to build feedback loops:
 ```python
-lm = agent.get_learning_machine()
+lm = agent.learning_machine
 
 # Via store directly
 lm.decision_log_store.update_outcome(
@@ -119,7 +119,7 @@ Or the agent can use the `record_outcome` tool during conversation.
 
 ## Accessing Decisions
 ```python
-lm = agent.get_learning_machine()
+lm = agent.learning_machine
 
 # Search decisions
 decisions = lm.decision_log_store.search(

--- a/learning/stores/entity-memory.mdx
+++ b/learning/stores/entity-memory.mdx
@@ -111,7 +111,7 @@ Available tools: `search_entities`, `create_entity`, `update_entity`, `add_fact`
 
 ## Accessing Entity Memory
 ```python
-lm = agent.get_learning_machine()
+lm = agent.learning_machine
 
 # Search for entities
 entities = lm.entity_memory_store.search(

--- a/learning/stores/learned-knowledge.mdx
+++ b/learning/stores/learned-knowledge.mdx
@@ -153,7 +153,7 @@ Tradeoff: extra LLM call per interaction, may save low-value insights.
 
 ## Accessing Learned Knowledge
 ```python
-lm = agent.get_learning_machine()
+lm = agent.learning_machine
 
 # Search for relevant learnings
 results = lm.learned_knowledge_store.search(query="cloud costs", limit=5)

--- a/learning/stores/session-context.mdx
+++ b/learning/stores/session-context.mdx
@@ -104,7 +104,7 @@ agent.print_response(
 
 ## Accessing Session Context
 ```python
-lm = agent.get_learning_machine()
+lm = agent.learning_machine
 
 context = lm.session_context_store.get(session_id="api_design")
 if context:

--- a/learning/stores/user-memory.mdx
+++ b/learning/stores/user-memory.mdx
@@ -107,7 +107,7 @@ Tradeoff: agent may miss implicit observations.
 
 ## Accessing Memories
 ```python
-lm = agent.get_learning_machine()
+lm = agent.learning_machine
 
 # Get all memories
 memories = lm.user_memory_store.get_memories(user_id="alice@example.com")
@@ -134,7 +134,7 @@ Relevant memories are injected into the system prompt:
 
 Over time, memories accumulate. Use the Curator to maintain them:
 ```python
-lm = agent.get_learning_machine()
+lm = agent.learning_machine
 
 # Remove memories older than 90 days
 lm.curator.prune(user_id="alice@example.com", max_age_days=90)

--- a/learning/stores/user-profile.mdx
+++ b/learning/stores/user-profile.mdx
@@ -128,7 +128,7 @@ The `metadata["description"]` tells the LLM what each field captures.
 
 ## Accessing Profile Data
 ```python
-lm = agent.get_learning_machine()
+lm = agent.learning_machine
 
 # Get profile
 profile = lm.user_profile_store.get(user_id="alice@example.com")


### PR DESCRIPTION
## Description
Base on the PR on the SDK https://github.com/agno-agi/agno/pull/6409, the ```get_learning_machine``` method has been converted to the ```learning_machine``` property.

## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Related SDK PR: agno-agi/agno#6409

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
