### PR TITLE
Restructure SDK tab navigation into 8 groups

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -9,7 +9,13 @@
   },
   "favicon": "/favicon.png",
   "contextual": {
-    "options": ["copy", "mcp", "cursor", "chatgpt", "claude"]
+    "options": [
+      "copy",
+      "mcp",
+      "cursor",
+      "chatgpt",
+      "claude"
+    ]
   },
   "logo": {
     "light": "/logo/black.svg",
@@ -74,7 +80,9 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["index"]
+            "pages": [
+              "index"
+            ]
           }
         ]
       },
@@ -83,7 +91,10 @@
         "groups": [
           {
             "group": "Get Started",
-            "pages": ["introduction", "first-agent"]
+            "pages": [
+              "introduction",
+              "first-agent"
+            ]
           },
           {
             "group": "Basics",
@@ -231,1563 +242,27 @@
                 ]
               },
               {
-                "group": "Database",
-                "pages": [
-                  "database/overview",
-                  "database/chat-history",
-                  "database/session-storage",
-                  {
-                    "group": "Supported Databases",
-                    "pages": [
-                      "database/providers/overview",
-                      {
-                        "group": "PostgreSQL",
-                        "pages": [
-                          "database/providers/postgres/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/postgres/usage/postgres-for-agent",
-                              "database/providers/postgres/usage/postgres-for-team",
-                              "database/providers/postgres/usage/postgres-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Async PostgreSQL",
-                        "pages": [
-                          "database/providers/async-postgres/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/async-postgres/usage/async-postgres-for-agent",
-                              "database/providers/async-postgres/usage/async-postgres-for-team",
-                              "database/providers/async-postgres/usage/async-postgres-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "MySQL",
-                        "pages": [
-                          "database/providers/mysql/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/mysql/usage/mysql-for-agent",
-                              "database/providers/mysql/usage/mysql-for-team",
-                              "database/providers/mysql/usage/mysql-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Async MySQL",
-                        "pages": [
-                          "database/providers/async-mysql/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/async-mysql/usage/async-mysql-for-agent",
-                              "database/providers/async-mysql/usage/async-mysql-for-team",
-                              "database/providers/async-mysql/usage/async-mysql-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "SQLite",
-                        "pages": [
-                          "database/providers/sqlite/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/sqlite/usage/sqlite-for-agent",
-                              "database/providers/sqlite/usage/sqlite-for-team",
-                              "database/providers/sqlite/usage/sqlite-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Async SQLite",
-                        "pages": [
-                          "database/providers/async-sqlite/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/async-sqlite/usage/async-sqlite-for-agent",
-                              "database/providers/async-sqlite/usage/async-sqlite-for-team",
-                              "database/providers/async-sqlite/usage/async-sqlite-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "In-Memory",
-                        "pages": [
-                          "database/providers/in-memory/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/in-memory/usage/in-memory-for-agent",
-                              "database/providers/in-memory/usage/in-memory-for-team",
-                              "database/providers/in-memory/usage/in-memory-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "DynamoDB",
-                        "pages": [
-                          "database/providers/dynamodb/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/dynamodb/usage/dynamodb-for-agent",
-                              "database/providers/dynamodb/usage/dynamodb-for-team",
-                              "database/providers/dynamodb/usage/dynamodb-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "MongoDB",
-                        "pages": [
-                          "database/providers/mongo/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/mongo/usage/mongodb-for-agent",
-                              "database/providers/mongo/usage/mongodb-for-team",
-                              "database/providers/mongo/usage/mongodb-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Async MongoDB",
-                        "pages": [
-                          "database/providers/async-mongo/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/async-mongo/usage/async-mongodb-for-agent",
-                              "database/providers/async-mongo/usage/async-mongodb-for-team",
-                              "database/providers/async-mongo/usage/async-mongodb-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "JSON",
-                        "pages": [
-                          "database/providers/json/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/json/usage/json-for-agent",
-                              "database/providers/json/usage/json-for-team",
-                              "database/providers/json/usage/json-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Singlestore",
-                        "pages": [
-                          "database/providers/singlestore/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/singlestore/usage/singlestore-for-agent",
-                              "database/providers/singlestore/usage/singlestore-for-team",
-                              "database/providers/singlestore/usage/singlestore-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "SurrealDB",
-                        "pages": [
-                          "database/providers/surrealdb/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/surrealdb/usage/surrealdb-for-agent",
-                              "database/providers/surrealdb/usage/surrealdb-for-team",
-                              "database/providers/surrealdb/usage/surrealdb-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Redis",
-                        "pages": [
-                          "database/providers/redis/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/redis/usage/redis-for-agent",
-                              "database/providers/redis/usage/redis-for-team",
-                              "database/providers/redis/usage/redis-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "GCS",
-                        "pages": [
-                          "database/providers/gcs/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/gcs/usage/gcs-for-agent",
-                              "database/providers/gcs/usage/gcs-for-team",
-                              "database/providers/gcs/usage/gcs-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Firestore",
-                        "pages": [
-                          "database/providers/firestore/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "database/providers/firestore/usage/firestore-for-agent",
-                              "database/providers/firestore/usage/firestore-for-team",
-                              "database/providers/firestore/usage/firestore-for-workflow"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Supabase",
-                        "pages": ["database/providers/supabase/overview"]
-                      },
-                      {
-                        "group": "Neon",
-                        "pages": ["database/providers/neon/overview"]
-                      },
-                      "database/providers/selecting-tables"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Memory",
-                "pages": [
-                  "memory/overview",
-                  {
-                    "group": "Working with Memories",
-                    "pages": [
-                      "memory/working-with-memories/overview",
-                      "memory/working-with-memories/memory-optimization",
-                      {
-                        "group": "Usage",
-                        "pages": [
-                          {
-                            "group": "Storage Usage",
-                            "pages": [
-                              "memory/working-with-memories/mongodb-memory",
-                              "memory/working-with-memories/postgres-memory",
-                              "memory/working-with-memories/sqlite-memory",
-                              "memory/working-with-memories/redis-memory"
-                            ]
-                          },
-                          {
-                            "group": "Memory Manager Usage",
-                            "pages": [
-                              "memory/working-with-memories/standalone-memory",
-                              "memory/working-with-memories/memory-creation",
-                              "memory/working-with-memories/custom-memory-instructions",
-                              "memory/working-with-memories/memory-search",
-                              "memory/working-with-memories/memory-optimization"
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Agents with Memory",
-                    "pages": [
-                      "memory/agent/overview",
-                      {
-                        "group": "Usage",
-                        "pages": [
-                          "memory/agent/agent-with-memory",
-                          "memory/agent/agentic-memory",
-                          "memory/agent/agents-share-memory",
-                          "memory/agent/custom-memory-manager",
-                          "memory/agent/multi-user-multi-session-chat",
-                          "memory/agent/multi-user-multi-session-chat-concurrent",
-                          "memory/agent/share-memory-and-history-between-agents"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Teams with Memory",
-                    "pages": [
-                      "memory/team/overview",
-                      {
-                        "group": "Usage",
-                        "pages": [
-                          "memory/team/team-with-memory-manager",
-                          "memory/team/team-with-agentic-memory"
-                        ]
-                      }
-                    ]
-                  },
-                  "memory/best-practices"
-                ]
-              },
-              {
-                "group": "Knowledge",
-                "pages": [
-                  "knowledge/overview",
-                  "knowledge/quickstart",
-                  {
-                    "group": "Concepts",
-                    "pages": [
-                      "knowledge/concepts/vector-db",
-                      "knowledge/concepts/contents-db",
-                      {
-                        "group": "Search & Retrieval",
-                        "pages": [
-                          "knowledge/concepts/search-and-retrieval/overview",
-                          "knowledge/concepts/search-and-retrieval/hybrid-search",
-                          "knowledge/concepts/search-and-retrieval/vector-search",
-                          "knowledge/concepts/search-and-retrieval/keyword-search",
-                          "knowledge/concepts/search-and-retrieval/agentic-rag",
-                          "knowledge/concepts/search-and-retrieval/custom-retriever"
-                        ]
-                      },
-                      "knowledge/concepts/readers/overview",
-                      "knowledge/concepts/chunking/overview",
-                      "knowledge/concepts/embedder/overview",
-                      "knowledge/concepts/filters/overview"
-                    ]
-                  },
-                  {
-                    "group": "Usage",
-                    "pages": [
-                      {
-                        "group": "Agents",
-                        "pages": [
-                          "knowledge/agents/overview",
-                          "knowledge/agents/agentic-rag-lancedb",
-                          "knowledge/agents/agentic-rag-pgvector",
-                          "knowledge/agents/traditional-rag-lancedb",
-                          "knowledge/agents/traditional-rag-pgvector"
-                        ]
-                      },
-                      {
-                        "group": "Teams",
-                        "pages": [
-                          "knowledge/teams/overview",
-                          "knowledge/teams/team-with-knowledge",
-                          "knowledge/teams/distributed-rag-pgvector",
-                          "knowledge/teams/distributed-rag-lancedb"
-                        ]
-                      },
-                      {
-                        "group": "Readers",
-                        "pages": [
-                          "knowledge/concepts/readers/pdf-reader",
-                          "knowledge/concepts/readers/csv-reader",
-                          "knowledge/concepts/readers/json-reader",
-                          "knowledge/concepts/readers/markdown-reader",
-                          "knowledge/concepts/readers/website-reader",
-                          "knowledge/concepts/readers/youtube-reader"
-                        ]
-                      },
-                      {
-                        "group": "Chunkers",
-                        "pages": [
-                          "knowledge/concepts/chunking/fixed-size-chunking",
-                          "knowledge/concepts/chunking/semantic-chunking",
-                          "knowledge/concepts/chunking/recursive-chunking",
-                          "knowledge/concepts/chunking/document-chunking",
-                          "knowledge/concepts/chunking/csv-row-chunking",
-                          "knowledge/concepts/chunking/markdown-chunking",
-                          "knowledge/concepts/chunking/agentic-chunking",
-                          "knowledge/concepts/chunking/code-chunking",
-                          "knowledge/concepts/chunking/custom-chunking"
-                        ]
-                      },
-                      {
-                        "group": "Embedders",
-                        "pages": [
-                          "knowledge/concepts/embedder/openai/openai-embedder",
-                          "knowledge/concepts/embedder/cohere/cohere-embedder",
-                          "knowledge/concepts/embedder/gemini/gemini-embedder",
-                          "knowledge/concepts/embedder/ollama/ollama-embedder",
-                          "knowledge/concepts/embedder/mistral/mistral-embedder",
-                          "knowledge/concepts/embedder/voyageai/voyageai-embedder"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Vector Stores",
-                    "pages": [
-                      "knowledge/vector-stores/index",
-                      {
-                        "group": "PgVector",
-                        "pages": [
-                          "knowledge/vector-stores/pgvector/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/pgvector/usage/pgvector-db",
-                              "knowledge/vector-stores/pgvector/usage/async-pgvector-db",
-                              "knowledge/vector-stores/pgvector/usage/pgvector-hybrid-search"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "LanceDB",
-                        "pages": [
-                          "knowledge/vector-stores/lancedb/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/lancedb/usage/lance-db",
-                              "knowledge/vector-stores/lancedb/usage/async-lance-db",
-                              "knowledge/vector-stores/lancedb/usage/lance-db-hybrid-search"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Pinecone",
-                        "pages": [
-                          "knowledge/vector-stores/pinecone/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/pinecone/usage/pinecone-db",
-                              "knowledge/vector-stores/pinecone/usage/async-pinecone-db"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Qdrant",
-                        "pages": [
-                          "knowledge/vector-stores/qdrant/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/qdrant/usage/qdrant-db",
-                              "knowledge/vector-stores/qdrant/usage/async-qdrant-db",
-                              "knowledge/vector-stores/qdrant/usage/qdrant-db-hybrid-search"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Chroma",
-                        "pages": [
-                          "knowledge/vector-stores/chroma/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/chroma/usage/chroma-db",
-                              "knowledge/vector-stores/chroma/usage/async-chroma-db",
-                              "knowledge/vector-stores/chroma/usage/chroma-hybrid-search"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Milvus",
-                        "pages": [
-                          "knowledge/vector-stores/milvus/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/milvus/usage/milvus-db",
-                              "knowledge/vector-stores/milvus/usage/async-milvus-db",
-                              "knowledge/vector-stores/milvus/usage/milvus-db-hybrid-search",
-                              "knowledge/vector-stores/milvus/usage/async-milvus-db-hybrid-search"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Weaviate",
-                        "pages": [
-                          "knowledge/vector-stores/weaviate/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/weaviate/usage/weaviate-db",
-                              "knowledge/vector-stores/weaviate/usage/async-weaviate-db",
-                              "knowledge/vector-stores/weaviate/usage/weaviate-db-hybrid-search"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Couchbase",
-                        "pages": [
-                          "knowledge/vector-stores/couchbase/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/couchbase/usage/couchbase-db",
-                              "knowledge/vector-stores/couchbase/usage/async-couchbase-db"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Cassandra",
-                        "pages": [
-                          "knowledge/vector-stores/cassandra/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/cassandra/usage/cassandra-db",
-                              "knowledge/vector-stores/cassandra/usage/async-cassandra-db"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Clickhouse",
-                        "pages": [
-                          "knowledge/vector-stores/clickhouse/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/clickhouse/usage/clickhouse-db",
-                              "knowledge/vector-stores/clickhouse/usage/async-clickhouse-db"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Singlestore",
-                        "pages": [
-                          "knowledge/vector-stores/singlestore/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/singlestore/usage/singlestore-db",
-                              "knowledge/vector-stores/singlestore/usage/async-singlestore-db"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Redis",
-                        "pages": [
-                          "knowledge/vector-stores/redis/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/redis/usage/redis-db",
-                              "knowledge/vector-stores/redis/usage/async-redis-db"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "MongoDB",
-                        "pages": [
-                          "knowledge/vector-stores/mongodb/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/mongodb/usage/mongo-db",
-                              "knowledge/vector-stores/mongodb/usage/async-mongo-db",
-                              "knowledge/vector-stores/mongodb/usage/mongo-db-hybrid-search"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Azure Cosmos DB MongoDB vCore",
-                        "pages": [
-                          "knowledge/vector-stores/azure_cosmos_mongodb/overview",
-                          {
-                            "group": "Usage"
-                          }
-                        ]
-                      },
-                      {
-                        "group": "SurrealDB",
-                        "pages": [
-                          "knowledge/vector-stores/surrealdb/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/surrealdb/usage/surreal-db",
-                              "knowledge/vector-stores/surrealdb/usage/async-surreal-db"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "LightRAG",
-                        "pages": [
-                          "knowledge/vector-stores/lightrag/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/lightrag/usage/lightrag-db",
-                              "knowledge/vector-stores/lightrag/usage/async-lightrag-db"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Upstash",
-                        "pages": [
-                          "knowledge/vector-stores/upstash/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/upstash/usage/upstash-db",
-                              "knowledge/vector-stores/upstash/usage/async-upstash-db"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "LangChain",
-                        "pages": [
-                          "knowledge/vector-stores/langchain/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/langchain/usage/langchain-db",
-                              "knowledge/vector-stores/langchain/usage/async-langchain-db"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "LlamaIndex",
-                        "pages": [
-                          "knowledge/vector-stores/llamaindex/overview",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "knowledge/vector-stores/llamaindex/usage/llamaindex-db",
-                              "knowledge/vector-stores/llamaindex/usage/async-llamaindex-db"
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "knowledge/concepts/performance-tips"
-                ]
-              },
-              {
-                "group": "Learning",
-                "pages": [
-                  "learning/overview",
-                  "learning/quickstart",
-                  {
-                    "group": "Learning Stores",
-                    "pages": [
-                      "learning/stores/intro",
-                      "learning/stores/user-profile",
-                      "learning/stores/user-memory",
-                      "learning/stores/session-context",
-                      "learning/stores/entity-memory",
-                      "learning/stores/learned-knowledge",
-                      "learning/stores/decision-log"
-                    ]
-                  },
-                  "learning/learning-modes",
-                  "learning/custom-schemas"
-                ]
-              },
-              {
                 "group": "Models",
                 "pages": [
                   "models/overview",
                   "models/model-as-string",
                   "models/compatibility",
-                  "models/cache-response",
-                  {
-                    "group": "Model Providers",
-                    "pages": [
-                      "models/providers/model-index",
-                      {
-                        "group": "Native Model Providers",
-                        "pages": [
-                          {
-                            "group": "Anthropic",
-                            "pages": [
-                              "models/providers/native/anthropic/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/native/anthropic/usage/basic",
-                                  "models/providers/native/anthropic/usage/basic-stream",
-                                  "models/providers/native/anthropic/usage/betas",
-                                  "models/providers/native/anthropic/usage/code-execution",
-                                  "models/providers/native/anthropic/usage/context-management",
-                                  "models/providers/native/anthropic/usage/skills",
-                                  "models/providers/native/anthropic/usage/tool-use",
-                                  "models/providers/native/anthropic/usage/structured-output",
-                                  "models/providers/native/anthropic/usage/structured-output-stream",
-                                  "models/providers/native/anthropic/usage/structured-output-strict-tools",
-                                  "models/providers/native/anthropic/usage/knowledge",
-                                  "models/providers/native/anthropic/usage/file-upload",
-                                  "models/providers/native/anthropic/usage/image-input-bytes",
-                                  "models/providers/native/anthropic/usage/image-input-url",
-                                  "models/providers/native/anthropic/usage/pdf-input-bytes",
-                                  "models/providers/native/anthropic/usage/pdf-input-local",
-                                  "models/providers/native/anthropic/usage/pdf-input-url",
-                                  "models/providers/native/anthropic/usage/prompt-caching",
-                                  "models/providers/native/anthropic/usage/cache-response",
-                                  "models/providers/native/anthropic/usage/web-fetch"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Cohere",
-                            "pages": [
-                              "models/providers/native/cohere/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/native/cohere/usage/basic",
-                                  "models/providers/native/cohere/usage/basic-stream",
-                                  "models/providers/native/cohere/usage/image-agent",
-                                  "models/providers/native/cohere/usage/tool-use",
-                                  "models/providers/native/cohere/usage/structured-output",
-                                  "models/providers/native/cohere/usage/storage",
-                                  "models/providers/native/cohere/usage/knowledge"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Dashscope",
-                            "pages": [
-                              "models/providers/native/dashscope/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/native/dashscope/usage/basic",
-                                  "models/providers/native/dashscope/usage/basic-stream",
-                                  "models/providers/native/dashscope/usage/tool-use",
-                                  "models/providers/native/dashscope/usage/image-agent",
-                                  "models/providers/native/dashscope/usage/image-agent-bytes",
-                                  "models/providers/native/dashscope/usage/structured-output",
-                                  "models/providers/native/dashscope/usage/thinking-agent"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "DeepSeek",
-                            "pages": [
-                              "models/providers/native/deepseek/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/native/deepseek/usage/basic",
-                                  "models/providers/native/deepseek/usage/basic-stream",
-                                  "models/providers/native/deepseek/usage/tool-use",
-                                  "models/providers/native/deepseek/usage/structured-output"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Google",
-                            "pages": [
-                              "models/providers/native/google/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/native/google/usage/basic",
-                                  "models/providers/native/google/usage/basic-stream",
-                                  "models/providers/native/google/usage/structured-output",
-                                  "models/providers/native/google/usage/tool-use",
-                                  "models/providers/native/google/usage/storage",
-                                  "models/providers/native/google/usage/knowledge",
-                                  "models/providers/native/google/usage/image-input",
-                                  "models/providers/native/google/usage/image-input-file-upload",
-                                  "models/providers/native/google/usage/image-generation",
-                                  "models/providers/native/google/usage/image-generation-stream",
-                                  "models/providers/native/google/usage/image-editing",
-                                  "models/providers/native/google/usage/imagen-tool",
-                                  "models/providers/native/google/usage/imagen-tool-advanced",
-                                  "models/providers/native/google/usage/vertexai",
-                                  "models/providers/native/google/usage/grounding",
-                                  "models/providers/native/google/usage/url-context",
-                                  "models/providers/native/google/usage/url-context-with-search",
-                                  "models/providers/native/google/usage/flash-thinking",
-                                  "models/providers/native/google/usage/audio-input-bytes-content",
-                                  "models/providers/native/google/usage/audio-input-file-upload",
-                                  "models/providers/native/google/usage/audio-input-local-file-upload",
-                                  "models/providers/native/google/usage/pdf-input-local",
-                                  "models/providers/native/google/usage/pdf-input-url",
-                                  "models/providers/native/google/usage/gcs-file-input",
-                                  "models/providers/native/google/usage/external-url-input",
-                                  "models/providers/native/google/usage/s3-presigned-url-input",
-                                  "models/providers/native/google/usage/video-input-bytes-content",
-                                  "models/providers/native/google/usage/video-input-file-upload",
-                                  "models/providers/native/google/usage/video-input-local-file-upload"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Meta",
-                            "pages": [
-                              "models/providers/native/meta/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/native/meta/usage/basic",
-                                  "models/providers/native/meta/usage/basic-stream",
-                                  "models/providers/native/meta/usage/async-basic",
-                                  "models/providers/native/meta/usage/async-stream",
-                                  "models/providers/native/meta/usage/tool-use",
-                                  "models/providers/native/meta/usage/async-tool-use",
-                                  "models/providers/native/meta/usage/structured-output",
-                                  "models/providers/native/meta/usage/image-input-bytes",
-                                  "models/providers/native/meta/usage/knowledge",
-                                  "models/providers/native/meta/usage/memory"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Mistral",
-                            "pages": [
-                              "models/providers/native/mistral/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/native/mistral/usage/basic",
-                                  "models/providers/native/mistral/usage/basic-stream",
-                                  "models/providers/native/mistral/usage/async-basic",
-                                  "models/providers/native/mistral/usage/async-basic-stream",
-                                  "models/providers/native/mistral/usage/tool-use",
-                                  "models/providers/native/mistral/usage/async-tool-use",
-                                  "models/providers/native/mistral/usage/memory",
-                                  "models/providers/native/mistral/usage/structured-output",
-                                  "models/providers/native/mistral/usage/structured-output-with-tool-use",
-                                  "models/providers/native/mistral/usage/async-structured-output",
-                                  "models/providers/native/mistral/usage/image-bytes-input-agent",
-                                  "models/providers/native/mistral/usage/image-compare-agent",
-                                  "models/providers/native/mistral/usage/image-file-input-agent",
-                                  "models/providers/native/mistral/usage/image-ocr-with-structured-output",
-                                  "models/providers/native/mistral/usage/image-transcribe-document-agent",
-                                  "models/providers/native/mistral/usage/mistral-small"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "OpenAI",
-                            "pages": [
-                              {
-                                "group": "OpenAI Chat Completion",
-                                "pages": [
-                                  "models/providers/native/openai/completion/overview",
-                                  {
-                                    "group": "Usage",
-                                    "pages": [
-                                      "models/providers/native/openai/completion/usage/basic",
-                                      "models/providers/native/openai/completion/usage/basic-stream",
-                                      "models/providers/native/openai/completion/usage/tool-use",
-                                      "models/providers/native/openai/completion/usage/structured-output",
-                                      "models/providers/native/openai/completion/usage/storage",
-                                      "models/providers/native/openai/completion/usage/knowledge",
-                                      "models/providers/native/openai/completion/usage/image-agent",
-                                      "models/providers/native/openai/completion/usage/audio-input-agent",
-                                      "models/providers/native/openai/completion/usage/audio-output-agent",
-                                      "models/providers/native/openai/completion/usage/generate-images",
-                                      "models/providers/native/openai/completion/usage/reasoning-effort",
-                                      "models/providers/native/openai/completion/usage/cache-response"
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "group": "OpenAI Responses",
-                                "pages": [
-                                  "models/providers/native/openai/responses/overview",
-                                  {
-                                    "group": "Usage",
-                                    "pages": [
-                                      "models/providers/native/openai/responses/usage/agent-flex-tier",
-                                      "models/providers/native/openai/responses/usage/async-basic",
-                                      "models/providers/native/openai/responses/usage/async-basic-stream",
-                                      "models/providers/native/openai/responses/usage/async-tool-use",
-                                      "models/providers/native/openai/responses/usage/basic",
-                                      "models/providers/native/openai/responses/usage/basic-stream",
-                                      "models/providers/native/openai/responses/usage/db",
-                                      "models/providers/native/openai/responses/usage/deep-research-agent",
-                                      "models/providers/native/openai/responses/usage/image-agent",
-                                      "models/providers/native/openai/responses/usage/image-agent-bytes",
-                                      "models/providers/native/openai/responses/usage/image-agent-with-memory",
-                                      "models/providers/native/openai/responses/usage/image-generation-agent",
-                                      "models/providers/native/openai/responses/usage/knowledge",
-                                      "models/providers/native/openai/responses/usage/memory",
-                                      "models/providers/native/openai/responses/usage/pdf-input-local",
-                                      "models/providers/native/openai/responses/usage/pdf-input-url",
-                                      "models/providers/native/openai/responses/usage/reasoning-o3-mini",
-                                      "models/providers/native/openai/responses/usage/structured-output",
-                                      "models/providers/native/openai/responses/usage/tool-use",
-                                      "models/providers/native/openai/responses/usage/tool-use-gpt-5",
-                                      "models/providers/native/openai/responses/usage/tool-use-o3",
-                                      "models/providers/native/openai/responses/usage/tool-use-stream",
-                                      "models/providers/native/openai/responses/usage/verbosity-control",
-                                      "models/providers/native/openai/responses/usage/websearch-builtin-tool",
-                                      "models/providers/native/openai/responses/usage/zdr-reasoning-agent"
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Perplexity",
-                            "pages": [
-                              "models/providers/native/perplexity/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/native/perplexity/usage/basic",
-                                  "models/providers/native/perplexity/usage/basic-stream",
-                                  "models/providers/native/perplexity/usage/async-basic",
-                                  "models/providers/native/perplexity/usage/async-basic-stream",
-                                  "models/providers/native/perplexity/usage/knowledge",
-                                  "models/providers/native/perplexity/usage/memory",
-                                  "models/providers/native/perplexity/usage/structured-output"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Vercel",
-                            "pages": [
-                              "models/providers/native/vercel/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/native/vercel/usage/basic",
-                                  "models/providers/native/vercel/usage/basic-stream",
-                                  "models/providers/native/vercel/usage/image-agent",
-                                  "models/providers/native/vercel/usage/knowledge",
-                                  "models/providers/native/vercel/usage/tool-use"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "XAI",
-                            "pages": [
-                              "models/providers/native/xai/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/native/xai/usage/basic",
-                                  "models/providers/native/xai/usage/basic-stream",
-                                  "models/providers/native/xai/usage/tool-use",
-                                  "models/providers/native/xai/usage/basic-async",
-                                  "models/providers/native/xai/usage/basic-async-stream",
-                                  "models/providers/native/xai/usage/tool-use-stream",
-                                  "models/providers/native/xai/usage/async-tool-use",
-                                  "models/providers/native/xai/usage/structured-output",
-                                  "models/providers/native/xai/usage/image-agent",
-                                  "models/providers/native/xai/usage/image-agent-bytes",
-                                  "models/providers/native/xai/usage/live-search-agent",
-                                  "models/providers/native/xai/usage/live-search-agent-stream",
-                                  "models/providers/native/xai/usage/reasoning-agent"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Local Model Providers",
-                        "pages": [
-                          {
-                            "group": "Ollama",
-                            "pages": [
-                              "models/providers/local/ollama/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/local/ollama/usage/basic",
-                                  "models/providers/local/ollama/usage/basic-stream",
-                                  "models/providers/local/ollama/usage/cloud",
-                                  "models/providers/local/ollama/usage/async-basic",
-                                  "models/providers/local/ollama/usage/async-basic-stream",
-                                  "models/providers/local/ollama/usage/tool-use",
-                                  "models/providers/local/ollama/usage/tool-use-stream",
-                                  "models/providers/local/ollama/usage/knowledge",
-                                  "models/providers/local/ollama/usage/memory",
-                                  "models/providers/local/ollama/usage/demo-deepseek-r1",
-                                  "models/providers/local/ollama/usage/demo-gemma",
-                                  "models/providers/local/ollama/usage/demo-phi4",
-                                  "models/providers/local/ollama/usage/demo-qwen",
-                                  "models/providers/local/ollama/usage/image-agent",
-                                  "models/providers/local/ollama/usage/multimodal",
-                                  "models/providers/local/ollama/usage/set-client",
-                                  "models/providers/local/ollama/usage/set-temperature",
-                                  "models/providers/local/ollama/usage/storage",
-                                  "models/providers/local/ollama/usage/structured-output"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "LlamaCpp",
-                            "pages": [
-                              "models/providers/local/llama-cpp/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/local/llama-cpp/usage/basic",
-                                  "models/providers/local/llama-cpp/usage/basic-stream",
-                                  "models/providers/local/llama-cpp/usage/structured-output",
-                                  "models/providers/local/llama-cpp/usage/tool-use",
-                                  "models/providers/local/llama-cpp/usage/tool-use-stream"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "LM Studio",
-                            "pages": [
-                              "models/providers/local/lmstudio/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/local/lmstudio/usage/basic",
-                                  "models/providers/local/lmstudio/usage/basic-stream",
-                                  "models/providers/local/lmstudio/usage/tool-use",
-                                  "models/providers/local/lmstudio/usage/structured-output",
-                                  "models/providers/local/lmstudio/usage/storage",
-                                  "models/providers/local/lmstudio/usage/knowledge",
-                                  "models/providers/local/lmstudio/usage/image-agent"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "VLLM",
-                            "pages": [
-                              "models/providers/local/vllm/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/local/vllm/usage/basic",
-                                  "models/providers/local/vllm/usage/basic-stream",
-                                  "models/providers/local/vllm/usage/async-basic",
-                                  "models/providers/local/vllm/usage/async-basic-stream",
-                                  "models/providers/local/vllm/usage/code-generation",
-                                  "models/providers/local/vllm/usage/storage",
-                                  "models/providers/local/vllm/usage/memory",
-                                  "models/providers/local/vllm/usage/structured-output",
-                                  "models/providers/local/vllm/usage/tool-use",
-                                  "models/providers/local/vllm/usage/async-tool-use"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Cloud Model Providers",
-                        "pages": [
-                          {
-                            "group": "AWS",
-                            "pages": [
-                              {
-                                "group": "AWS Bedrock",
-                                "pages": [
-                                  "models/providers/cloud/aws-bedrock/overview",
-                                  {
-                                    "group": "Usage",
-                                    "pages": [
-                                      "models/providers/cloud/aws-bedrock/usage/basic",
-                                      "models/providers/cloud/aws-bedrock/usage/basic-stream",
-                                      "models/providers/cloud/aws-bedrock/usage/tool-use",
-                                      "models/providers/cloud/aws-bedrock/usage/structured-output",
-                                      "models/providers/cloud/aws-bedrock/usage/storage",
-                                      "models/providers/cloud/aws-bedrock/usage/knowledge",
-                                      "models/providers/cloud/aws-bedrock/usage/image-agent"
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "group": "AWS Claude",
-                                "pages": [
-                                  "models/providers/cloud/aws-claude/overview",
-                                  {
-                                    "group": "Usage",
-                                    "pages": [
-                                      "models/providers/cloud/aws-claude/usage/basic",
-                                      "models/providers/cloud/aws-claude/usage/basic-stream",
-                                      "models/providers/cloud/aws-claude/usage/tool-use",
-                                      "models/providers/cloud/aws-claude/usage/structured-output",
-                                      "models/providers/cloud/aws-claude/usage/storage",
-                                      "models/providers/cloud/aws-claude/usage/knowledge"
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Azure",
-                            "pages": [
-                              {
-                                "group": "Azure AI Foundry",
-                                "pages": [
-                                  "models/providers/cloud/azure-ai-foundry/overview",
-                                  {
-                                    "group": "Usage",
-                                    "pages": [
-                                      "models/providers/cloud/azure-ai-foundry/usage/basic",
-                                      "models/providers/cloud/azure-ai-foundry/usage/basic-stream",
-                                      "models/providers/cloud/azure-ai-foundry/usage/knowledge",
-                                      "models/providers/cloud/azure-ai-foundry/usage/storage",
-                                      "models/providers/cloud/azure-ai-foundry/usage/structured-output",
-                                      "models/providers/cloud/azure-ai-foundry/usage/tool-use"
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "group": "Azure OpenAI",
-                                "pages": [
-                                  "models/providers/cloud/azure-openai/overview",
-                                  {
-                                    "group": "Usage",
-                                    "pages": [
-                                      "models/providers/cloud/azure-openai/usage/basic",
-                                      "models/providers/cloud/azure-openai/usage/basic-stream",
-                                      "models/providers/cloud/azure-openai/usage/knowledge",
-                                      "models/providers/cloud/azure-openai/usage/storage",
-                                      "models/providers/cloud/azure-openai/usage/structured-output",
-                                      "models/providers/cloud/azure-openai/usage/tool-use"
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "IBM WatsonX",
-                            "pages": [
-                              "models/providers/cloud/ibm-watsonx/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/cloud/ibm-watsonx/usage/basic",
-                                  "models/providers/cloud/ibm-watsonx/usage/basic-stream",
-                                  "models/providers/cloud/ibm-watsonx/usage/async-basic-stream",
-                                  "models/providers/cloud/ibm-watsonx/usage/async-basic",
-                                  "models/providers/cloud/ibm-watsonx/usage/tool-use",
-                                  "models/providers/cloud/ibm-watsonx/usage/async-tool-use",
-                                  "models/providers/cloud/ibm-watsonx/usage/structured-output",
-                                  "models/providers/cloud/ibm-watsonx/usage/storage",
-                                  "models/providers/cloud/ibm-watsonx/usage/knowledge",
-                                  "models/providers/cloud/ibm-watsonx/usage/image-agent-bytes"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Vertex AI",
-                            "pages": [
-                              "models/providers/cloud/vertexai-claude/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/cloud/vertexai-claude/usage/basic",
-                                  "models/providers/cloud/vertexai-claude/usage/basic-stream",
-                                  "models/providers/cloud/vertexai-claude/usage/tool-use",
-                                  "models/providers/cloud/vertexai-claude/usage/structured-output",
-                                  "models/providers/cloud/vertexai-claude/usage/pdf-input-local",
-                                  "models/providers/cloud/vertexai-claude/usage/pdf-input-url",
-                                  "models/providers/cloud/vertexai-claude/usage/pdf-input-bytes",
-                                  "models/providers/cloud/vertexai-claude/usage/image-input-bytes",
-                                  "models/providers/cloud/vertexai-claude/usage/image-input-url"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Model Gateways & Aggregators",
-                        "pages": [
-                          {
-                            "group": "AIML API",
-                            "pages": [
-                              "models/providers/gateways/aimlapi/overview",
-                              {
-                                "group": "Usage",
-                                "pages": []
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Cerebras",
-                            "pages": [
-                              {
-                                "group": "Cerebras",
-                                "pages": [
-                                  "models/providers/gateways/cerebras/overview",
-                                  {
-                                    "group": "Usage",
-                                    "pages": [
-                                      "models/providers/gateways/cerebras/usage/basic",
-                                      "models/providers/gateways/cerebras/usage/basic-stream",
-                                      "models/providers/gateways/cerebras/usage/tool-use",
-                                      "models/providers/gateways/cerebras/usage/structured-output",
-                                      "models/providers/gateways/cerebras/usage/storage",
-                                      "models/providers/gateways/cerebras/usage/knowledge"
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "group": "Cerebras OpenAI",
-                                "pages": [
-                                  "models/providers/gateways/cerebras-openai/overview",
-                                  {
-                                    "group": "Usage",
-                                    "pages": [
-                                      "models/providers/gateways/cerebras-openai/usage/basic",
-                                      "models/providers/gateways/cerebras-openai/usage/basic-stream",
-                                      "models/providers/gateways/cerebras-openai/usage/tool-use",
-                                      "models/providers/gateways/cerebras-openai/usage/structured-output",
-                                      "models/providers/gateways/cerebras-openai/usage/storage",
-                                      "models/providers/gateways/cerebras-openai/usage/knowledge"
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "CometAPI",
-                            "pages": [
-                              "models/providers/gateways/cometapi/overview",
-                              {
-                                "group": "Usage",
-                                "pages": []
-                              }
-                            ]
-                          },
-                          {
-                            "group": "DeepInfra",
-                            "pages": [
-                              "models/providers/gateways/deepinfra/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/deepinfra/usage/basic",
-                                  "models/providers/gateways/deepinfra/usage/basic-stream",
-                                  "models/providers/gateways/deepinfra/usage/tool-use",
-                                  "models/providers/gateways/deepinfra/usage/structured-output"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Fireworks",
-                            "pages": [
-                              "models/providers/gateways/fireworks/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/fireworks/usage/basic",
-                                  "models/providers/gateways/fireworks/usage/basic-stream",
-                                  "models/providers/gateways/fireworks/usage/tool-use",
-                                  "models/providers/gateways/fireworks/usage/structured-output"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Groq",
-                            "pages": [
-                              "models/providers/gateways/groq/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/groq/usage/basic",
-                                  "models/providers/gateways/groq/usage/basic-stream",
-                                  "models/providers/gateways/groq/usage/tool-use",
-                                  "models/providers/gateways/groq/usage/structured-output",
-                                  "models/providers/gateways/groq/usage/storage",
-                                  "models/providers/gateways/groq/usage/knowledge",
-                                  "models/providers/gateways/groq/usage/image-agent",
-                                  "models/providers/gateways/groq/usage/deep-knowledge",
-                                  "models/providers/gateways/groq/usage/browser-search",
-                                  "models/providers/gateways/groq/usage/metrics",
-                                  "models/providers/gateways/groq/usage/reasoning-agent",
-                                  "models/providers/gateways/groq/usage/transcription-agent",
-                                  "models/providers/gateways/groq/usage/translation-agent"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Hugging Face",
-                            "pages": [
-                              "models/providers/gateways/huggingface/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/huggingface/usage/basic",
-                                  "models/providers/gateways/huggingface/usage/basic-stream",
-                                  "models/providers/gateways/huggingface/usage/async-basic",
-                                  "models/providers/gateways/huggingface/usage/async-basic-stream",
-                                  "models/providers/gateways/huggingface/usage/llama-essay-writer",
-                                  "models/providers/gateways/huggingface/usage/tool-use"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "LangDB",
-                            "pages": [
-                              "models/providers/gateways/langdb/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/langdb/usage/basic",
-                                  "models/providers/gateways/langdb/usage/basic-stream",
-                                  "models/providers/gateways/langdb/usage/data-analyst",
-                                  "models/providers/gateways/langdb/usage/structured-output",
-                                  "models/providers/gateways/langdb/usage/tool-use"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "LiteLLM",
-                            "pages": [
-                              {
-                                "group": "LiteLLM",
-                                "pages": [
-                                  "models/providers/gateways/litellm/overview",
-                                  {
-                                    "group": "Usage",
-                                    "pages": [
-                                      "models/providers/gateways/litellm/usage/basic",
-                                      "models/providers/gateways/litellm/usage/basic-stream",
-                                      "models/providers/gateways/litellm/usage/async-basic",
-                                      "models/providers/gateways/litellm/usage/async-basic-stream",
-                                      "models/providers/gateways/litellm/usage/tool-use",
-                                      "models/providers/gateways/litellm/usage/async-tool-use",
-                                      "models/providers/gateways/litellm/usage/audio-input-agent",
-                                      "models/providers/gateways/litellm/usage/knowledge",
-                                      "models/providers/gateways/litellm/usage/structured-output",
-                                      "models/providers/gateways/litellm/usage/storage"
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "group": "LiteLLM OpenAI",
-                                "pages": [
-                                  "models/providers/gateways/litellm-openai/overview",
-                                  {
-                                    "group": "Usage",
-                                    "pages": [
-                                      "models/providers/gateways/litellm-openai/usage/basic",
-                                      "models/providers/gateways/litellm-openai/usage/basic-stream",
-                                      "models/providers/gateways/litellm-openai/usage/tool-use"
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Nebius",
-                            "pages": [
-                              "models/providers/gateways/nebius/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/nebius/usage/basic",
-                                  "models/providers/gateways/nebius/usage/basic-stream",
-                                  "models/providers/gateways/nebius/usage/tool-use",
-                                  "models/providers/gateways/nebius/usage/structured-output",
-                                  "models/providers/gateways/nebius/usage/storage",
-                                  "models/providers/gateways/nebius/usage/knowledge"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Neosantara",
-                            "pages": [
-                              "models/providers/gateways/neosantara/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/neosantara/usage/basic",
-                                  "models/providers/gateways/neosantara/usage/basic-stream",
-                                  "models/providers/gateways/neosantara/usage/tool-use",
-                                  "models/providers/gateways/neosantara/usage/structured-output",
-                                  "models/providers/gateways/neosantara/usage/async-basic",
-                                  "models/providers/gateways/neosantara/usage/async-basic-stream",
-                                  "models/providers/gateways/neosantara/usage/async-tool-use"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Nexus",
-                            "pages": [
-                              "models/providers/gateways/nexus/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/nexus/usage/basic",
-                                  "models/providers/gateways/nexus/usage/basic-stream",
-                                  "models/providers/gateways/nexus/usage/async-basic",
-                                  "models/providers/gateways/nexus/usage/async-basic-stream",
-                                  "models/providers/gateways/nexus/usage/tool-use",
-                                  "models/providers/gateways/nexus/usage/async-tool-use"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "NVIDIA",
-                            "pages": [
-                              "models/providers/gateways/nvidia/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/nvidia/usage/basic",
-                                  "models/providers/gateways/nvidia/usage/basic-stream",
-                                  "models/providers/gateways/nvidia/usage/async-basic",
-                                  "models/providers/gateways/nvidia/usage/async-basic-stream",
-                                  "models/providers/gateways/nvidia/usage/tool-use",
-                                  "models/providers/gateways/nvidia/usage/async-tool-use"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "OpenRouter",
-                            "pages": [
-                              "models/providers/gateways/openrouter/overview",
-                              {
-                                "group": "Usage",
-                                "pages": []
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Portkey",
-                            "pages": [
-                              "models/providers/gateways/portkey/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/portkey/usage/basic",
-                                  "models/providers/gateways/portkey/usage/basic-stream",
-                                  "models/providers/gateways/portkey/usage/tool-use",
-                                  "models/providers/gateways/portkey/usage/tool-use-stream",
-                                  "models/providers/gateways/portkey/usage/structured-output"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Requesty",
-                            "pages": [
-                              "models/providers/gateways/requesty/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/requesty/usage/basic",
-                                  "models/providers/gateways/requesty/usage/basic-stream",
-                                  "models/providers/gateways/requesty/usage/tool-use",
-                                  "models/providers/gateways/requesty/usage/structured-output"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Sambanova",
-                            "pages": [
-                              "models/providers/gateways/sambanova/overview",
-                              {
-                                "group": "Usage",
-                                "pages": []
-                              }
-                            ]
-                          },
-                          {
-                            "group": "SiliconFlow",
-                            "pages": [
-                              "models/providers/gateways/siliconflow/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/siliconflow/usage/async-basic-stream",
-                                  "models/providers/gateways/siliconflow/usage/async-basic",
-                                  "models/providers/gateways/siliconflow/usage/async-tool-use",
-                                  "models/providers/gateways/siliconflow/usage/basic",
-                                  "models/providers/gateways/siliconflow/usage/basic-stream",
-                                  "models/providers/gateways/siliconflow/usage/tool-use"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "group": "Together",
-                            "pages": [
-                              "models/providers/gateways/together/overview",
-                              {
-                                "group": "Usage",
-                                "pages": [
-                                  "models/providers/gateways/together/usage/basic",
-                                  "models/providers/gateways/together/usage/basic-stream",
-                                  "models/providers/gateways/together/usage/image-agent",
-                                  "models/providers/gateways/together/usage/image-agent-bytes",
-                                  "models/providers/gateways/together/usage/image-agent-memory",
-                                  "models/providers/gateways/together/usage/structured-output",
-                                  "models/providers/gateways/together/usage/tool-use"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "models/providers/openai-like"
-                    ]
-                  }
+                  "models/cache-response"
                 ]
               },
+              {
+                "group": "Database",
+                "pages": [
+                  "database/overview",
+                  "database/chat-history",
+                  "database/session-storage"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Capabilities",
+            "pages": [
               {
                 "group": "Tools",
                 "pages": [
@@ -2035,308 +510,173 @@
                     ]
                   }
                 ]
-              }
-            ]
-          },
-          {
-            "group": "Advanced",
-            "pages": [
+              },
               {
-                "group": "Session Management",
+                "group": "Knowledge & RAG",
                 "pages": [
-                  "sessions/overview",
+                  "knowledge/overview",
+                  "knowledge/quickstart",
                   {
-                    "group": "Persisting Sessions",
+                    "group": "Concepts",
                     "pages": [
-                      "sessions/persisting-sessions/overview",
-                      "sessions/persisting-sessions/storage-control"
-                    ]
-                  },
-                  "sessions/session-management",
-                  "sessions/history-management",
-                  "sessions/session-summaries",
-                  "sessions/workflow-sessions",
-                  {
-                    "group": "Metrics",
-                    "pages": [
-                      "sessions/metrics/overview",
+                      "knowledge/concepts/vector-db",
+                      "knowledge/concepts/contents-db",
                       {
-                        "group": "Agent Metrics",
+                        "group": "Search & Retrieval",
                         "pages": [
-                          "sessions/metrics/agent",
-                          {
-                            "group": "Usage",
-                            "pages": [
-                              "sessions/metrics/usage/agent-extra-metrics",
-                              "sessions/metrics/usage/agent-metrics"
-                            ]
-                          }
+                          "knowledge/concepts/search-and-retrieval/overview",
+                          "knowledge/concepts/search-and-retrieval/hybrid-search",
+                          "knowledge/concepts/search-and-retrieval/vector-search",
+                          "knowledge/concepts/search-and-retrieval/keyword-search",
+                          "knowledge/concepts/search-and-retrieval/agentic-rag",
+                          "knowledge/concepts/search-and-retrieval/custom-retriever"
                         ]
                       },
-                      {
-                        "group": "Team Metrics",
-                        "pages": [
-                          "sessions/metrics/team",
-                          {
-                            "group": "Usage",
-                            "pages": ["sessions/metrics/usage/team-metrics"]
-                          }
-                        ]
-                      },
-                      "sessions/metrics/workflow"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Context Management",
-                "pages": [
-                  "context/overview",
-                  {
-                    "group": "For Agents",
-                    "pages": [
-                      "context/agent/overview",
-                      "context/agent/instructions",
-                      "context/agent/dynamic-instructions",
-                      "context/agent/instructions-via-function",
-                      "context/agent/few-shot-learning",
-                      "context/agent/datetime-instructions",
-                      "context/agent/location-instructions",
-                      "context/agent/filter-tool-calls-from-history"
+                      "knowledge/concepts/readers/overview",
+                      "knowledge/concepts/chunking/overview",
+                      "knowledge/concepts/filters/overview"
                     ]
                   },
-                  {
-                    "group": "For Teams",
-                    "pages": [
-                      "context/team/overview",
-                      "context/team/filter-tool-calls-from-history"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "State Management",
-                "pages": [
-                  "state/overview",
-                  {
-                    "group": "For Agents",
-                    "pages": [
-                      "state/agent/overview",
-                      "state/agent/session-state-basic",
-                      "state/agent/session-state-in-instructions",
-                      "state/agent/session-state-in-context",
-                      "state/agent/session-state-advanced",
-                      "state/agent/session-state-multiple-users",
-                      "state/agent/agentic-session-state",
-                      "state/agent/dynamic-session-state",
-                      "state/agent/change-state-on-run",
-                      "state/agent/last-n-session-messages"
-                    ]
-                  },
-                  {
-                    "group": "For Teams",
-                    "pages": [
-                      "state/team/overview",
-                      "state/team/agentic-session-state",
-                      "state/team/change-state-on-run",
-                      "state/team/session-state-in-instructions",
-                      "state/team/share-member-interactions"
-                    ]
-                  },
-                  {
-                    "group": "For Workflows",
-                    "pages": [
-                      "state/workflows/overview",
-                      "state/workflows/access-session-state-in-custom-python-function-step",
-                      "state/workflows/access-session-state-in-condition-evaluator-function",
-                      "state/workflows/access-session-state-in-router-selector-function"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Chat History",
-                "pages": [
-                  "history/overview",
-                  {
-                    "group": "For Agents",
-                    "pages": [
-                      "history/agent/overview",
-                      "history/agent/chat-history"
-                    ]
-                  },
-                  {
-                    "group": "For Teams",
-                    "pages": [
-                      "history/team/overview",
-                      "history/team/respond-directly-with-history",
-                      "history/team/team-history",
-                      "history/team/history-of-members",
-                      "history/team/share-member-interactions"
-                    ]
-                  },
-                  {
-                    "group": "For Workflows",
-                    "pages": [
-                      "history/workflow/overview",
-                      "history/workflow/single-step-continuous-execution-workflow",
-                      "history/workflow/workflow-with-history-enabled-for-steps",
-                      "history/workflow/enable-history-for-step",
-                      "history/workflow/get-history-in-function",
-                      "history/workflow/multi-purpose-cli",
-                      "history/workflow/intent-routing-with-history"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Context Compression",
-                "tag": "BETA",
-                "pages": ["compression/overview", "compression/token-counting"]
-              },
-              {
-                "group": "Dependency Injection",
-                "pages": [
-                  "dependencies/overview",
-                  {
-                    "group": "For Agents",
-                    "pages": [
-                      "dependencies/agent/overview",
-                      {
-                        "group": "Usage",
-                        "pages": [
-                          "dependencies/agent/add-dependencies-run",
-                          "dependencies/agent/add-dependencies-to-context",
-                          "dependencies/agent/access-dependencies-in-tool"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "For Teams",
-                    "pages": [
-                      "dependencies/team/overview",
-                      {
-                        "group": "Usage",
-                        "pages": [
-                          "dependencies/team/add-dependencies-run",
-                          "dependencies/team/add-dependencies-to-context",
-                          "dependencies/team/reference-dependencies",
-                          "dependencies/team/access-dependencies-in-tool"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Hooks",
-                "pages": [
-                  "hooks/overview",
-                  {
-                    "group": "Agent",
-                    "pages": [
-                      "hooks/usage/agent/input-validation-pre-hook",
-                      "hooks/usage/agent/input-transformation-pre-hook",
-                      "hooks/usage/agent/output-validation-post-hook",
-                      "hooks/usage/agent/output-transformation-post-hook"
-                    ]
-                  },
-                  {
-                    "group": "Team",
-                    "pages": [
-                      "hooks/usage/team/input-validation-pre-hook",
-                      "hooks/usage/team/input-transformation-pre-hook",
-                      "hooks/usage/team/output-validation-post-hook",
-                      "hooks/usage/team/output-transformation-post-hook"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Guardrails",
-                "pages": [
-                  "guardrails/overview",
-                  {
-                    "group": "Included Guardrails",
-                    "pages": [
-                      "guardrails/included/prompt-injection",
-                      "guardrails/included/pii",
-                      "guardrails/included/openai-moderation"
-                    ]
-                  },
-                  {
-                    "group": "Agent",
-                    "pages": [
-                      "guardrails/usage/agent/pii-detection",
-                      "guardrails/usage/agent/prompt-injection",
-                      "guardrails/usage/agent/openai-moderation"
-                    ]
-                  },
-                  {
-                    "group": "Team",
-                    "pages": [
-                      "guardrails/usage/team/pii-detection",
-                      "guardrails/usage/team/prompt-injection",
-                      "guardrails/usage/team/openai-moderation"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Human-in-the-Loop",
-                "pages": [
-                  "hitl/overview",
-                  "hitl/user-confirmation",
-                  "hitl/user-input",
-                  "hitl/dynamic-user-input",
-                  "hitl/external-execution",
                   {
                     "group": "Usage",
                     "pages": [
-                      "hitl/usage/agentic-user-input",
                       {
-                        "group": "Confirmation Required",
+                        "group": "Agents",
                         "pages": [
-                          "hitl/usage/confirmation-required",
-                          "hitl/usage/confirmation-required-async",
-                          "hitl/usage/confirmation-required-mixed-tools",
-                          "hitl/usage/confirmation-required-multiple-tools",
-                          "hitl/usage/confirmation-required-stream-async",
-                          "hitl/usage/confirmation-required-toolkit",
-                          "hitl/usage/confirmation-required-with-history",
-                          "hitl/usage/confirmation-required-with-run-id"
+                          "knowledge/agents/overview",
+                          "knowledge/agents/agentic-rag-lancedb",
+                          "knowledge/agents/agentic-rag-pgvector",
+                          "knowledge/agents/traditional-rag-lancedb",
+                          "knowledge/agents/traditional-rag-pgvector"
                         ]
                       },
                       {
-                        "group": "User Input Required",
+                        "group": "Teams",
                         "pages": [
-                          "hitl/usage/user-input-required",
-                          "hitl/usage/user-input-required-all-fields",
-                          "hitl/usage/user-input-required-async",
-                          "hitl/usage/user-input-required-stream-async"
+                          "knowledge/teams/overview",
+                          "knowledge/teams/team-with-knowledge",
+                          "knowledge/teams/distributed-rag-pgvector",
+                          "knowledge/teams/distributed-rag-lancedb"
                         ]
                       },
                       {
-                        "group": "External Tool Execution",
+                        "group": "Readers",
                         "pages": [
-                          "hitl/usage/external-tool-execution",
-                          "hitl/usage/external-tool-execution-async",
-                          "hitl/usage/external-tool-execution-stream-async",
-                          "hitl/usage/external-tool-execution-toolkit"
+                          "knowledge/concepts/readers/pdf-reader",
+                          "knowledge/concepts/readers/csv-reader",
+                          "knowledge/concepts/readers/json-reader",
+                          "knowledge/concepts/readers/markdown-reader",
+                          "knowledge/concepts/readers/website-reader",
+                          "knowledge/concepts/readers/youtube-reader"
+                        ]
+                      },
+                      {
+                        "group": "Chunkers",
+                        "pages": [
+                          "knowledge/concepts/chunking/fixed-size-chunking",
+                          "knowledge/concepts/chunking/semantic-chunking",
+                          "knowledge/concepts/chunking/recursive-chunking",
+                          "knowledge/concepts/chunking/document-chunking",
+                          "knowledge/concepts/chunking/csv-row-chunking",
+                          "knowledge/concepts/chunking/markdown-chunking",
+                          "knowledge/concepts/chunking/agentic-chunking",
+                          "knowledge/concepts/chunking/code-chunking",
+                          "knowledge/concepts/chunking/custom-chunking"
                         ]
                       }
                     ]
-                  }
+                  },
+                  "knowledge/concepts/performance-tips"
                 ]
               },
               {
-                "group": "Run Cancellation",
+                "group": "Memory",
                 "pages": [
-                  "run-cancellation/overview",
-                  "run-cancellation/agent-cancel-run",
-                  "run-cancellation/team-cancel-run",
-                  "run-cancellation/workflow-cancel-run"
+                  "memory/overview",
+                  {
+                    "group": "Working with Memories",
+                    "pages": [
+                      "memory/working-with-memories/overview",
+                      "memory/working-with-memories/memory-optimization",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          {
+                            "group": "Storage Usage",
+                            "pages": [
+                              "memory/working-with-memories/mongodb-memory",
+                              "memory/working-with-memories/postgres-memory",
+                              "memory/working-with-memories/sqlite-memory",
+                              "memory/working-with-memories/redis-memory"
+                            ]
+                          },
+                          {
+                            "group": "Memory Manager Usage",
+                            "pages": [
+                              "memory/working-with-memories/standalone-memory",
+                              "memory/working-with-memories/memory-creation",
+                              "memory/working-with-memories/custom-memory-instructions",
+                              "memory/working-with-memories/memory-search",
+                              "memory/working-with-memories/memory-optimization"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Agents with Memory",
+                    "pages": [
+                      "memory/agent/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "memory/agent/agent-with-memory",
+                          "memory/agent/agentic-memory",
+                          "memory/agent/agents-share-memory",
+                          "memory/agent/custom-memory-manager",
+                          "memory/agent/multi-user-multi-session-chat",
+                          "memory/agent/multi-user-multi-session-chat-concurrent",
+                          "memory/agent/share-memory-and-history-between-agents"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Teams with Memory",
+                    "pages": [
+                      "memory/team/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "memory/team/team-with-memory-manager",
+                          "memory/team/team-with-agentic-memory"
+                        ]
+                      }
+                    ]
+                  },
+                  "memory/best-practices"
+                ]
+              },
+              {
+                "group": "Learning",
+                "pages": [
+                  "learning/overview",
+                  "learning/quickstart",
+                  {
+                    "group": "Learning Stores",
+                    "pages": [
+                      "learning/stores/intro",
+                      "learning/stores/user-profile",
+                      "learning/stores/user-memory",
+                      "learning/stores/session-context",
+                      "learning/stores/entity-memory",
+                      "learning/stores/learned-knowledge",
+                      "learning/stores/decision-log"
+                    ]
+                  },
+                  "learning/learning-modes",
+                  "learning/custom-schemas"
                 ]
               },
               {
@@ -2387,7 +727,9 @@
                           },
                           {
                             "group": "Ollama",
-                            "pages": ["reasoning/usage/models/ollama/ollama"]
+                            "pages": [
+                              "reasoning/usage/models/ollama/ollama"
+                            ]
                           },
                           {
                             "group": "OpenAI",
@@ -2505,7 +847,9 @@
                       },
                       {
                         "group": "Files",
-                        "pages": ["multimodal/agent/usage/file-input-for-tool"]
+                        "pages": [
+                          "multimodal/agent/usage/file-input-for-tool"
+                        ]
                       }
                     ]
                   },
@@ -2538,19 +882,283 @@
                     ]
                   }
                 ]
+              }
+            ]
+          },
+          {
+            "group": "Context",
+            "pages": [
+              {
+                "group": "Session Management",
+                "pages": [
+                  "sessions/overview",
+                  {
+                    "group": "Persisting Sessions",
+                    "pages": [
+                      "sessions/persisting-sessions/overview",
+                      "sessions/persisting-sessions/storage-control"
+                    ]
+                  },
+                  "sessions/session-management",
+                  "sessions/history-management",
+                  "sessions/session-summaries",
+                  "sessions/workflow-sessions",
+                  {
+                    "group": "Metrics",
+                    "pages": [
+                      "sessions/metrics/overview",
+                      {
+                        "group": "Agent Metrics",
+                        "pages": [
+                          "sessions/metrics/agent",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "sessions/metrics/usage/agent-extra-metrics",
+                              "sessions/metrics/usage/agent-metrics"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Team Metrics",
+                        "pages": [
+                          "sessions/metrics/team",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "sessions/metrics/usage/team-metrics"
+                            ]
+                          }
+                        ]
+                      },
+                      "sessions/metrics/workflow"
+                    ]
+                  }
+                ]
               },
               {
-                "group": "Tracing",
+                "group": "State Management",
                 "pages": [
-                  "tracing/overview",
-                  "tracing/basic-setup",
-                  "tracing/db-functions",
+                  "state/overview",
+                  {
+                    "group": "For Agents",
+                    "pages": [
+                      "state/agent/overview",
+                      "state/agent/session-state-basic",
+                      "state/agent/session-state-in-instructions",
+                      "state/agent/session-state-in-context",
+                      "state/agent/session-state-advanced",
+                      "state/agent/session-state-multiple-users",
+                      "state/agent/agentic-session-state",
+                      "state/agent/dynamic-session-state",
+                      "state/agent/change-state-on-run",
+                      "state/agent/last-n-session-messages"
+                    ]
+                  },
+                  {
+                    "group": "For Teams",
+                    "pages": [
+                      "state/team/overview",
+                      "state/team/agentic-session-state",
+                      "state/team/change-state-on-run",
+                      "state/team/session-state-in-instructions",
+                      "state/team/share-member-interactions"
+                    ]
+                  },
+                  {
+                    "group": "For Workflows",
+                    "pages": [
+                      "state/workflows/overview",
+                      "state/workflows/access-session-state-in-custom-python-function-step",
+                      "state/workflows/access-session-state-in-condition-evaluator-function",
+                      "state/workflows/access-session-state-in-router-selector-function"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Context Management",
+                "pages": [
+                  "context/overview",
+                  {
+                    "group": "For Agents",
+                    "pages": [
+                      "context/agent/overview",
+                      "context/agent/instructions",
+                      "context/agent/dynamic-instructions",
+                      "context/agent/instructions-via-function",
+                      "context/agent/few-shot-learning",
+                      "context/agent/datetime-instructions",
+                      "context/agent/location-instructions",
+                      "context/agent/filter-tool-calls-from-history"
+                    ]
+                  },
+                  {
+                    "group": "For Teams",
+                    "pages": [
+                      "context/team/overview",
+                      "context/team/filter-tool-calls-from-history"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Chat History",
+                "pages": [
+                  "history/overview",
+                  {
+                    "group": "For Agents",
+                    "pages": [
+                      "history/agent/overview",
+                      "history/agent/chat-history"
+                    ]
+                  },
+                  {
+                    "group": "For Teams",
+                    "pages": [
+                      "history/team/overview",
+                      "history/team/respond-directly-with-history",
+                      "history/team/team-history",
+                      "history/team/history-of-members",
+                      "history/team/share-member-interactions"
+                    ]
+                  },
+                  {
+                    "group": "For Workflows",
+                    "pages": [
+                      "history/workflow/overview",
+                      "history/workflow/single-step-continuous-execution-workflow",
+                      "history/workflow/workflow-with-history-enabled-for-steps",
+                      "history/workflow/enable-history-for-step",
+                      "history/workflow/get-history-in-function",
+                      "history/workflow/multi-purpose-cli",
+                      "history/workflow/intent-routing-with-history"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Context Compression",
+                "tag": "BETA",
+                "pages": [
+                  "compression/overview",
+                  "compression/token-counting"
+                ]
+              },
+              {
+                "group": "Dependency Injection",
+                "pages": [
+                  "dependencies/overview",
+                  {
+                    "group": "For Agents",
+                    "pages": [
+                      "dependencies/agent/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "dependencies/agent/add-dependencies-run",
+                          "dependencies/agent/add-dependencies-to-context",
+                          "dependencies/agent/access-dependencies-in-tool"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "For Teams",
+                    "pages": [
+                      "dependencies/team/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "dependencies/team/add-dependencies-run",
+                          "dependencies/team/add-dependencies-to-context",
+                          "dependencies/team/reference-dependencies",
+                          "dependencies/team/access-dependencies-in-tool"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Production",
+            "pages": [
+              {
+                "group": "Guardrails",
+                "pages": [
+                  "guardrails/overview",
+                  {
+                    "group": "Included Guardrails",
+                    "pages": [
+                      "guardrails/included/prompt-injection",
+                      "guardrails/included/pii",
+                      "guardrails/included/openai-moderation"
+                    ]
+                  },
+                  {
+                    "group": "Agent",
+                    "pages": [
+                      "guardrails/usage/agent/pii-detection",
+                      "guardrails/usage/agent/prompt-injection",
+                      "guardrails/usage/agent/openai-moderation"
+                    ]
+                  },
+                  {
+                    "group": "Team",
+                    "pages": [
+                      "guardrails/usage/team/pii-detection",
+                      "guardrails/usage/team/prompt-injection",
+                      "guardrails/usage/team/openai-moderation"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Human-in-the-Loop",
+                "pages": [
+                  "hitl/overview",
+                  "hitl/user-confirmation",
+                  "hitl/user-input",
+                  "hitl/dynamic-user-input",
+                  "hitl/external-execution",
                   {
                     "group": "Usage",
                     "pages": [
-                      "tracing/usage/basic-agent-tracing",
-                      "tracing/usage/basic-team-tracing",
-                      "tracing/usage/basic-workflow-tracing"
+                      "hitl/usage/agentic-user-input",
+                      {
+                        "group": "Confirmation Required",
+                        "pages": [
+                          "hitl/usage/confirmation-required",
+                          "hitl/usage/confirmation-required-async",
+                          "hitl/usage/confirmation-required-mixed-tools",
+                          "hitl/usage/confirmation-required-multiple-tools",
+                          "hitl/usage/confirmation-required-stream-async",
+                          "hitl/usage/confirmation-required-toolkit",
+                          "hitl/usage/confirmation-required-with-history",
+                          "hitl/usage/confirmation-required-with-run-id"
+                        ]
+                      },
+                      {
+                        "group": "User Input Required",
+                        "pages": [
+                          "hitl/usage/user-input-required",
+                          "hitl/usage/user-input-required-all-fields",
+                          "hitl/usage/user-input-required-async",
+                          "hitl/usage/user-input-required-stream-async"
+                        ]
+                      },
+                      {
+                        "group": "External Tool Execution",
+                        "pages": [
+                          "hitl/usage/external-tool-execution",
+                          "hitl/usage/external-tool-execution-async",
+                          "hitl/usage/external-tool-execution-stream-async",
+                          "hitl/usage/external-tool-execution-toolkit"
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -2638,9 +1246,1447 @@
                 ]
               },
               {
+                "group": "Hooks",
+                "pages": [
+                  "hooks/overview",
+                  {
+                    "group": "Agent",
+                    "pages": [
+                      "hooks/usage/agent/input-validation-pre-hook",
+                      "hooks/usage/agent/input-transformation-pre-hook",
+                      "hooks/usage/agent/output-validation-post-hook",
+                      "hooks/usage/agent/output-transformation-post-hook"
+                    ]
+                  },
+                  {
+                    "group": "Team",
+                    "pages": [
+                      "hooks/usage/team/input-validation-pre-hook",
+                      "hooks/usage/team/input-transformation-pre-hook",
+                      "hooks/usage/team/output-validation-post-hook",
+                      "hooks/usage/team/output-transformation-post-hook"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Tracing",
+                "pages": [
+                  "tracing/overview",
+                  "tracing/basic-setup",
+                  "tracing/db-functions",
+                  {
+                    "group": "Usage",
+                    "pages": [
+                      "tracing/usage/basic-agent-tracing",
+                      "tracing/usage/basic-team-tracing",
+                      "tracing/usage/basic-workflow-tracing"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Run Cancellation",
+                "pages": [
+                  "run-cancellation/overview",
+                  "run-cancellation/agent-cancel-run",
+                  "run-cancellation/team-cancel-run",
+                  "run-cancellation/workflow-cancel-run"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Providers",
+            "pages": [
+              {
+                "group": "Model Providers",
+                "pages": [
+                  "models/providers/model-index",
+                  {
+                    "group": "Native Model Providers",
+                    "pages": [
+                      {
+                        "group": "Anthropic",
+                        "pages": [
+                          "models/providers/native/anthropic/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/native/anthropic/usage/basic",
+                              "models/providers/native/anthropic/usage/basic-stream",
+                              "models/providers/native/anthropic/usage/betas",
+                              "models/providers/native/anthropic/usage/code-execution",
+                              "models/providers/native/anthropic/usage/context-management",
+                              "models/providers/native/anthropic/usage/skills",
+                              "models/providers/native/anthropic/usage/tool-use",
+                              "models/providers/native/anthropic/usage/structured-output",
+                              "models/providers/native/anthropic/usage/structured-output-stream",
+                              "models/providers/native/anthropic/usage/structured-output-strict-tools",
+                              "models/providers/native/anthropic/usage/knowledge",
+                              "models/providers/native/anthropic/usage/file-upload",
+                              "models/providers/native/anthropic/usage/image-input-bytes",
+                              "models/providers/native/anthropic/usage/image-input-url",
+                              "models/providers/native/anthropic/usage/pdf-input-bytes",
+                              "models/providers/native/anthropic/usage/pdf-input-local",
+                              "models/providers/native/anthropic/usage/pdf-input-url",
+                              "models/providers/native/anthropic/usage/prompt-caching",
+                              "models/providers/native/anthropic/usage/cache-response",
+                              "models/providers/native/anthropic/usage/web-fetch"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Cohere",
+                        "pages": [
+                          "models/providers/native/cohere/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/native/cohere/usage/basic",
+                              "models/providers/native/cohere/usage/basic-stream",
+                              "models/providers/native/cohere/usage/image-agent",
+                              "models/providers/native/cohere/usage/tool-use",
+                              "models/providers/native/cohere/usage/structured-output",
+                              "models/providers/native/cohere/usage/storage",
+                              "models/providers/native/cohere/usage/knowledge"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Dashscope",
+                        "pages": [
+                          "models/providers/native/dashscope/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/native/dashscope/usage/basic",
+                              "models/providers/native/dashscope/usage/basic-stream",
+                              "models/providers/native/dashscope/usage/tool-use",
+                              "models/providers/native/dashscope/usage/image-agent",
+                              "models/providers/native/dashscope/usage/image-agent-bytes",
+                              "models/providers/native/dashscope/usage/structured-output",
+                              "models/providers/native/dashscope/usage/thinking-agent"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "DeepSeek",
+                        "pages": [
+                          "models/providers/native/deepseek/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/native/deepseek/usage/basic",
+                              "models/providers/native/deepseek/usage/basic-stream",
+                              "models/providers/native/deepseek/usage/tool-use",
+                              "models/providers/native/deepseek/usage/structured-output"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Google",
+                        "pages": [
+                          "models/providers/native/google/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/native/google/usage/basic",
+                              "models/providers/native/google/usage/basic-stream",
+                              "models/providers/native/google/usage/structured-output",
+                              "models/providers/native/google/usage/tool-use",
+                              "models/providers/native/google/usage/storage",
+                              "models/providers/native/google/usage/knowledge",
+                              "models/providers/native/google/usage/image-input",
+                              "models/providers/native/google/usage/image-input-file-upload",
+                              "models/providers/native/google/usage/image-generation",
+                              "models/providers/native/google/usage/image-generation-stream",
+                              "models/providers/native/google/usage/image-editing",
+                              "models/providers/native/google/usage/imagen-tool",
+                              "models/providers/native/google/usage/imagen-tool-advanced",
+                              "models/providers/native/google/usage/vertexai",
+                              "models/providers/native/google/usage/grounding",
+                              "models/providers/native/google/usage/url-context",
+                              "models/providers/native/google/usage/url-context-with-search",
+                              "models/providers/native/google/usage/flash-thinking",
+                              "models/providers/native/google/usage/audio-input-bytes-content",
+                              "models/providers/native/google/usage/audio-input-file-upload",
+                              "models/providers/native/google/usage/audio-input-local-file-upload",
+                              "models/providers/native/google/usage/pdf-input-local",
+                              "models/providers/native/google/usage/pdf-input-url",
+                              "models/providers/native/google/usage/gcs-file-input",
+                              "models/providers/native/google/usage/external-url-input",
+                              "models/providers/native/google/usage/s3-presigned-url-input",
+                              "models/providers/native/google/usage/video-input-bytes-content",
+                              "models/providers/native/google/usage/video-input-file-upload",
+                              "models/providers/native/google/usage/video-input-local-file-upload"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Meta",
+                        "pages": [
+                          "models/providers/native/meta/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/native/meta/usage/basic",
+                              "models/providers/native/meta/usage/basic-stream",
+                              "models/providers/native/meta/usage/async-basic",
+                              "models/providers/native/meta/usage/async-stream",
+                              "models/providers/native/meta/usage/tool-use",
+                              "models/providers/native/meta/usage/async-tool-use",
+                              "models/providers/native/meta/usage/structured-output",
+                              "models/providers/native/meta/usage/image-input-bytes",
+                              "models/providers/native/meta/usage/knowledge",
+                              "models/providers/native/meta/usage/memory"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Mistral",
+                        "pages": [
+                          "models/providers/native/mistral/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/native/mistral/usage/basic",
+                              "models/providers/native/mistral/usage/basic-stream",
+                              "models/providers/native/mistral/usage/async-basic",
+                              "models/providers/native/mistral/usage/async-basic-stream",
+                              "models/providers/native/mistral/usage/tool-use",
+                              "models/providers/native/mistral/usage/async-tool-use",
+                              "models/providers/native/mistral/usage/memory",
+                              "models/providers/native/mistral/usage/structured-output",
+                              "models/providers/native/mistral/usage/structured-output-with-tool-use",
+                              "models/providers/native/mistral/usage/async-structured-output",
+                              "models/providers/native/mistral/usage/image-bytes-input-agent",
+                              "models/providers/native/mistral/usage/image-compare-agent",
+                              "models/providers/native/mistral/usage/image-file-input-agent",
+                              "models/providers/native/mistral/usage/image-ocr-with-structured-output",
+                              "models/providers/native/mistral/usage/image-transcribe-document-agent",
+                              "models/providers/native/mistral/usage/mistral-small"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "OpenAI",
+                        "pages": [
+                          {
+                            "group": "OpenAI Chat Completion",
+                            "pages": [
+                              "models/providers/native/openai/completion/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/native/openai/completion/usage/basic",
+                                  "models/providers/native/openai/completion/usage/basic-stream",
+                                  "models/providers/native/openai/completion/usage/tool-use",
+                                  "models/providers/native/openai/completion/usage/structured-output",
+                                  "models/providers/native/openai/completion/usage/storage",
+                                  "models/providers/native/openai/completion/usage/knowledge",
+                                  "models/providers/native/openai/completion/usage/image-agent",
+                                  "models/providers/native/openai/completion/usage/audio-input-agent",
+                                  "models/providers/native/openai/completion/usage/audio-output-agent",
+                                  "models/providers/native/openai/completion/usage/generate-images",
+                                  "models/providers/native/openai/completion/usage/reasoning-effort",
+                                  "models/providers/native/openai/completion/usage/cache-response"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "group": "OpenAI Responses",
+                            "pages": [
+                              "models/providers/native/openai/responses/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/native/openai/responses/usage/agent-flex-tier",
+                                  "models/providers/native/openai/responses/usage/async-basic",
+                                  "models/providers/native/openai/responses/usage/async-basic-stream",
+                                  "models/providers/native/openai/responses/usage/async-tool-use",
+                                  "models/providers/native/openai/responses/usage/basic",
+                                  "models/providers/native/openai/responses/usage/basic-stream",
+                                  "models/providers/native/openai/responses/usage/db",
+                                  "models/providers/native/openai/responses/usage/deep-research-agent",
+                                  "models/providers/native/openai/responses/usage/image-agent",
+                                  "models/providers/native/openai/responses/usage/image-agent-bytes",
+                                  "models/providers/native/openai/responses/usage/image-agent-with-memory",
+                                  "models/providers/native/openai/responses/usage/image-generation-agent",
+                                  "models/providers/native/openai/responses/usage/knowledge",
+                                  "models/providers/native/openai/responses/usage/memory",
+                                  "models/providers/native/openai/responses/usage/pdf-input-local",
+                                  "models/providers/native/openai/responses/usage/pdf-input-url",
+                                  "models/providers/native/openai/responses/usage/reasoning-o3-mini",
+                                  "models/providers/native/openai/responses/usage/structured-output",
+                                  "models/providers/native/openai/responses/usage/tool-use",
+                                  "models/providers/native/openai/responses/usage/tool-use-gpt-5",
+                                  "models/providers/native/openai/responses/usage/tool-use-o3",
+                                  "models/providers/native/openai/responses/usage/tool-use-stream",
+                                  "models/providers/native/openai/responses/usage/verbosity-control",
+                                  "models/providers/native/openai/responses/usage/websearch-builtin-tool",
+                                  "models/providers/native/openai/responses/usage/zdr-reasoning-agent"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Perplexity",
+                        "pages": [
+                          "models/providers/native/perplexity/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/native/perplexity/usage/basic",
+                              "models/providers/native/perplexity/usage/basic-stream",
+                              "models/providers/native/perplexity/usage/async-basic",
+                              "models/providers/native/perplexity/usage/async-basic-stream",
+                              "models/providers/native/perplexity/usage/knowledge",
+                              "models/providers/native/perplexity/usage/memory",
+                              "models/providers/native/perplexity/usage/structured-output"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Vercel",
+                        "pages": [
+                          "models/providers/native/vercel/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/native/vercel/usage/basic",
+                              "models/providers/native/vercel/usage/basic-stream",
+                              "models/providers/native/vercel/usage/image-agent",
+                              "models/providers/native/vercel/usage/knowledge",
+                              "models/providers/native/vercel/usage/tool-use"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "XAI",
+                        "pages": [
+                          "models/providers/native/xai/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/native/xai/usage/basic",
+                              "models/providers/native/xai/usage/basic-stream",
+                              "models/providers/native/xai/usage/tool-use",
+                              "models/providers/native/xai/usage/basic-async",
+                              "models/providers/native/xai/usage/basic-async-stream",
+                              "models/providers/native/xai/usage/tool-use-stream",
+                              "models/providers/native/xai/usage/async-tool-use",
+                              "models/providers/native/xai/usage/structured-output",
+                              "models/providers/native/xai/usage/image-agent",
+                              "models/providers/native/xai/usage/image-agent-bytes",
+                              "models/providers/native/xai/usage/live-search-agent",
+                              "models/providers/native/xai/usage/live-search-agent-stream",
+                              "models/providers/native/xai/usage/reasoning-agent"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Local Model Providers",
+                    "pages": [
+                      {
+                        "group": "Ollama",
+                        "pages": [
+                          "models/providers/local/ollama/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/local/ollama/usage/basic",
+                              "models/providers/local/ollama/usage/basic-stream",
+                              "models/providers/local/ollama/usage/cloud",
+                              "models/providers/local/ollama/usage/async-basic",
+                              "models/providers/local/ollama/usage/async-basic-stream",
+                              "models/providers/local/ollama/usage/tool-use",
+                              "models/providers/local/ollama/usage/tool-use-stream",
+                              "models/providers/local/ollama/usage/knowledge",
+                              "models/providers/local/ollama/usage/memory",
+                              "models/providers/local/ollama/usage/demo-deepseek-r1",
+                              "models/providers/local/ollama/usage/demo-gemma",
+                              "models/providers/local/ollama/usage/demo-phi4",
+                              "models/providers/local/ollama/usage/demo-qwen",
+                              "models/providers/local/ollama/usage/image-agent",
+                              "models/providers/local/ollama/usage/multimodal",
+                              "models/providers/local/ollama/usage/set-client",
+                              "models/providers/local/ollama/usage/set-temperature",
+                              "models/providers/local/ollama/usage/storage",
+                              "models/providers/local/ollama/usage/structured-output"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "LlamaCpp",
+                        "pages": [
+                          "models/providers/local/llama-cpp/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/local/llama-cpp/usage/basic",
+                              "models/providers/local/llama-cpp/usage/basic-stream",
+                              "models/providers/local/llama-cpp/usage/structured-output",
+                              "models/providers/local/llama-cpp/usage/tool-use",
+                              "models/providers/local/llama-cpp/usage/tool-use-stream"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "LM Studio",
+                        "pages": [
+                          "models/providers/local/lmstudio/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/local/lmstudio/usage/basic",
+                              "models/providers/local/lmstudio/usage/basic-stream",
+                              "models/providers/local/lmstudio/usage/tool-use",
+                              "models/providers/local/lmstudio/usage/structured-output",
+                              "models/providers/local/lmstudio/usage/storage",
+                              "models/providers/local/lmstudio/usage/knowledge",
+                              "models/providers/local/lmstudio/usage/image-agent"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "VLLM",
+                        "pages": [
+                          "models/providers/local/vllm/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/local/vllm/usage/basic",
+                              "models/providers/local/vllm/usage/basic-stream",
+                              "models/providers/local/vllm/usage/async-basic",
+                              "models/providers/local/vllm/usage/async-basic-stream",
+                              "models/providers/local/vllm/usage/code-generation",
+                              "models/providers/local/vllm/usage/storage",
+                              "models/providers/local/vllm/usage/memory",
+                              "models/providers/local/vllm/usage/structured-output",
+                              "models/providers/local/vllm/usage/tool-use",
+                              "models/providers/local/vllm/usage/async-tool-use"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Cloud Model Providers",
+                    "pages": [
+                      {
+                        "group": "AWS",
+                        "pages": [
+                          {
+                            "group": "AWS Bedrock",
+                            "pages": [
+                              "models/providers/cloud/aws-bedrock/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/cloud/aws-bedrock/usage/basic",
+                                  "models/providers/cloud/aws-bedrock/usage/basic-stream",
+                                  "models/providers/cloud/aws-bedrock/usage/tool-use",
+                                  "models/providers/cloud/aws-bedrock/usage/structured-output",
+                                  "models/providers/cloud/aws-bedrock/usage/storage",
+                                  "models/providers/cloud/aws-bedrock/usage/knowledge",
+                                  "models/providers/cloud/aws-bedrock/usage/image-agent"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "group": "AWS Claude",
+                            "pages": [
+                              "models/providers/cloud/aws-claude/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/cloud/aws-claude/usage/basic",
+                                  "models/providers/cloud/aws-claude/usage/basic-stream",
+                                  "models/providers/cloud/aws-claude/usage/tool-use",
+                                  "models/providers/cloud/aws-claude/usage/structured-output",
+                                  "models/providers/cloud/aws-claude/usage/storage",
+                                  "models/providers/cloud/aws-claude/usage/knowledge"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Azure",
+                        "pages": [
+                          {
+                            "group": "Azure AI Foundry",
+                            "pages": [
+                              "models/providers/cloud/azure-ai-foundry/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/cloud/azure-ai-foundry/usage/basic",
+                                  "models/providers/cloud/azure-ai-foundry/usage/basic-stream",
+                                  "models/providers/cloud/azure-ai-foundry/usage/knowledge",
+                                  "models/providers/cloud/azure-ai-foundry/usage/storage",
+                                  "models/providers/cloud/azure-ai-foundry/usage/structured-output",
+                                  "models/providers/cloud/azure-ai-foundry/usage/tool-use"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "group": "Azure OpenAI",
+                            "pages": [
+                              "models/providers/cloud/azure-openai/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/cloud/azure-openai/usage/basic",
+                                  "models/providers/cloud/azure-openai/usage/basic-stream",
+                                  "models/providers/cloud/azure-openai/usage/knowledge",
+                                  "models/providers/cloud/azure-openai/usage/storage",
+                                  "models/providers/cloud/azure-openai/usage/structured-output",
+                                  "models/providers/cloud/azure-openai/usage/tool-use"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "IBM WatsonX",
+                        "pages": [
+                          "models/providers/cloud/ibm-watsonx/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/cloud/ibm-watsonx/usage/basic",
+                              "models/providers/cloud/ibm-watsonx/usage/basic-stream",
+                              "models/providers/cloud/ibm-watsonx/usage/async-basic-stream",
+                              "models/providers/cloud/ibm-watsonx/usage/async-basic",
+                              "models/providers/cloud/ibm-watsonx/usage/tool-use",
+                              "models/providers/cloud/ibm-watsonx/usage/async-tool-use",
+                              "models/providers/cloud/ibm-watsonx/usage/structured-output",
+                              "models/providers/cloud/ibm-watsonx/usage/storage",
+                              "models/providers/cloud/ibm-watsonx/usage/knowledge",
+                              "models/providers/cloud/ibm-watsonx/usage/image-agent-bytes"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Vertex AI",
+                        "pages": [
+                          "models/providers/cloud/vertexai-claude/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/cloud/vertexai-claude/usage/basic",
+                              "models/providers/cloud/vertexai-claude/usage/basic-stream",
+                              "models/providers/cloud/vertexai-claude/usage/tool-use",
+                              "models/providers/cloud/vertexai-claude/usage/structured-output",
+                              "models/providers/cloud/vertexai-claude/usage/pdf-input-local",
+                              "models/providers/cloud/vertexai-claude/usage/pdf-input-url",
+                              "models/providers/cloud/vertexai-claude/usage/pdf-input-bytes",
+                              "models/providers/cloud/vertexai-claude/usage/image-input-bytes",
+                              "models/providers/cloud/vertexai-claude/usage/image-input-url"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Model Gateways & Aggregators",
+                    "pages": [
+                      {
+                        "group": "AIML API",
+                        "pages": [
+                          "models/providers/gateways/aimlapi/overview",
+                          {
+                            "group": "Usage",
+                            "pages": []
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Cerebras",
+                        "pages": [
+                          {
+                            "group": "Cerebras",
+                            "pages": [
+                              "models/providers/gateways/cerebras/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/gateways/cerebras/usage/basic",
+                                  "models/providers/gateways/cerebras/usage/basic-stream",
+                                  "models/providers/gateways/cerebras/usage/tool-use",
+                                  "models/providers/gateways/cerebras/usage/structured-output",
+                                  "models/providers/gateways/cerebras/usage/storage",
+                                  "models/providers/gateways/cerebras/usage/knowledge"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "group": "Cerebras OpenAI",
+                            "pages": [
+                              "models/providers/gateways/cerebras-openai/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/gateways/cerebras-openai/usage/basic",
+                                  "models/providers/gateways/cerebras-openai/usage/basic-stream",
+                                  "models/providers/gateways/cerebras-openai/usage/tool-use",
+                                  "models/providers/gateways/cerebras-openai/usage/structured-output",
+                                  "models/providers/gateways/cerebras-openai/usage/storage",
+                                  "models/providers/gateways/cerebras-openai/usage/knowledge"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "CometAPI",
+                        "pages": [
+                          "models/providers/gateways/cometapi/overview",
+                          {
+                            "group": "Usage",
+                            "pages": []
+                          }
+                        ]
+                      },
+                      {
+                        "group": "DeepInfra",
+                        "pages": [
+                          "models/providers/gateways/deepinfra/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/deepinfra/usage/basic",
+                              "models/providers/gateways/deepinfra/usage/basic-stream",
+                              "models/providers/gateways/deepinfra/usage/tool-use",
+                              "models/providers/gateways/deepinfra/usage/structured-output"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Fireworks",
+                        "pages": [
+                          "models/providers/gateways/fireworks/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/fireworks/usage/basic",
+                              "models/providers/gateways/fireworks/usage/basic-stream",
+                              "models/providers/gateways/fireworks/usage/tool-use",
+                              "models/providers/gateways/fireworks/usage/structured-output"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Groq",
+                        "pages": [
+                          "models/providers/gateways/groq/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/groq/usage/basic",
+                              "models/providers/gateways/groq/usage/basic-stream",
+                              "models/providers/gateways/groq/usage/tool-use",
+                              "models/providers/gateways/groq/usage/structured-output",
+                              "models/providers/gateways/groq/usage/storage",
+                              "models/providers/gateways/groq/usage/knowledge",
+                              "models/providers/gateways/groq/usage/image-agent",
+                              "models/providers/gateways/groq/usage/deep-knowledge",
+                              "models/providers/gateways/groq/usage/browser-search",
+                              "models/providers/gateways/groq/usage/metrics",
+                              "models/providers/gateways/groq/usage/reasoning-agent",
+                              "models/providers/gateways/groq/usage/transcription-agent",
+                              "models/providers/gateways/groq/usage/translation-agent"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Hugging Face",
+                        "pages": [
+                          "models/providers/gateways/huggingface/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/huggingface/usage/basic",
+                              "models/providers/gateways/huggingface/usage/basic-stream",
+                              "models/providers/gateways/huggingface/usage/async-basic",
+                              "models/providers/gateways/huggingface/usage/async-basic-stream",
+                              "models/providers/gateways/huggingface/usage/llama-essay-writer",
+                              "models/providers/gateways/huggingface/usage/tool-use"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "LangDB",
+                        "pages": [
+                          "models/providers/gateways/langdb/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/langdb/usage/basic",
+                              "models/providers/gateways/langdb/usage/basic-stream",
+                              "models/providers/gateways/langdb/usage/data-analyst",
+                              "models/providers/gateways/langdb/usage/structured-output",
+                              "models/providers/gateways/langdb/usage/tool-use"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "LiteLLM",
+                        "pages": [
+                          {
+                            "group": "LiteLLM",
+                            "pages": [
+                              "models/providers/gateways/litellm/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/gateways/litellm/usage/basic",
+                                  "models/providers/gateways/litellm/usage/basic-stream",
+                                  "models/providers/gateways/litellm/usage/async-basic",
+                                  "models/providers/gateways/litellm/usage/async-basic-stream",
+                                  "models/providers/gateways/litellm/usage/tool-use",
+                                  "models/providers/gateways/litellm/usage/async-tool-use",
+                                  "models/providers/gateways/litellm/usage/audio-input-agent",
+                                  "models/providers/gateways/litellm/usage/knowledge",
+                                  "models/providers/gateways/litellm/usage/structured-output",
+                                  "models/providers/gateways/litellm/usage/storage"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "group": "LiteLLM OpenAI",
+                            "pages": [
+                              "models/providers/gateways/litellm-openai/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/gateways/litellm-openai/usage/basic",
+                                  "models/providers/gateways/litellm-openai/usage/basic-stream",
+                                  "models/providers/gateways/litellm-openai/usage/tool-use"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Nebius",
+                        "pages": [
+                          "models/providers/gateways/nebius/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/nebius/usage/basic",
+                              "models/providers/gateways/nebius/usage/basic-stream",
+                              "models/providers/gateways/nebius/usage/tool-use",
+                              "models/providers/gateways/nebius/usage/structured-output",
+                              "models/providers/gateways/nebius/usage/storage",
+                              "models/providers/gateways/nebius/usage/knowledge"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Neosantara",
+                        "pages": [
+                          "models/providers/gateways/neosantara/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/neosantara/usage/basic",
+                              "models/providers/gateways/neosantara/usage/basic-stream",
+                              "models/providers/gateways/neosantara/usage/tool-use",
+                              "models/providers/gateways/neosantara/usage/structured-output",
+                              "models/providers/gateways/neosantara/usage/async-basic",
+                              "models/providers/gateways/neosantara/usage/async-basic-stream",
+                              "models/providers/gateways/neosantara/usage/async-tool-use"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Nexus",
+                        "pages": [
+                          "models/providers/gateways/nexus/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/nexus/usage/basic",
+                              "models/providers/gateways/nexus/usage/basic-stream",
+                              "models/providers/gateways/nexus/usage/async-basic",
+                              "models/providers/gateways/nexus/usage/async-basic-stream",
+                              "models/providers/gateways/nexus/usage/tool-use",
+                              "models/providers/gateways/nexus/usage/async-tool-use"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "NVIDIA",
+                        "pages": [
+                          "models/providers/gateways/nvidia/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/nvidia/usage/basic",
+                              "models/providers/gateways/nvidia/usage/basic-stream",
+                              "models/providers/gateways/nvidia/usage/async-basic",
+                              "models/providers/gateways/nvidia/usage/async-basic-stream",
+                              "models/providers/gateways/nvidia/usage/tool-use",
+                              "models/providers/gateways/nvidia/usage/async-tool-use"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "OpenRouter",
+                        "pages": [
+                          "models/providers/gateways/openrouter/overview",
+                          {
+                            "group": "Usage",
+                            "pages": []
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Portkey",
+                        "pages": [
+                          "models/providers/gateways/portkey/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/portkey/usage/basic",
+                              "models/providers/gateways/portkey/usage/basic-stream",
+                              "models/providers/gateways/portkey/usage/tool-use",
+                              "models/providers/gateways/portkey/usage/tool-use-stream",
+                              "models/providers/gateways/portkey/usage/structured-output"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Requesty",
+                        "pages": [
+                          "models/providers/gateways/requesty/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/requesty/usage/basic",
+                              "models/providers/gateways/requesty/usage/basic-stream",
+                              "models/providers/gateways/requesty/usage/tool-use",
+                              "models/providers/gateways/requesty/usage/structured-output"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Sambanova",
+                        "pages": [
+                          "models/providers/gateways/sambanova/overview",
+                          {
+                            "group": "Usage",
+                            "pages": []
+                          }
+                        ]
+                      },
+                      {
+                        "group": "SiliconFlow",
+                        "pages": [
+                          "models/providers/gateways/siliconflow/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/siliconflow/usage/async-basic-stream",
+                              "models/providers/gateways/siliconflow/usage/async-basic",
+                              "models/providers/gateways/siliconflow/usage/async-tool-use",
+                              "models/providers/gateways/siliconflow/usage/basic",
+                              "models/providers/gateways/siliconflow/usage/basic-stream",
+                              "models/providers/gateways/siliconflow/usage/tool-use"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Together",
+                        "pages": [
+                          "models/providers/gateways/together/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "models/providers/gateways/together/usage/basic",
+                              "models/providers/gateways/together/usage/basic-stream",
+                              "models/providers/gateways/together/usage/image-agent",
+                              "models/providers/gateways/together/usage/image-agent-bytes",
+                              "models/providers/gateways/together/usage/image-agent-memory",
+                              "models/providers/gateways/together/usage/structured-output",
+                              "models/providers/gateways/together/usage/tool-use"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "models/providers/openai-like"
+                ]
+              },
+              {
+                "group": "Supported Databases",
+                "pages": [
+                  "database/providers/overview",
+                  {
+                    "group": "PostgreSQL",
+                    "pages": [
+                      "database/providers/postgres/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/postgres/usage/postgres-for-agent",
+                          "database/providers/postgres/usage/postgres-for-team",
+                          "database/providers/postgres/usage/postgres-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Async PostgreSQL",
+                    "pages": [
+                      "database/providers/async-postgres/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/async-postgres/usage/async-postgres-for-agent",
+                          "database/providers/async-postgres/usage/async-postgres-for-team",
+                          "database/providers/async-postgres/usage/async-postgres-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "MySQL",
+                    "pages": [
+                      "database/providers/mysql/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/mysql/usage/mysql-for-agent",
+                          "database/providers/mysql/usage/mysql-for-team",
+                          "database/providers/mysql/usage/mysql-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Async MySQL",
+                    "pages": [
+                      "database/providers/async-mysql/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/async-mysql/usage/async-mysql-for-agent",
+                          "database/providers/async-mysql/usage/async-mysql-for-team",
+                          "database/providers/async-mysql/usage/async-mysql-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "SQLite",
+                    "pages": [
+                      "database/providers/sqlite/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/sqlite/usage/sqlite-for-agent",
+                          "database/providers/sqlite/usage/sqlite-for-team",
+                          "database/providers/sqlite/usage/sqlite-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Async SQLite",
+                    "pages": [
+                      "database/providers/async-sqlite/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/async-sqlite/usage/async-sqlite-for-agent",
+                          "database/providers/async-sqlite/usage/async-sqlite-for-team",
+                          "database/providers/async-sqlite/usage/async-sqlite-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "In-Memory",
+                    "pages": [
+                      "database/providers/in-memory/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/in-memory/usage/in-memory-for-agent",
+                          "database/providers/in-memory/usage/in-memory-for-team",
+                          "database/providers/in-memory/usage/in-memory-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "DynamoDB",
+                    "pages": [
+                      "database/providers/dynamodb/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/dynamodb/usage/dynamodb-for-agent",
+                          "database/providers/dynamodb/usage/dynamodb-for-team",
+                          "database/providers/dynamodb/usage/dynamodb-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "MongoDB",
+                    "pages": [
+                      "database/providers/mongo/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/mongo/usage/mongodb-for-agent",
+                          "database/providers/mongo/usage/mongodb-for-team",
+                          "database/providers/mongo/usage/mongodb-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Async MongoDB",
+                    "pages": [
+                      "database/providers/async-mongo/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/async-mongo/usage/async-mongodb-for-agent",
+                          "database/providers/async-mongo/usage/async-mongodb-for-team",
+                          "database/providers/async-mongo/usage/async-mongodb-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "JSON",
+                    "pages": [
+                      "database/providers/json/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/json/usage/json-for-agent",
+                          "database/providers/json/usage/json-for-team",
+                          "database/providers/json/usage/json-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Singlestore",
+                    "pages": [
+                      "database/providers/singlestore/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/singlestore/usage/singlestore-for-agent",
+                          "database/providers/singlestore/usage/singlestore-for-team",
+                          "database/providers/singlestore/usage/singlestore-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "SurrealDB",
+                    "pages": [
+                      "database/providers/surrealdb/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/surrealdb/usage/surrealdb-for-agent",
+                          "database/providers/surrealdb/usage/surrealdb-for-team",
+                          "database/providers/surrealdb/usage/surrealdb-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Redis",
+                    "pages": [
+                      "database/providers/redis/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/redis/usage/redis-for-agent",
+                          "database/providers/redis/usage/redis-for-team",
+                          "database/providers/redis/usage/redis-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "GCS",
+                    "pages": [
+                      "database/providers/gcs/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/gcs/usage/gcs-for-agent",
+                          "database/providers/gcs/usage/gcs-for-team",
+                          "database/providers/gcs/usage/gcs-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Firestore",
+                    "pages": [
+                      "database/providers/firestore/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/firestore/usage/firestore-for-agent",
+                          "database/providers/firestore/usage/firestore-for-team",
+                          "database/providers/firestore/usage/firestore-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Supabase",
+                    "pages": [
+                      "database/providers/supabase/overview"
+                    ]
+                  },
+                  {
+                    "group": "Neon",
+                    "pages": [
+                      "database/providers/neon/overview"
+                    ]
+                  },
+                  "database/providers/selecting-tables"
+                ]
+              },
+              {
+                "group": "Vector Stores",
+                "pages": [
+                  "knowledge/vector-stores/index",
+                  {
+                    "group": "PgVector",
+                    "pages": [
+                      "knowledge/vector-stores/pgvector/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/pgvector/usage/pgvector-db",
+                          "knowledge/vector-stores/pgvector/usage/async-pgvector-db",
+                          "knowledge/vector-stores/pgvector/usage/pgvector-hybrid-search"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "LanceDB",
+                    "pages": [
+                      "knowledge/vector-stores/lancedb/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/lancedb/usage/lance-db",
+                          "knowledge/vector-stores/lancedb/usage/async-lance-db",
+                          "knowledge/vector-stores/lancedb/usage/lance-db-hybrid-search"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Pinecone",
+                    "pages": [
+                      "knowledge/vector-stores/pinecone/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/pinecone/usage/pinecone-db",
+                          "knowledge/vector-stores/pinecone/usage/async-pinecone-db"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Qdrant",
+                    "pages": [
+                      "knowledge/vector-stores/qdrant/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/qdrant/usage/qdrant-db",
+                          "knowledge/vector-stores/qdrant/usage/async-qdrant-db",
+                          "knowledge/vector-stores/qdrant/usage/qdrant-db-hybrid-search"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Chroma",
+                    "pages": [
+                      "knowledge/vector-stores/chroma/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/chroma/usage/chroma-db",
+                          "knowledge/vector-stores/chroma/usage/async-chroma-db",
+                          "knowledge/vector-stores/chroma/usage/chroma-hybrid-search"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Milvus",
+                    "pages": [
+                      "knowledge/vector-stores/milvus/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/milvus/usage/milvus-db",
+                          "knowledge/vector-stores/milvus/usage/async-milvus-db",
+                          "knowledge/vector-stores/milvus/usage/milvus-db-hybrid-search",
+                          "knowledge/vector-stores/milvus/usage/async-milvus-db-hybrid-search"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Weaviate",
+                    "pages": [
+                      "knowledge/vector-stores/weaviate/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/weaviate/usage/weaviate-db",
+                          "knowledge/vector-stores/weaviate/usage/async-weaviate-db",
+                          "knowledge/vector-stores/weaviate/usage/weaviate-db-hybrid-search"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Couchbase",
+                    "pages": [
+                      "knowledge/vector-stores/couchbase/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/couchbase/usage/couchbase-db",
+                          "knowledge/vector-stores/couchbase/usage/async-couchbase-db"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Cassandra",
+                    "pages": [
+                      "knowledge/vector-stores/cassandra/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/cassandra/usage/cassandra-db",
+                          "knowledge/vector-stores/cassandra/usage/async-cassandra-db"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Clickhouse",
+                    "pages": [
+                      "knowledge/vector-stores/clickhouse/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/clickhouse/usage/clickhouse-db",
+                          "knowledge/vector-stores/clickhouse/usage/async-clickhouse-db"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Singlestore",
+                    "pages": [
+                      "knowledge/vector-stores/singlestore/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/singlestore/usage/singlestore-db",
+                          "knowledge/vector-stores/singlestore/usage/async-singlestore-db"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Redis",
+                    "pages": [
+                      "knowledge/vector-stores/redis/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/redis/usage/redis-db",
+                          "knowledge/vector-stores/redis/usage/async-redis-db"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "MongoDB",
+                    "pages": [
+                      "knowledge/vector-stores/mongodb/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/mongodb/usage/mongo-db",
+                          "knowledge/vector-stores/mongodb/usage/async-mongo-db",
+                          "knowledge/vector-stores/mongodb/usage/mongo-db-hybrid-search"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Azure Cosmos DB MongoDB vCore",
+                    "pages": [
+                      "knowledge/vector-stores/azure_cosmos_mongodb/overview",
+                      {
+                        "group": "Usage"
+                      }
+                    ]
+                  },
+                  {
+                    "group": "SurrealDB",
+                    "pages": [
+                      "knowledge/vector-stores/surrealdb/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/surrealdb/usage/surreal-db",
+                          "knowledge/vector-stores/surrealdb/usage/async-surreal-db"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "LightRAG",
+                    "pages": [
+                      "knowledge/vector-stores/lightrag/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/lightrag/usage/lightrag-db",
+                          "knowledge/vector-stores/lightrag/usage/async-lightrag-db"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Upstash",
+                    "pages": [
+                      "knowledge/vector-stores/upstash/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/upstash/usage/upstash-db",
+                          "knowledge/vector-stores/upstash/usage/async-upstash-db"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "LangChain",
+                    "pages": [
+                      "knowledge/vector-stores/langchain/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/langchain/usage/langchain-db",
+                          "knowledge/vector-stores/langchain/usage/async-langchain-db"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "LlamaIndex",
+                    "pages": [
+                      "knowledge/vector-stores/llamaindex/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "knowledge/vector-stores/llamaindex/usage/llamaindex-db",
+                          "knowledge/vector-stores/llamaindex/usage/async-llamaindex-db"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Embedders",
+                "pages": [
+                  "knowledge/concepts/embedder/overview",
+                  "knowledge/concepts/embedder/openai/openai-embedder",
+                  "knowledge/concepts/embedder/cohere/cohere-embedder",
+                  "knowledge/concepts/embedder/gemini/gemini-embedder",
+                  "knowledge/concepts/embedder/ollama/ollama-embedder",
+                  "knowledge/concepts/embedder/mistral/mistral-embedder",
+                  "knowledge/concepts/embedder/voyageai/voyageai-embedder"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Other",
+            "pages": [
+              {
                 "group": "Culture",
                 "tag": "experimental",
-                "pages": ["culture/overview"]
+                "pages": [
+                  "culture/overview"
+                ]
               },
               "custom-logging"
             ]
@@ -2673,7 +2719,9 @@
                 "pages": [
                   {
                     "group": "Memory",
-                    "pages": ["integrations/memory/memori"]
+                    "pages": [
+                      "integrations/memory/memori"
+                    ]
                   },
                   {
                     "group": "Discord Bot",
@@ -2695,7 +2743,9 @@
                       "integrations/testing/overview",
                       {
                         "group": "Usage",
-                        "pages": ["integrations/testing/usage/basic"]
+                        "pages": [
+                          "integrations/testing/usage/basic"
+                        ]
                       }
                     ]
                   }
@@ -2706,7 +2756,10 @@
                 "pages": [
                   {
                     "group": "Agno v2 Migration",
-                    "pages": ["other/v2-migration", "other/v2-changelog"]
+                    "pages": [
+                      "other/v2-migration",
+                      "other/v2-changelog"
+                    ]
                   },
                   "other/database-migrations",
                   "other/workflows-migration"
@@ -2753,7 +2806,10 @@
               },
               {
                 "group": "MCP",
-                "pages": ["agent-os/mcp/mcp", "agent-os/mcp/tools"]
+                "pages": [
+                  "agent-os/mcp/mcp",
+                  "agent-os/mcp/tools"
+                ]
               },
               {
                 "group": "Middleware",
@@ -3001,15 +3057,21 @@
               },
               {
                 "group": "Dash",
-                "pages": ["deploy/templates/dash/overview"]
+                "pages": [
+                  "deploy/templates/dash/overview"
+                ]
               },
               {
                 "group": "Gcode",
-                "pages": ["deploy/templates/gcode/overview"]
+                "pages": [
+                  "deploy/templates/gcode/overview"
+                ]
               },
               {
                 "group": "Scout",
-                "pages": ["deploy/templates/scout/overview"]
+                "pages": [
+                  "deploy/templates/scout/overview"
+                ]
               }
             ]
           },
@@ -3033,7 +3095,9 @@
               },
               {
                 "group": "Teams",
-                "pages": ["deploy/apps/teams/content-team"]
+                "pages": [
+                  "deploy/apps/teams/content-team"
+                ]
               },
               {
                 "group": "Workflows",
@@ -3051,27 +3115,39 @@
             "pages": [
               {
                 "group": "Slack",
-                "pages": ["deploy/interfaces/slack/overview"]
+                "pages": [
+                  "deploy/interfaces/slack/overview"
+                ]
               },
               {
                 "group": "Discord",
-                "pages": ["deploy/interfaces/discord/overview"]
+                "pages": [
+                  "deploy/interfaces/discord/overview"
+                ]
               },
               {
                 "group": "WhatsApp",
-                "pages": ["deploy/interfaces/whatsapp/overview"]
+                "pages": [
+                  "deploy/interfaces/whatsapp/overview"
+                ]
               },
               {
                 "group": "MCP",
-                "pages": ["deploy/interfaces/mcp/overview"]
+                "pages": [
+                  "deploy/interfaces/mcp/overview"
+                ]
               },
               {
                 "group": "AG-UI",
-                "pages": ["deploy/interfaces/ag-ui/overview"]
+                "pages": [
+                  "deploy/interfaces/ag-ui/overview"
+                ]
               },
               {
                 "group": "Telegram",
-                "pages": ["deploy/interfaces/telegram/overview"]
+                "pages": [
+                  "deploy/interfaces/telegram/overview"
+                ]
               }
             ]
           }
@@ -5578,7 +5654,10 @@
               },
               {
                 "group": "Team",
-                "pages": ["reference/teams/team", "reference/teams/remote-team"]
+                "pages": [
+                  "reference/teams/team",
+                  "reference/teams/remote-team"
+                ]
               },
               {
                 "group": "Workflows",
@@ -5631,11 +5710,15 @@
               },
               {
                 "group": "Memory",
-                "pages": ["reference/memory/memory"]
+                "pages": [
+                  "reference/memory/memory"
+                ]
               },
               {
                 "group": "Context Compression",
-                "pages": ["reference/compression/compression-manager"]
+                "pages": [
+                  "reference/compression/compression-manager"
+                ]
               },
               {
                 "group": "Database",
@@ -5657,7 +5740,10 @@
               },
               {
                 "group": "Tracing",
-                "pages": ["reference/tracing/trace", "reference/tracing/span"]
+                "pages": [
+                  "reference/tracing/trace",
+                  "reference/tracing/span"
+                ]
               },
               {
                 "group": "Hooks",
@@ -5767,7 +5853,9 @@
                   },
                   {
                     "group": "Rerankers",
-                    "pages": ["reference/knowledge/reranker/cohere"]
+                    "pages": [
+                      "reference/knowledge/reranker/cohere"
+                    ]
                   },
                   {
                     "group": "Chunking",
@@ -5799,11 +5887,15 @@
               "reference-api/overview",
               {
                 "group": "Home",
-                "pages": ["reference-api/schema/home/api-information"]
+                "pages": [
+                  "reference-api/schema/home/api-information"
+                ]
               },
               {
                 "group": "Health",
-                "pages": ["reference-api/schema/health/health-check"]
+                "pages": [
+                  "reference-api/schema/health/health-check"
+                ]
               },
               {
                 "group": "Core",
@@ -5847,7 +5939,9 @@
               },
               {
                 "group": "Slack",
-                "pages": ["reference-api/schema/slack/slack-events"]
+                "pages": [
+                  "reference-api/schema/slack/slack-events"
+                ]
               },
               {
                 "group": "Whatsapp",
@@ -5978,7 +6072,9 @@
               },
               {
                 "group": "Registry",
-                "pages": ["reference-api/schema/registry/list-registry"]
+                "pages": [
+                  "reference-api/schema/registry/list-registry"
+                ]
               },
               {
                 "group": "Schedules",


### PR DESCRIPTION
## Summary

- Restructures the SDK tab in `docs.json` from 4 groups (Get Started, Basics, Advanced, Additional Resources) to 8 groups: **Get Started, Basics, Capabilities, Context, Production, Providers, Other, Additional Resources**
- Navigation-only change. No file moves, no content edits, no URL changes
- All 1102 pages preserved with no additions or removals

## New Group Structure

| Group | Pages | What it contains |
|-------|-------|-----------------|
| Get Started | 2 | Introduction, First Agent |
| Basics | 74 | Agents, Teams, Workflows, I/O, Models (concepts), Database (concepts) |
| Capabilities | 306 | Tools, Knowledge & RAG, Memory, Learning, Skills, Reasoning, Multimodal |
| Context | 72 | Session, State, Context, Chat History, Dependency Injection |
| Production | 88 | Guardrails, Human-in-the-Loop, Evals, Hooks, Tracing, Run Cancellation |
| Providers | 528 | Model Providers, Database Providers, Vector Stores, Embedders |
| Other | 2 | Culture, Custom Logging |
| Additional Resources | 30 | Unchanged |

## Test plan

- [ ] Verify JSON is valid (`python3 -c "import json; json.load(open('docs.json'))"`)
- [ ] Verify all 1102 pages present with no duplicates (beyond the pre-existing one)
- [ ] Run `mintlify dev` and confirm navigation renders correctly
- [ ] Spot-check that pages load at their existing URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)