### PR TITLE
fix: update deprecated models to latest

### DIFF
--- a/agent-os/usage/interfaces/slack/agent-with-user-memory.mdx
+++ b/agent-os/usage/interfaces/slack/agent-with-user-memory.mdx
@@ -29,7 +29,7 @@ memory_manager = MemoryManager(
 
 personal_agent = Agent(
     name="Basic Agent",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     add_history_to_context=True,
     num_history_runs=3,

--- a/agent-os/usage/interfaces/slack/reasoning-agent.mdx
+++ b/agent-os/usage/interfaces/slack/reasoning-agent.mdx
@@ -18,7 +18,7 @@ agent_db = SqliteDb(session_table="agent_sessions", db_file="tmp/persistent_memo
 
 reasoning_finance_agent = Agent(
     name="Reasoning Finance Agent",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=agent_db,
     tools=[
         ThinkingTools(add_instructions=True),

--- a/agent-os/usage/interfaces/whatsapp/agent-with-media.mdx
+++ b/agent-os/usage/interfaces/whatsapp/agent-with-media.mdx
@@ -15,7 +15,7 @@ from agno.os.interfaces.whatsapp import Whatsapp
 agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 media_agent = Agent(
     name="Media Agent",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     db=agent_db,
     add_history_to_context=True,
     num_history_runs=3,
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 
 ## Key Features
 
-- **Multimodal AI**: Gemini 2.0 Flash for image, video, and audio processing
+- **Multimodal AI**: Gemini Flash for image, video, and audio processing
 - **Image Analysis**: Object recognition, scene understanding, text extraction
 - **Video Processing**: Content analysis and summarization
 - **Audio Support**: Voice message transcription and response

--- a/agent-os/usage/interfaces/whatsapp/agent-with-user-memory.mdx
+++ b/agent-os/usage/interfaces/whatsapp/agent-with-user-memory.mdx
@@ -24,12 +24,12 @@ memory_manager = MemoryManager(
                     Collect Information about the users likes and dislikes,
                     Collect information about what the user is doing with their life right now
                 """,
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
 )
 
 personal_agent = Agent(
     name="Basic Agent",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[HackerNewsTools()],
     add_history_to_context=True,
     num_history_runs=3,

--- a/agent-os/usage/interfaces/whatsapp/image-generation-model.mdx
+++ b/agent-os/usage/interfaces/whatsapp/image-generation-model.mdx
@@ -17,7 +17,7 @@ image_agent = Agent(
     id="image_generation_model",
     db=agent_db,
     model=Gemini(
-        id="gemini-2.0-flash-exp-image-generation",
+        id="gemini-2.5-flash-image",
         response_modalities=["Text", "Image"],
     ),
     debug_mode=True,
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 
 ## Key Features
 
-- **Direct Image Generation**: Gemini 2.0 Flash experimental image generation
+- **Direct Image Generation**: Gemini 2.5 Flash image generation
 - **Text-to-Image**: Converts descriptions into visual content
 - **Multimodal Responses**: Generates both text and images
 - **WhatsApp Integration**: Sends images directly through WhatsApp

--- a/agent-os/usage/interfaces/whatsapp/reasoning-agent.mdx
+++ b/agent-os/usage/interfaces/whatsapp/reasoning-agent.mdx
@@ -18,7 +18,7 @@ agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 
 reasoning_finance_agent = Agent(
     name="Reasoning Finance Agent",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=agent_db,
     tools=[
         ThinkingTools(add_instructions=True),

--- a/cookbook/models/anthropic.mdx
+++ b/cookbook/models/anthropic.mdx
@@ -10,7 +10,7 @@ from agno.agent import Agent
 from agno.models.anthropic import Claude
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True,
 )
 
@@ -25,7 +25,7 @@ from agno.models.anthropic import Claude
 from agno.tools.yfinance import YFinanceTools
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[YFinanceTools(stock_price=True)],
     markdown=True,
 )
@@ -41,7 +41,7 @@ from agno.media import Image
 from agno.models.anthropic import Claude
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True,
 )
 
@@ -60,7 +60,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-5-20250929",
+        id="claude-sonnet-4-6",
         max_tokens=16000,
         thinking={"type": "enabled", "budget_tokens": 10000},
     ),
@@ -88,7 +88,7 @@ class MovieScript(BaseModel):
     storyline: str = Field(..., description="3 sentence storyline")
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     description="You write movie scripts.",
     output_schema=MovieScript,
 )

--- a/cookbook/models/enterprise/aws-bedrock.mdx
+++ b/cookbook/models/enterprise/aws-bedrock.mdx
@@ -10,7 +10,7 @@ from agno.agent import Agent
 from agno.models.aws import AwsBedrock
 
 agent = Agent(
-    model=AwsBedrock(id="anthropic.claude-3-5-sonnet-20241022-v2:0"),
+    model=AwsBedrock(id="anthropic.claude-sonnet-4-6"),
     markdown=True,
 )
 
@@ -25,7 +25,7 @@ from agno.models.aws import AwsBedrock
 from agno.tools.yfinance import YFinanceTools
 
 agent = Agent(
-    model=AwsBedrock(id="anthropic.claude-3-5-sonnet-20241022-v2:0"),
+    model=AwsBedrock(id="anthropic.claude-sonnet-4-6"),
     tools=[YFinanceTools(stock_price=True)],
     markdown=True,
 )
@@ -45,7 +45,7 @@ class Analysis(BaseModel):
     recommendations: list[str] = Field(..., description="Recommendations")
 
 agent = Agent(
-    model=AwsBedrock(id="anthropic.claude-3-5-sonnet-20241022-v2:0"),
+    model=AwsBedrock(id="anthropic.claude-sonnet-4-6"),
     output_schema=Analysis,
 )
 

--- a/cookbook/models/google.mdx
+++ b/cookbook/models/google.mdx
@@ -10,7 +10,7 @@ from agno.agent import Agent
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 
@@ -25,7 +25,7 @@ from agno.models.google import Gemini
 from agno.tools.yfinance import YFinanceTools
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[YFinanceTools(stock_price=True)],
     markdown=True,
 )
@@ -41,7 +41,7 @@ from agno.media import Video
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 
@@ -58,7 +58,7 @@ from agno.agent import Agent
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash", search=True),
+    model=Gemini(id="gemini-flash-latest", search=True),
     markdown=True,
 )
 
@@ -78,7 +78,7 @@ class Recipe(BaseModel):
     instructions: list[str] = Field(..., description="Cooking instructions")
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     output_schema=Recipe,
 )
 

--- a/cookbook/streamlit/answer-engine.mdx
+++ b/cookbook/streamlit/answer-engine.mdx
@@ -92,8 +92,8 @@ The complete code is available in the [Agno repository](https://github.com/agno-
 ## Model Selection
 The application supports multiple model providers:
 - OpenAI (o3-mini, gpt-5-mini)
-- Anthropic (claude-3-5-sonnet)
-- Google (gemini-2.0-flash-exp)
+- Anthropic (claude-sonnet-4-6)
+- Google (gemini-flash-latest)
 - Groq (llama-3.3-70b-versatile)
 
 ## Agent Configuration

--- a/database/providers/surrealdb/usage/surrealdb-for-agent.mdx
+++ b/database/providers/surrealdb/usage/surrealdb-for-agent.mdx
@@ -31,7 +31,7 @@ db = SurrealDb(None, SURREALDB_URL, creds, SURREALDB_NAMESPACE, SURREALDB_DATABA
 
 agent = Agent(
     db=db,
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     add_history_to_context=True,
 )

--- a/database/providers/surrealdb/usage/surrealdb-for-team.mdx
+++ b/database/providers/surrealdb/usage/surrealdb-for-team.mdx
@@ -41,14 +41,14 @@ class Article(BaseModel):
 
 hn_researcher = Agent(
     name="HackerNews Researcher",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Gets top stories from hackernews.",
     tools=[HackerNewsTools()],
 )
 
 web_searcher = Agent(
     name="Web Searcher",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Searches the web for information on a topic",
     tools=[HackerNewsTools()],
     add_datetime_to_context=True,
@@ -56,7 +56,7 @@ web_searcher = Agent(
 
 hn_team = Team(
     name="HackerNews Team",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     members=[hn_researcher, web_searcher],
     db=db,
     instructions=[

--- a/database/providers/surrealdb/usage/surrealdb-for-workflow.mdx
+++ b/database/providers/surrealdb/usage/surrealdb-for-workflow.mdx
@@ -37,13 +37,13 @@ db = SurrealDb(None, SURREALDB_URL, creds, SURREALDB_NAMESPACE, SURREALDB_DATABA
 # Define agents
 hackernews_agent = Agent(
     name="Hackernews Agent",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     role="Extract key insights and content from Hackernews posts",
 )
 web_agent = Agent(
     name="Web Agent",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     role="Search the web for the latest news and trends",
 )
@@ -51,14 +51,14 @@ web_agent = Agent(
 # Define research team for complex analysis
 research_team = Team(
     name="Research Team",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     members=[hackernews_agent, web_agent],
     instructions="Research tech topics from Hackernews and the web",
 )
 
 content_planner = Agent(
     name="Content Planner",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     instructions=[
         "Plan a content schedule over 4 weeks for the provided topic and research content",
         "Ensure that I have posts for 3 posts per week",

--- a/examples/agent-os/advanced-demo/agents.mdx
+++ b/examples/agent-os/advanced-demo/agents.mdx
@@ -126,7 +126,7 @@ EXPECTED_OUTPUT_TEMPLATE = dedent("""\
 sage = Agent(
     name="Sage",
     id="sage",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=PostgresDb(db_url=db_url, session_table="sage_sessions"),
     tools=[
         ExaTools(
@@ -166,7 +166,7 @@ knowledge = Knowledge(
 
 agno_assist = Agent(
     name="Agno Assist",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     description="You help answer questions about the Agno framework.",
     instructions="Search your knowledge before answering the question.",
     knowledge=knowledge,

--- a/examples/agent-os/advanced-demo/demo.mdx
+++ b/examples/agent-os/advanced-demo/demo.mdx
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     evaluation = AccuracyEval(
         db=agno_assist.db,
         name="Calculator Evaluation",
-        model=Claude(id="claude-3-7-sonnet-latest"),
+        model=Claude(id="claude-sonnet-4-6"),
         agent=agno_assist,
         input="Should I post my password online? Answer yes or no.",
         expected_output="No",

--- a/examples/agent-os/advanced-demo/teams-demo.mdx
+++ b/examples/agent-os/advanced-demo/teams-demo.mdx
@@ -32,7 +32,7 @@ file_agent = Agent(
     name="File Upload Agent",
     id="file-upload-agent",
     role="Answer questions about the uploaded files",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     update_memory_on_run=True,
     instructions=[

--- a/examples/agent-os/advanced-demo/teams.mdx
+++ b/examples/agent-os/advanced-demo/teams.mdx
@@ -27,7 +27,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 web_agent = Agent(
     name="Web Search Agent",
     role="Handle web search requests",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=PostgresDb(db_url=db_url, session_table="web_agent_sessions"),
     tools=[WebSearchTools()],
     instructions=["Always include sources"],
@@ -36,7 +36,7 @@ web_agent = Agent(
 finance_agent = Agent(
     name="Finance Agent",
     role="Handle financial data requests",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=PostgresDb(db_url=db_url, session_table="finance_agent_sessions"),
     tools=[
         YFinanceTools(stock_price=True, analyst_recommendations=True, company_info=True)
@@ -46,7 +46,7 @@ finance_agent = Agent(
 
 finance_reasoning_team = Team(
     name="Reasoning Team Leader",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=PostgresDb(db_url=db_url, session_table="finance_reasoning_team_sessions"),
     members=[
         web_agent,

--- a/examples/agent-os/interfaces/slack/agent-with-user-memory.mdx
+++ b/examples/agent-os/interfaces/slack/agent-with-user-memory.mdx
@@ -33,13 +33,13 @@ memory_manager = MemoryManager(
                     Collect Information about the users likes and dislikes,
                     Collect information about what the user is doing with their life right now
                 """,
-    model=Claude(id="claude-3-5-sonnet-20241022"),
+    model=Claude(id="claude-sonnet-4-6"),
 )
 
 
 personal_agent = Agent(
     name="Basic Agent",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[WebSearchTools()],
     add_history_to_context=True,
     num_history_runs=3,

--- a/examples/agent-os/interfaces/slack/file-analyst.mdx
+++ b/examples/agent-os/interfaces/slack/file-analyst.mdx
@@ -25,7 +25,7 @@ agent_db = SqliteDb(session_table="agent_sessions", db_file="tmp/file_analyst.db
 
 file_analyst = Agent(
     name="File Analyst",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=agent_db,
     tools=[
         SlackTools(

--- a/examples/agent-os/interfaces/slack/reasoning-agent.mdx
+++ b/examples/agent-os/interfaces/slack/reasoning-agent.mdx
@@ -26,7 +26,7 @@ agent_db = SqliteDb(session_table="agent_sessions", db_file="tmp/persistent_memo
 
 reasoning_finance_agent = Agent(
     name="Reasoning Finance Agent",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=agent_db,
     tools=[
         ReasoningTools(add_instructions=True),

--- a/examples/agent-os/interfaces/whatsapp/agent-with-user-memory.mdx
+++ b/examples/agent-os/interfaces/whatsapp/agent-with-user-memory.mdx
@@ -33,13 +33,13 @@ memory_manager = MemoryManager(
                     Collect Information about the users likes and dislikes,
                     Collect information about what the user is doing with their life right now
                 """,
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
 )
 
 
 personal_agent = Agent(
     name="Basic Agent",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     add_history_to_context=True,
     num_history_runs=3,

--- a/examples/agent-os/interfaces/whatsapp/reasoning-agent.mdx
+++ b/examples/agent-os/interfaces/whatsapp/reasoning-agent.mdx
@@ -26,7 +26,7 @@ agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 
 reasoning_finance_agent = Agent(
     name="Reasoning Finance Agent",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=agent_db,
     tools=[
         ReasoningTools(add_instructions=True),

--- a/examples/integrations/discord/agent-with-user-memory.mdx
+++ b/examples/integrations/discord/agent-with-user-memory.mdx
@@ -29,7 +29,7 @@ db = SqliteDb(db_file="tmp/discord_client_cookbook.db")
 # ---------------------------------------------------------------------------
 personal_agent = Agent(
     name="Basic Agent",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     add_history_to_context=True,
     num_history_runs=3,

--- a/examples/integrations/rag/agentic-rag-infinity-reranker.mdx
+++ b/examples/integrations/rag/agentic-rag-infinity-reranker.mdx
@@ -44,7 +44,7 @@ knowledge = Knowledge(
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     # Agentic RAG is enabled by default when `knowledge` is provided to the Agent.
     knowledge=knowledge,
     # search_knowledge=True gives the Agent the ability to search on demand

--- a/examples/integrations/surrealdb/custom-memory-instructions.mdx
+++ b/examples/integrations/surrealdb/custom-memory-instructions.mdx
@@ -45,7 +45,7 @@ custom_memory_manager = MemoryManager(
 
 # Use default memory manager
 jane_memory_manager = MemoryManager(
-    model=Claude(id="claude-3-5-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=memory_db,
 )
 

--- a/examples/knowledge/vector-db/pgvector/pgvector-with-bedrock-reranker.mdx
+++ b/examples/knowledge/vector-db/pgvector/pgvector-with-bedrock-reranker.mdx
@@ -78,7 +78,7 @@ knowledge_amazon = Knowledge(
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=AwsBedrock(id="anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=AwsBedrock(id="anthropic.claude-sonnet-4-6-v1:0"),
     knowledge=knowledge_cohere,
     markdown=True,
 )

--- a/examples/memory/memory-manager/custom-memory-instructions.mdx
+++ b/examples/memory/memory-manager/custom-memory-instructions.mdx
@@ -60,7 +60,7 @@ I am interested to learn about the history of the universe and other astronomica
     print("John Doe's memories:")
     pprint(memories)
 
-    memory = MemoryManager(model=Claude(id="claude-3-5-sonnet-latest"), db=memory_db)
+    memory = MemoryManager(model=Claude(id="claude-sonnet-4-6"), db=memory_db)
     jane_doe_id = "jane_doe@example.com"
 
     memory.create_user_memories(

--- a/examples/models/anthropic/basic-with-timeout.mdx
+++ b/examples/models/anthropic/basic-with-timeout.mdx
@@ -17,7 +17,7 @@ from agno.models.anthropic import Claude
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Claude(id="claude-sonnet-4-5-20250929", timeout=1.0), markdown=True)
+agent = Agent(model=Claude(id="claude-sonnet-4-6", timeout=1.0), markdown=True)
 
 agent.print_response("Share a 2 sentence horror story")
 

--- a/examples/models/anthropic/basic.mdx
+++ b/examples/models/anthropic/basic.mdx
@@ -18,7 +18,7 @@ import asyncio
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Claude(id="claude-sonnet-4-5-20250929"), markdown=True)
+agent = Agent(model=Claude(id="claude-sonnet-4-6"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/examples/models/anthropic/code-execution.mdx
+++ b/examples/models/anthropic/code-execution.mdx
@@ -19,7 +19,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-6",
         betas=["code-execution-2025-05-22"],
     ),
     tools=[

--- a/examples/models/anthropic/csv-input.mdx
+++ b/examples/models/anthropic/csv-input.mdx
@@ -28,7 +28,7 @@ download_file(
 )
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True,
 )
 

--- a/examples/models/anthropic/db.mdx
+++ b/examples/models/anthropic/db.mdx
@@ -19,7 +19,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 db = PostgresDb(db_url=db_url)
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     tools=[WebSearchTools()],
     add_history_to_context=True,

--- a/examples/models/anthropic/financial-analyst-thinking.mdx
+++ b/examples/models/anthropic/financial-analyst-thinking.mdx
@@ -30,7 +30,7 @@ task = (
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-6",
         thinking={"type": "enabled", "budget_tokens": 2048},
         betas=["interleaved-thinking-2025-05-14"],
     ),

--- a/examples/models/anthropic/image-input-bytes.mdx
+++ b/examples/models/anthropic/image-input-bytes.mdx
@@ -23,7 +23,7 @@ from agno.utils.media import download_image
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/examples/models/anthropic/image-input-local-file.mdx
+++ b/examples/models/anthropic/image-input-local-file.mdx
@@ -31,7 +31,7 @@ download_file(
 client = Anthropic()
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True,
 )
 

--- a/examples/models/anthropic/image-input-url.mdx
+++ b/examples/models/anthropic/image-input-url.mdx
@@ -20,7 +20,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/examples/models/anthropic/knowledge.mdx
+++ b/examples/models/anthropic/knowledge.mdx
@@ -28,7 +28,7 @@ knowledge = Knowledge(
 knowledge.insert(url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf")
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     knowledge=knowledge,
 )
 agent.print_response("How to make Thai curry?", markdown=True)

--- a/examples/models/anthropic/mcp-connector.mdx
+++ b/examples/models/anthropic/mcp-connector.mdx
@@ -20,7 +20,7 @@ from agno.utils.models.claude import MCPServerConfiguration
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-6",
         betas=["mcp-client-2025-04-04"],
         mcp_servers=[
             MCPServerConfiguration(

--- a/examples/models/anthropic/memory.mdx
+++ b/examples/models/anthropic/memory.mdx
@@ -26,7 +26,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 db = PostgresDb(db_url=db_url)
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     # Pass the database to the Agent
     db=db,
     # Store the memories and summary in the database

--- a/examples/models/anthropic/pdf-input-bytes.mdx
+++ b/examples/models/anthropic/pdf-input-bytes.mdx
@@ -29,7 +29,7 @@ download_file(
 )
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True,
 )
 

--- a/examples/models/anthropic/pdf-input-local.mdx
+++ b/examples/models/anthropic/pdf-input-local.mdx
@@ -29,7 +29,7 @@ download_file(
 )
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True,
 )
 

--- a/examples/models/anthropic/pdf-input-url.mdx
+++ b/examples/models/anthropic/pdf-input-url.mdx
@@ -19,7 +19,7 @@ from agno.models.anthropic import Claude
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True,
 )
 

--- a/examples/models/anthropic/prompt-caching-extended.mdx
+++ b/examples/models/anthropic/prompt-caching-extended.mdx
@@ -31,7 +31,7 @@ system_message = txt_path.read_text()
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-6",
         betas=["extended-cache-ttl-2025-04-11"],
         system_prompt=system_message,
         cache_system_prompt=True,  # Activate prompt caching for Anthropic to cache the system prompt

--- a/examples/models/anthropic/prompt-caching.mdx
+++ b/examples/models/anthropic/prompt-caching.mdx
@@ -34,7 +34,7 @@ system_message = txt_path.read_text()
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-6",
         cache_system_prompt=True,  # Activate prompt caching for Anthropic to cache the system prompt
     ),
     system_message=system_message,

--- a/examples/models/anthropic/skills/agent-with-documents.mdx
+++ b/examples/models/anthropic/skills/agent-with-documents.mdx
@@ -29,7 +29,7 @@ from file_download_helper import download_skill_files
 document_agent = Agent(
     name="Document Creator",
     model=Claude(
-        id="claude-sonnet-4-5-20250929",
+        id="claude-sonnet-4-6",
         skills=[
             {"type": "anthropic", "skill_id": "docx", "version": "latest"}
         ],  # Enable Word document skill

--- a/examples/models/anthropic/skills/agent-with-excel.mdx
+++ b/examples/models/anthropic/skills/agent-with-excel.mdx
@@ -29,7 +29,7 @@ from file_download_helper import download_skill_files
 excel_agent = Agent(
     name="Excel Creator",
     model=Claude(
-        id="claude-sonnet-4-5-20250929",
+        id="claude-sonnet-4-6",
         skills=[
             {"type": "anthropic", "skill_id": "xlsx", "version": "latest"}
         ],  # Enable Excel spreadsheet skill

--- a/examples/models/anthropic/skills/agent-with-powerpoint.mdx
+++ b/examples/models/anthropic/skills/agent-with-powerpoint.mdx
@@ -29,7 +29,7 @@ from file_download_helper import download_skill_files
 powerpoint_agent = Agent(
     name="PowerPoint Creator",
     model=Claude(
-        id="claude-sonnet-4-5-20250929",
+        id="claude-sonnet-4-6",
         skills=[
             {"type": "anthropic", "skill_id": "pptx", "version": "latest"}
         ],  # Enable PowerPoint presentation skill

--- a/examples/models/anthropic/skills/multi-skill-agent.mdx
+++ b/examples/models/anthropic/skills/multi-skill-agent.mdx
@@ -32,7 +32,7 @@ from file_download_helper import download_skill_files
 multi_skill_agent = Agent(
     name="Multi-Skill Document Creator",
     model=Claude(
-        id="claude-sonnet-4-5-20250929",
+        id="claude-sonnet-4-6",
         skills=[
             {"type": "anthropic", "skill_id": "pptx", "version": "latest"},
             {"type": "anthropic", "skill_id": "xlsx", "version": "latest"},

--- a/examples/models/anthropic/structured-output-strict-tools.mdx
+++ b/examples/models/anthropic/structured-output-strict-tools.mdx
@@ -59,7 +59,7 @@ weather_tool = Function(
 
 # Agent with both structured outputs and strict tool
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[weather_tool],
     output_schema=WeatherInfo,
     description="You help users get weather information.",

--- a/examples/models/anthropic/thinking.mdx
+++ b/examples/models/anthropic/thinking.mdx
@@ -19,7 +19,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-3-7-sonnet-20250219",
+        id="claude-sonnet-4-6",
         max_tokens=2048,
         thinking={"type": "enabled", "budget_tokens": 1024},
     ),

--- a/examples/models/anthropic/tool-use.mdx
+++ b/examples/models/anthropic/tool-use.mdx
@@ -16,7 +16,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/examples/models/anthropic/web-search.mdx
+++ b/examples/models/anthropic/web-search.mdx
@@ -22,7 +22,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-6",
     ),
     db=InMemoryDb(),
     tools=[

--- a/examples/models/cometapi/multi-model.mdx
+++ b/examples/models/cometapi/multi-model.mdx
@@ -38,7 +38,7 @@ def main():
         # OpenAI models
         ("gpt-5.2", "Latest GPT-5 Mini model"),
         # Anthropic models
-        ("claude-sonnet-4-20250514", "Claude Sonnet 4"),
+        ("claude-sonnet-4-6", "Claude Sonnet 4"),
         # Google models
         ("gemini-2.5-pro", "Gemini 2.5 Pro"),
         ("gemini-3-flash-preview", "Gemini 3 Flash Preview"),

--- a/examples/models/google/gemini/image-input-file-upload.mdx
+++ b/examples/models/google/gemini/image-input-file-upload.mdx
@@ -24,7 +24,7 @@ from google.generativeai.types import file_types
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/examples/models/google/gemini/image-input.mdx
+++ b/examples/models/google/gemini/image-input.mdx
@@ -20,7 +20,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/examples/models/google/gemini/storage-and-memory.mdx
+++ b/examples/models/google/gemini/storage-and-memory.mdx
@@ -25,7 +25,7 @@ knowledge_base = PDFUrlKnowledgeBase(
 knowledge_base.load(recreate=True)  # Comment out after first run
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     knowledge=knowledge_base,
     # Store the memories and summary in a database

--- a/examples/models/google/gemini/tool-use.mdx
+++ b/examples/models/google/gemini/tool-use.mdx
@@ -16,7 +16,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/examples/models/nexus/basic.mdx
+++ b/examples/models/nexus/basic.mdx
@@ -18,7 +18,7 @@ import asyncio
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Nexus(id="anthropic/claude-sonnet-4-20250514"), markdown=True)
+agent = Agent(model=Nexus(id="anthropic/claude-sonnet-4-6"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/examples/models/nexus/tool-use.mdx
+++ b/examples/models/nexus/tool-use.mdx
@@ -16,7 +16,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Nexus(id="anthropic/claude-sonnet-4-20250514"),
+    model=Nexus(id="anthropic/claude-sonnet-4-6"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/examples/reasoning/agents/is-9-11-bigger-than-9-9.mdx
+++ b/examples/reasoning/agents/is-9-11-bigger-than-9-9.mdx
@@ -31,10 +31,10 @@ cot_agent_openai = Agent(
     markdown=True,
 )
 
-regular_agent_claude = Agent(model=Claude("claude-3-5-sonnet-20241022"), markdown=True)
+regular_agent_claude = Agent(model=Claude("claude-sonnet-4-6"), markdown=True)
 
 deepseek_agent_claude = Agent(
-    model=Claude("claude-3-5-sonnet-20241022"),
+    model=Claude("claude-sonnet-4-6"),
     reasoning_model=DeepSeek(id="deepseek-reasoner"),
     markdown=True,
 )

--- a/examples/reasoning/models/groq/deepseek-plus-claude.mdx
+++ b/examples/reasoning/models/groq/deepseek-plus-claude.mdx
@@ -20,7 +20,7 @@ from agno.models.groq import Groq
 # ---------------------------------------------------------------------------
 def run_example() -> None:
     deepseek_plus_claude = Agent(
-        model=Claude(id="claude-3-7-sonnet-20250219"),
+        model=Claude(id="claude-sonnet-4-6"),
         reasoning_model=Groq(
             id="qwen/qwen3-32b",
             temperature=0.6,

--- a/examples/reasoning/tools/claude-reasoning-tools.mdx
+++ b/examples/reasoning/tools/claude-reasoning-tools.mdx
@@ -21,7 +21,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 def run_example() -> None:
     reasoning_agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-6"),
         tools=[
             ReasoningTools(add_instructions=True),
             WebSearchTools(enable_news=False),

--- a/examples/storage/surrealdb/surrealdb-for-agent.mdx
+++ b/examples/storage/surrealdb/surrealdb-for-agent.mdx
@@ -45,7 +45,7 @@ db = SurrealDb(None, SURREALDB_URL, creds, SURREALDB_NAMESPACE, SURREALDB_DATABA
 # ---------------------------------------------------------------------------
 agent = Agent(
     db=db,
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[WebSearchTools()],
     add_history_to_context=True,
 )

--- a/examples/storage/surrealdb/surrealdb-for-team.mdx
+++ b/examples/storage/surrealdb/surrealdb-for-team.mdx
@@ -56,14 +56,14 @@ class Article(BaseModel):
 
 hn_researcher = Agent(
     name="HackerNews Researcher",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Gets top stories from hackernews.",
     tools=[HackerNewsTools()],
 )
 
 web_searcher = Agent(
     name="Web Searcher",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Searches the web for information on a topic",
     tools=[WebSearchTools()],
     add_datetime_to_context=True,
@@ -72,7 +72,7 @@ web_searcher = Agent(
 
 hn_team = Team(
     name="HackerNews Team",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     members=[hn_researcher, web_searcher],
     db=db,
     instructions=[

--- a/examples/storage/surrealdb/surrealdb-for-workflow.mdx
+++ b/examples/storage/surrealdb/surrealdb-for-workflow.mdx
@@ -48,13 +48,13 @@ db = SurrealDb(None, SURREALDB_URL, creds, SURREALDB_NAMESPACE, SURREALDB_DATABA
 # ---------------------------------------------------------------------------
 hackernews_agent = Agent(
     name="Hackernews Agent",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     role="Extract key insights and content from Hackernews posts",
 )
 web_agent = Agent(
     name="Web Agent",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[WebSearchTools()],
     role="Search the web for the latest news and trends",
 )
@@ -62,14 +62,14 @@ web_agent = Agent(
 # Define research team for complex analysis
 research_team = Team(
     name="Research Team",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     members=[hackernews_agent, web_agent],
     instructions="Research tech topics from Hackernews and the web",
 )
 
 content_planner = Agent(
     name="Content Planner",
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     instructions=[
         "Plan a content schedule over 4 weeks for the provided topic and research content",
         "Ensure that I have posts for 3 posts per week",

--- a/examples/teams/context-compression/tool-call-compression-with-manager.mdx
+++ b/examples/teams/context-compression/tool-call-compression-with-manager.mdx
@@ -65,7 +65,7 @@ compression_manager = CompressionManager(
 tech_researcher = Agent(
     name="Alex",
     role="Technology Researcher",
-    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-6"),
     instructions=dedent("""
         You specialize in technology and AI research.
         - Focus on latest developments, trends, and breakthroughs
@@ -77,7 +77,7 @@ tech_researcher = Agent(
 business_analyst = Agent(
     name="Sarah",
     role="Business Analyst",
-    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-6"),
     instructions=dedent("""
         You specialize in business and market analysis.
         - Focus on companies, markets, and economic trends
@@ -91,7 +91,7 @@ business_analyst = Agent(
 # ---------------------------------------------------------------------------
 research_team = Team(
     name="Research Team",
-    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-6"),
     members=[tech_researcher, business_analyst],
     tools=[WebSearchTools()],  # Team uses DuckDuckGo for research
     description="Research team that investigates topics and provides analysis.",

--- a/examples/teams/context-compression/tool-call-compression.mdx
+++ b/examples/teams/context-compression/tool-call-compression.mdx
@@ -26,7 +26,7 @@ from agno.tools.websearch import WebSearchTools
 sync_tech_researcher = Agent(
     name="Alex",
     role="Technology Researcher",
-    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-6"),
     instructions=dedent("""
         You specialize in technology and AI research.
         - Focus on latest developments, trends, and breakthroughs
@@ -38,7 +38,7 @@ sync_tech_researcher = Agent(
 sync_business_analyst = Agent(
     name="Sarah",
     role="Business Analyst",
-    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-6"),
     instructions=dedent("""
         You specialize in business and market analysis.
         - Focus on companies, markets, and economic trends
@@ -76,7 +76,7 @@ async_business_analyst = Agent(
 # ---------------------------------------------------------------------------
 sync_research_team = Team(
     name="Research Team",
-    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=AwsBedrock(id="us.anthropic.claude-sonnet-4-6"),
     members=[sync_tech_researcher, sync_business_analyst],
     tools=[WebSearchTools()],  # Team uses DuckDuckGo for research
     description="Research team that investigates topics and provides analysis.",

--- a/examples/tools/mcp/brave.mdx
+++ b/examples/tools/mcp/brave.mdx
@@ -33,7 +33,7 @@ async def run_agent(message: str) -> None:
         },
     ) as mcp_tools:
         agent = Agent(
-            model=Claude(id="claude-sonnet-4-20250514"),
+            model=Claude(id="claude-sonnet-4-6"),
             tools=[mcp_tools],
             markdown=True,
         )

--- a/examples/tools/mcp/parallel.mdx
+++ b/examples/tools/mcp/parallel.mdx
@@ -47,7 +47,7 @@ async def run_agent(message: str) -> None:
         transport="streamable-http", server_params=server_params
     ) as parallel_mcp_server:
         agent = Agent(
-            model=Claude(id="claude-sonnet-4-20250514"),
+            model=Claude(id="claude-sonnet-4-6"),
             tools=[parallel_mcp_server],
             markdown=True,
         )

--- a/examples/tools/spotify-tools.mdx
+++ b/examples/tools/spotify-tools.mdx
@@ -32,7 +32,7 @@ spotify = SpotifyTools(
 # Create an agent with the Spotify toolkit
 agent = Agent(
     name="Spotify DJ",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[spotify],
     instructions=[
         "You are a helpful music assistant that can search for songs and manage Spotify playlists.",

--- a/examples/tools/webbrowser-tools.mdx
+++ b/examples/tools/webbrowser-tools.mdx
@@ -19,7 +19,7 @@ from agno.tools.websearch import WebSearchTools
 
 # Example 1: Enable specific WebBrowser functions
 agent = Agent(
-    model=Gemini("gemini-2.0-flash"),
+    model=Gemini("gemini-flash-latest"),
     tools=[WebBrowserTools(enable_open_page=True), WebSearchTools()],
     instructions=[
         "Find related websites and pages using DuckDuckGo",
@@ -30,7 +30,7 @@ agent = Agent(
 
 # Example 2: Enable all WebBrowser functions
 agent_all = Agent(
-    model=Gemini("gemini-2.0-flash"),
+    model=Gemini("gemini-flash-latest"),
     tools=[WebBrowserTools(all=True), WebSearchTools()],
     instructions=[
         "Find related websites and pages using DuckDuckGo",

--- a/examples/workflows/basic-workflows/sequence-of-steps/workflow-with-file-input.mdx
+++ b/examples/workflows/basic-workflows/sequence-of-steps/workflow-with-file-input.mdx
@@ -23,7 +23,7 @@ from agno.workflow.workflow import Workflow
 # ---------------------------------------------------------------------------
 read_agent = Agent(
     name="Agent",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Read the contents of the attached file.",
 )
 

--- a/faq/openai-key-request-for-other-models.mdx
+++ b/faq/openai-key-request-for-other-models.mdx
@@ -19,7 +19,7 @@ from agno.agent import Agent, RunOutput
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-1.5-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 

--- a/faq/switching-models.mdx
+++ b/faq/switching-models.mdx
@@ -91,7 +91,7 @@ openai_agent.print_response(
 
 # Now switch to Google Gemini using same session
 gemini_agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     instructions="You are a helpful assistant.",
     db=db,
     add_history_to_context=True,

--- a/input-output/multimodal.mdx
+++ b/input-output/multimodal.mdx
@@ -98,7 +98,7 @@ This section introduces Multimodal I/O. Check out the [full guide](/multimodal/o
                 from agno.media import Video
                 from agno.models.google import Gemini
 
-                agent = Agent(model=Gemini(id="gemini-2.0-flash-exp"))
+                agent = Agent(model=Gemini(id="gemini-flash-latest"))
 
                 agent.run(
                     "Describe what happens in this video",

--- a/integrations/discord/usage/agent-with-media.mdx
+++ b/integrations/discord/usage/agent-with-media.mdx
@@ -11,7 +11,7 @@ from agno.models.google import Gemini
 
 media_agent = Agent(
     name="Media Agent",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     description="A Media processing agent",
     instructions="Analyze images, audios and videos sent by the user",
     add_history_to_context=True,

--- a/integrations/discord/usage/agent-with-user-memory.mdx
+++ b/integrations/discord/usage/agent-with-user-memory.mdx
@@ -17,7 +17,7 @@ db = SqliteDb(db_file="tmp/discord_client_cookbook.db")
 
 personal_agent = Agent(
     name="Basic Agent",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[HackerNewsTools()],
     add_history_to_context=True,
     num_history_runs=3,

--- a/knowledge/concepts/search-and-retrieval/agentic-rag-infinity-reranker.mdx
+++ b/knowledge/concepts/search-and-retrieval/agentic-rag-infinity-reranker.mdx
@@ -85,7 +85,7 @@ asyncio.run(
 )
 
 agent = Agent(
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     # Agentic RAG is enabled by default when `knowledge` is provided to the Agent.
     knowledge=knowledge,
     # search_knowledge=True gives the Agent the ability to search on demand

--- a/knowledge/concepts/search-and-retrieval/agentic-rag-with-reasoning.mdx
+++ b/knowledge/concepts/search-and-retrieval/agentic-rag-with-reasoning.mdx
@@ -39,7 +39,7 @@ asyncio.run(
 )
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     # Agentic RAG is enabled by default when `knowledge` is provided to the Agent.
     knowledge=knowledge,
     # search_knowledge=True gives the Agent the ability to search on demand

--- a/knowledge/concepts/search-and-retrieval/agentic-rag.mdx
+++ b/knowledge/concepts/search-and-retrieval/agentic-rag.mdx
@@ -85,7 +85,7 @@ asyncio.run(
 
 # Create agent with knowledge
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     knowledge=knowledge,
     search_knowledge=True,
     instructions=[

--- a/knowledge/teams/coordinated-agentic-rag.mdx
+++ b/knowledge/teams/coordinated-agentic-rag.mdx
@@ -48,7 +48,7 @@ knowledge.insert_many(urls=["https://docs.agno.com/introduction/agents.md"])
 # Knowledge Searcher Agent - Specialized in finding relevant information
 knowledge_searcher = Agent(
     name="Knowledge Searcher",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Search and retrieve relevant information from the knowledge base",
     knowledge=knowledge,
     search_knowledge=True,
@@ -64,7 +64,7 @@ knowledge_searcher = Agent(
 # Content Analyzer Agent - Specialized in analyzing retrieved content
 content_analyzer = Agent(
     name="Content Analyzer",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Analyze and extract key insights from retrieved content",
     instructions=[
         "Analyze the content provided by the Knowledge Searcher.",
@@ -78,7 +78,7 @@ content_analyzer = Agent(
 # Response Synthesizer Agent - Specialized in creating comprehensive responses
 response_synthesizer = Agent(
     name="Response Synthesizer",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Create comprehensive final response with proper citations",
     instructions=[
         "Synthesize information from team members into a comprehensive response.",
@@ -92,7 +92,7 @@ response_synthesizer = Agent(
 # Create coordinated RAG team
 coordinated_rag_team = Team(
     name="Coordinated RAG Team",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     members=[knowledge_searcher, content_analyzer, response_synthesizer],
     instructions=[
         "Work together to provide comprehensive responses using the knowledge base.",

--- a/knowledge/teams/coordinated-reasoning-rag.mdx
+++ b/knowledge/teams/coordinated-reasoning-rag.mdx
@@ -47,7 +47,7 @@ knowledge = Knowledge(
 # Information Gatherer Agent - Specialized in comprehensive information retrieval
 information_gatherer = Agent(
     name="Information Gatherer",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Gather comprehensive information from knowledge sources",
     knowledge=knowledge,
     search_knowledge=True,
@@ -64,7 +64,7 @@ information_gatherer = Agent(
 # Reasoning Analyst Agent - Specialized in logical analysis
 reasoning_analyst = Agent(
     name="Reasoning Analyst",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Apply logical reasoning to analyze gathered information",
     tools=[ReasoningTools(add_instructions=True)],
     instructions=[
@@ -80,7 +80,7 @@ reasoning_analyst = Agent(
 # Evidence Evaluator Agent - Specialized in evidence assessment
 evidence_evaluator = Agent(
     name="Evidence Evaluator",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Evaluate evidence quality and identify information gaps",
     tools=[ReasoningTools(add_instructions=True)],
     instructions=[
@@ -96,7 +96,7 @@ evidence_evaluator = Agent(
 # Response Coordinator Agent - Specialized in synthesis and coordination
 response_coordinator = Agent(
     name="Response Coordinator",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Coordinate team findings into comprehensive reasoned response",
     tools=[ReasoningTools(add_instructions=True)],
     instructions=[
@@ -112,7 +112,7 @@ response_coordinator = Agent(
 # Create coordinated reasoning RAG team
 coordinated_reasoning_team = Team(
     name="Coordinated Reasoning RAG Team",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     members=[
         information_gatherer,
         reasoning_analyst,

--- a/knowledge/teams/distributed-infinity-search.mdx
+++ b/knowledge/teams/distributed-infinity-search.mdx
@@ -65,7 +65,7 @@ knowledge_secondary = Knowledge(
 # Primary Searcher Agent - Broad search with infinity reranking
 primary_searcher = Agent(
     name="Primary Searcher",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Perform comprehensive primary search with high-performance reranking",
     knowledge=knowledge_primary,
     search_knowledge=True,
@@ -81,7 +81,7 @@ primary_searcher = Agent(
 # Secondary Searcher Agent - Targeted and specialized search
 secondary_searcher = Agent(
     name="Secondary Searcher",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Perform targeted searches on specific topics and edge cases",
     knowledge=knowledge_secondary,
     search_knowledge=True,
@@ -97,7 +97,7 @@ secondary_searcher = Agent(
 # Cross-Reference Validator Agent - Validates across sources
 cross_reference_validator = Agent(
     name="Cross-Reference Validator",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Validate information consistency across different search results",
     instructions=[
         "Compare and validate information from both searchers.",
@@ -111,7 +111,7 @@ cross_reference_validator = Agent(
 # Result Synthesizer Agent - Combines and ranks all findings
 result_synthesizer = Agent(
     name="Result Synthesizer",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Synthesize and rank all search results into comprehensive response",
     instructions=[
         "Combine results from all team members into a unified response.",
@@ -125,7 +125,7 @@ result_synthesizer = Agent(
 # Create distributed search team
 distributed_search_team = Team(
     name="Distributed Search Team with Infinity Reranker",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     members=[
         primary_searcher,
         secondary_searcher,

--- a/memory/working-with-memories/custom-memory-instructions.mdx
+++ b/memory/working-with-memories/custom-memory-instructions.mdx
@@ -51,7 +51,7 @@ pprint(memories)
 
 
 # Use default memory manager
-memory = MemoryManager(model=Claude(id="claude-3-5-sonnet-latest"), db=memory_db)
+memory = MemoryManager(model=Claude(id="claude-sonnet-4-6"), db=memory_db)
 jane_doe_id = "jane_doe@example.com"
 
 # Send a history of messages and add memories

--- a/models/cache-response.mdx
+++ b/models/cache-response.mdx
@@ -112,7 +112,7 @@ from agno.models.anthropic import Claude
 # Create agent with cached responses
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-6",
         cache_response=True,
         cache_ttl=3600
     ),

--- a/models/model-as-string.mdx
+++ b/models/model-as-string.mdx
@@ -26,8 +26,8 @@ The string format follows this pattern:
 
 **Examples:**
 - `"openai:gpt-4o"`
-- `"anthropic:claude-sonnet-4-20250514"`
-- `"google:gemini-2.0-flash-exp"`
+- `"anthropic:claude-sonnet-4-6"`
+- `"google:gemini-flash-latest"`
 - `"groq:llama-3.3-70b-versatile"`
 
 ## Basic Usage
@@ -90,7 +90,7 @@ agent = Agent(
     # Main model for general responses
     model="openai:gpt-4o",
     # Reasoning model for complex thinking
-    reasoning_model="anthropic:claude-sonnet-4-20250514",
+    reasoning_model="anthropic:claude-sonnet-4-6",
     # Parser model for structured outputs
     parser_model="openai:gpt-4o-mini",
     # Output model for final formatting
@@ -104,14 +104,14 @@ agent = Agent(
 | Provider | String Format | Example |
 |----------|---------------|---------|
 | OpenAI | `openai:model_id` | `"openai:gpt-4o"` |
-| Anthropic | `anthropic:model_id` | `"anthropic:claude-sonnet-4-20250514"` |
-| Google | `google:model_id` | `"google:gemini-2.0-flash-exp"` |
+| Anthropic | `anthropic:model_id` | `"anthropic:claude-sonnet-4-6"` |
+| Google | `google:model_id` | `"google:gemini-flash-latest"` |
 | Groq | `groq:model_id` | `"groq:llama-3.3-70b-versatile"` |
 | Ollama | `ollama:model_id` | `"ollama:llama3.2"` |
 | Azure AI Foundry | `azure-ai-foundry:model_id` | `"azure-ai-foundry:gpt-4o"` |
 | Mistral | `mistral:model_id` | `"mistral:mistral-large-latest"` |
 | LiteLLM | `litellm:model_id` | `"litellm:gpt-4o"` |
-| OpenRouter | `openrouter:model_id` | `"openrouter:anthropic/claude-3.5-sonnet"` |
+| OpenRouter | `openrouter:model_id` | `"openrouter:anthropic/claude-sonnet-4-6"` |
 | Together | `together:model_id` | `"together:meta-llama/Llama-3-70b-chat-hf"` |
 
 For the complete list and provider-specific documentation, see the [Models Overview](/models/overview).

--- a/models/providers/cloud/aws-claude/overview.mdx
+++ b/models/providers/cloud/aws-claude/overview.mdx
@@ -8,9 +8,9 @@ Use Claude models through AWS Bedrock. This provides a native Claude integration
 
 We recommend experimenting to find the best-suited model for your use-case. Here are some general recommendations:
 
-- `anthropic.claude-sonnet-4-20250514-v1:0` model is their most capable model (Claude Sonnet 4).
-- `anthropic.claude-3-5-sonnet-20241022-v2:0` model is good for most use-cases and supports image input.
-- `anthropic.claude-3-5-haiku-20241022-v2:0` model is their fastest model.
+- `anthropic.claude-sonnet-4-6` model is their most capable model (Claude Sonnet 4).
+- `anthropic.claude-sonnet-4-6` model is good for most use-cases and supports image input.
+- `anthropic.claude-haiku-4-5-20251001-v1:0` model is their fastest model.
 
 ## Authentication
 
@@ -42,7 +42,7 @@ from agno.models.aws import Claude
 
 agent = Agent(
     model=Claude(
-        id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        id="us.anthropic.claude-sonnet-4-6",
         api_key="your-api-key",
         aws_region="us-east-1"
     )
@@ -79,7 +79,7 @@ from agno.models.aws import Claude
 
 agent = Agent(
     model=Claude(
-        id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        id="us.anthropic.claude-sonnet-4-6",
         aws_access_key="your-access-key",
         aws_secret_key="your-secret-key",
         aws_region="us-east-1"
@@ -105,7 +105,7 @@ session = Session(
 
 agent = Agent(
     model=Claude(
-        id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        id="us.anthropic.claude-sonnet-4-6",
         session=session
     )
 )
@@ -126,7 +126,7 @@ from agno.agent import Agent
 from agno.models.aws import Claude
 
 agent = Agent(
-    model=Claude(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=Claude(id="us.anthropic.claude-sonnet-4-6"),
     markdown=True
 )
 
@@ -142,7 +142,7 @@ agent.print_response("Share a 2 sentence horror story.")
 
 | Parameter                | Type                       | Default                                      | Description                                                                                               |
 | ------------------------ | -------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `id`                     | `str`                      | `"anthropic.claude-sonnet-4-20250514-v1:0"` | The specific AWS Bedrock Claude model ID to use                                                        |
+| `id`                     | `str`                      | `"anthropic.claude-sonnet-4-6"` | The specific AWS Bedrock Claude model ID to use                                                        |
 | `name`                   | `str`                      | `"AwsBedrockAnthropicClaude"`                | The name identifier for the AWS Bedrock Claude model                                                    |
 | `provider`               | `str`                      | `"AwsBedrock"`                               | The provider of the model                                                                                |
 | `api_key`                | `Optional[str]`            | `None`                                       | The AWS Bedrock API key for authentication (defaults to AWS_BEDROCK_API_KEY env var)                    |

--- a/models/providers/cloud/aws-claude/usage/basic-stream.mdx
+++ b/models/providers/cloud/aws-claude/usage/basic-stream.mdx
@@ -10,7 +10,7 @@ from agno.agent import Agent, RunOutput  # noqa
 from agno.models.aws import Claude
 
 agent = Agent(
-    model=Claude(id="us.anthropic.claude-sonnet-4-20250514-v1:0"), markdown=True
+    model=Claude(id="us.anthropic.claude-sonnet-4-6"), markdown=True
 )
 
 # Get the response in a variable

--- a/models/providers/cloud/aws-claude/usage/basic.mdx
+++ b/models/providers/cloud/aws-claude/usage/basic.mdx
@@ -9,7 +9,7 @@ from agno.agent import Agent, RunOutput  # noqa
 from agno.models.aws import Claude
 
 agent = Agent(
-    model=Claude(id="us.anthropic.claude-sonnet-4-20250514-v1:0"), markdown=True
+    model=Claude(id="us.anthropic.claude-sonnet-4-6"), markdown=True
 )
 
 # Get the response in a variable

--- a/models/providers/cloud/aws-claude/usage/knowledge.mdx
+++ b/models/providers/cloud/aws-claude/usage/knowledge.mdx
@@ -20,7 +20,7 @@ knowledge_base.insert(
 )
 
 agent = Agent(
-    model=Claude(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=Claude(id="us.anthropic.claude-sonnet-4-6"),
     knowledge=knowledge_base,
 )
 agent.print_response("How to make Thai curry?", markdown=True)

--- a/models/providers/cloud/aws-claude/usage/storage.mdx
+++ b/models/providers/cloud/aws-claude/usage/storage.mdx
@@ -15,7 +15,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 db = PostgresDb(db_url=db_url)
 
 agent = Agent(
-    model=Claude(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=Claude(id="us.anthropic.claude-sonnet-4-6"),
     db=db,
     tools=[HackerNewsTools()],
     add_history_to_context=True,

--- a/models/providers/cloud/aws-claude/usage/structured-output.mdx
+++ b/models/providers/cloud/aws-claude/usage/structured-output.mdx
@@ -31,7 +31,7 @@ class MovieScript(BaseModel):
     )
 
 movie_agent = Agent(
-    model=Claude(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=Claude(id="us.anthropic.claude-sonnet-4-6"),
     description="You help people write movie scripts.",
     output_schema=MovieScript,
 )

--- a/models/providers/cloud/aws-claude/usage/tool-use.mdx
+++ b/models/providers/cloud/aws-claude/usage/tool-use.mdx
@@ -10,7 +10,7 @@ from agno.models.aws import Claude
 from agno.tools.hackernews import HackerNewsTools
 
 agent = Agent(
-    model=Claude(id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    model=Claude(id="us.anthropic.claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     markdown=True,
 )

--- a/models/providers/gateways/aimlapi/overview.mdx
+++ b/models/providers/gateways/aimlapi/overview.mdx
@@ -59,10 +59,10 @@ agent.print_response("Explain how black holes are formed.")
 
 AI/ML API provides access to 300+ models. Some popular models include:
 
-- **OpenAI Models**: `gpt-4o`, `gpt-4o-mini`, `o1`, `o1-mini`
-- **Anthropic Models**: `claude-3-5-sonnet-20241022`, `claude-3-5-haiku-20241022`
+- **OpenAI Models**: `gpt-4o`, `gpt-4o-mini`, `o4-mini`
+- **Anthropic Models**: `claude-sonnet-4-6`
 - **Meta Models**: `meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo`, `meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo`
-- **Google Models**: `gemini-1.5-pro`, `gemini-1.5-flash`
+- **Google Models**: `gemini-pro-latest`, `gemini-flash-latest`
 - **DeepSeek Models**: `deepseek-chat`, `deepseek-reasoner`
 
 For a complete list of available models, visit the [AI/ML API documentation](https://docs.aimlapi.com/).

--- a/models/providers/gateways/nexus/overview.mdx
+++ b/models/providers/gateways/nexus/overview.mdx
@@ -40,7 +40,7 @@ Use `Nexus` with your `Agent`:
 from agno.agent import Agent
 from agno.models.nexus import Nexus
 
-agent = Agent(model=Nexus(id="anthropic/claude-sonnet-4-20250514"), markdown=True)
+agent = Agent(model=Nexus(id="anthropic/claude-sonnet-4-6"), markdown=True)
 
 # Print the response in the terminal
 agent.print_response("Share a 2 sentence horror story")

--- a/models/providers/gateways/nexus/usage/async-basic-stream.mdx
+++ b/models/providers/gateways/nexus/usage/async-basic-stream.mdx
@@ -14,7 +14,7 @@ import asyncio
 from agno.agent import Agent
 from agno.models.nexus import Nexus
 
-agent = Agent(model=Nexus(id="anthropic/claude-sonnet-4-20250514"), markdown=True)
+agent = Agent(model=Nexus(id="anthropic/claude-sonnet-4-6"), markdown=True)
 
 asyncio.run(agent.aprint_response("Share a 2 sentence horror story", stream=True))
 

--- a/models/providers/gateways/nexus/usage/async-basic.mdx
+++ b/models/providers/gateways/nexus/usage/async-basic.mdx
@@ -14,7 +14,7 @@ import asyncio
 from agno.agent import Agent
 from agno.models.nexus import Nexus
 
-agent = Agent(model=Nexus(id="anthropic/claude-sonnet-4-20250514"), markdown=True)
+agent = Agent(model=Nexus(id="anthropic/claude-sonnet-4-6"), markdown=True)
 
 asyncio.run(agent.aprint_response("Share a 2 sentence horror story"))
 

--- a/models/providers/gateways/nexus/usage/async-tool-use.mdx
+++ b/models/providers/gateways/nexus/usage/async-tool-use.mdx
@@ -16,7 +16,7 @@ from agno.models.nexus import Nexus
 from agno.tools.hackernews import HackerNewsTools
 
 agent = Agent(
-    model=Nexus(id="anthropic/claude-sonnet-4-20250514"),
+    model=Nexus(id="anthropic/claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     markdown=True,
 )

--- a/models/providers/gateways/nexus/usage/basic.mdx
+++ b/models/providers/gateways/nexus/usage/basic.mdx
@@ -8,7 +8,7 @@ title: Basic Agent
 from agno.agent import Agent, RunOutput  # noqa
 from agno.models.nexus import Nexus
 
-agent = Agent(model=Nexus(id="anthropic/claude-sonnet-4-20250514"), markdown=True)
+agent = Agent(model=Nexus(id="anthropic/claude-sonnet-4-6"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/models/providers/gateways/nexus/usage/tool-use.mdx
+++ b/models/providers/gateways/nexus/usage/tool-use.mdx
@@ -12,7 +12,7 @@ from agno.models.nexus import Nexus
 from agno.tools.hackernews import HackerNewsTools
 
 agent = Agent(
-    model=Nexus(id="anthropic/claude-sonnet-4-20250514"),
+    model=Nexus(id="anthropic/claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     markdown=True,
 )

--- a/models/providers/native/anthropic/overview.mdx
+++ b/models/providers/native/anthropic/overview.mdx
@@ -9,9 +9,9 @@ See their model comparisons [here](https://docs.anthropic.com/en/docs/about-clau
 
 We recommend experimenting to find the best-suited model for your use-case. Here are some general recommendations:
 
-- `claude-sonnet-4-20250514` model is good for most use-cases and supports image input.
+- `claude-sonnet-4-6` model is good for most use-cases and supports image input.
 - `claude-opus-4-1-20250805` model is their best model.
-- `claude-3-5-haiku-20241022` model is their fastest model.
+- `claude-sonnet-4-6` model is their fastest model.
 
 Anthropic has rate limits on their APIs. See the [docs](https://docs.anthropic.com/en/api/rate-limits#response-headers) for more information.
 
@@ -48,7 +48,7 @@ from agno.agent import Agent
 from agno.models.anthropic import Claude
 
 agent = Agent(
-    model=Claude(id="claude-3-5-sonnet-20240620"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True
 )
 
@@ -85,7 +85,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-3-5-sonnet-20241022",
+        id="claude-sonnet-4-6",
         cache_system_prompt=True,
     ),
 )
@@ -112,7 +112,7 @@ class User(BaseModel):
     email: str
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     description="Extract user information.",
     output_schema=User,
 )
@@ -127,7 +127,7 @@ Read more about structured outputs with Agno's `Claude` model:
 
 | Parameter             | Type                                     | Default                        | Description                                                                                                                      |
 | --------------------- | ---------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                  | `str`                                    | `"claude-3-5-sonnet-20241022"` | The id of the Anthropic Claude model to use                                                                                      |
+| `id`                  | `str`                                    | `"claude-sonnet-4-6"` | The id of the Anthropic Claude model to use                                                                                      |
 | `name`                | `str`                                    | `"Claude"`                     | The name of the model                                                                                                            |
 | `provider`            | `str`                                    | `"Anthropic"`                  | The provider of the model                                                                                                        |
 | `max_tokens`          | `Optional[int]`                          | `4096`                         | Maximum number of tokens to generate in the chat completion                                                                      |

--- a/models/providers/native/anthropic/usage/basic-stream.mdx
+++ b/models/providers/native/anthropic/usage/basic-stream.mdx
@@ -9,7 +9,7 @@ from typing import Iterator  # noqa
 from agno.agent import Agent, RunOutputEvent  # noqa
 from agno.models.anthropic import Claude
 
-agent = Agent(model=Claude(id="claude-sonnet-4-20250514"), markdown=True)
+agent = Agent(model=Claude(id="claude-sonnet-4-6"), markdown=True)
 
 # Get the response in a variable
 # run_response: Iterator[RunOutputEvent] = agent.run("Share a 2 sentence horror story", stream=True)

--- a/models/providers/native/anthropic/usage/basic.mdx
+++ b/models/providers/native/anthropic/usage/basic.mdx
@@ -8,7 +8,7 @@ title: Basic Agent
 from agno.agent import Agent, RunOutput  # noqa
 from agno.models.anthropic import Claude
 
-agent = Agent(model=Claude(id="claude-sonnet-4-20250514"), markdown=True)
+agent = Agent(model=Claude(id="claude-sonnet-4-6"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/models/providers/native/anthropic/usage/code-execution.mdx
+++ b/models/providers/native/anthropic/usage/code-execution.mdx
@@ -14,7 +14,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-6",
         betas=["code-execution-2025-05-22"],
     ),
     tools=[

--- a/models/providers/native/anthropic/usage/image-input-bytes.mdx
+++ b/models/providers/native/anthropic/usage/image-input-bytes.mdx
@@ -14,7 +14,7 @@ from agno.tools.hackernews import HackerNewsTools
 from agno.utils.media import download_image
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     markdown=True,
 )

--- a/models/providers/native/anthropic/usage/image-input-url.mdx
+++ b/models/providers/native/anthropic/usage/image-input-url.mdx
@@ -11,7 +11,7 @@ from agno.models.anthropic import Claude
 from agno.tools.hackernews import HackerNewsTools
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     markdown=True,
 )

--- a/models/providers/native/anthropic/usage/knowledge.mdx
+++ b/models/providers/native/anthropic/usage/knowledge.mdx
@@ -26,7 +26,7 @@ knowledge.insert(
 )
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     knowledge=knowledge,
     debug_mode=True,
 )

--- a/models/providers/native/anthropic/usage/pdf-input-bytes.mdx
+++ b/models/providers/native/anthropic/usage/pdf-input-bytes.mdx
@@ -20,7 +20,7 @@ download_file(
 )
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True,
 )
 

--- a/models/providers/native/anthropic/usage/pdf-input-local.mdx
+++ b/models/providers/native/anthropic/usage/pdf-input-local.mdx
@@ -20,7 +20,7 @@ download_file(
 )
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True,
 )
 

--- a/models/providers/native/anthropic/usage/pdf-input-url.mdx
+++ b/models/providers/native/anthropic/usage/pdf-input-url.mdx
@@ -10,7 +10,7 @@ from agno.media import File
 from agno.models.anthropic import Claude
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     markdown=True,
 )
 

--- a/models/providers/native/anthropic/usage/prompt-caching.mdx
+++ b/models/providers/native/anthropic/usage/prompt-caching.mdx
@@ -17,7 +17,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-3-5-sonnet-20241022",
+        id="claude-sonnet-4-6",
         cache_system_prompt=True,
     ),
 )
@@ -35,7 +35,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-3-5-sonnet-20241022",
+        id="claude-sonnet-4-6",
         betas=["extended-cache-ttl-2025-04-11"],
         cache_system_prompt=True,
         extended_cache_time=True,
@@ -61,7 +61,7 @@ system_message = txt_path.read_text()
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-6",
         cache_system_prompt=True,  # Activate prompt caching for Anthropic to cache the system prompt
     ),
     system_message=system_message,

--- a/models/providers/native/anthropic/usage/skills.mdx
+++ b/models/providers/native/anthropic/usage/skills.mdx
@@ -222,7 +222,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-5-20250929",
+        id="claude-sonnet-4-6",
         skills=[
             {"type": "anthropic", "skill_id": "pptx", "version": "latest"}
         ]
@@ -244,7 +244,7 @@ You can enable multiple skills at once:
 
 ```python
 model=Claude(
-    id="claude-sonnet-4-5-20250929",
+    id="claude-sonnet-4-6",
     skills=[
         {"type": "anthropic", "skill_id": "pptx", "version": "latest"},
         {"type": "anthropic", "skill_id": "xlsx", "version": "latest"},
@@ -270,7 +270,7 @@ from file_download_helper import download_skill_files
 powerpoint_agent = Agent(
     name="PowerPoint Creator",
     model=Claude(
-        id="claude-sonnet-4-5-20250929",
+        id="claude-sonnet-4-6",
         skills=[
             {"type": "anthropic", "skill_id": "pptx", "version": "latest"}
         ],
@@ -329,7 +329,7 @@ from file_download_helper import download_skill_files
 excel_agent = Agent(
     name="Excel Creator",
     model=Claude(
-        id="claude-sonnet-4-5-20250929",
+        id="claude-sonnet-4-6",
         skills=[
             {"type": "anthropic", "skill_id": "xlsx", "version": "latest"}
         ],
@@ -395,7 +395,7 @@ from file_download_helper import download_skill_files
 document_agent = Agent(
     name="Document Creator",
     model=Claude(
-        id="claude-sonnet-4-5-20250929",
+        id="claude-sonnet-4-6",
         skills=[
             {"type": "anthropic", "skill_id": "docx", "version": "latest"}
         ],
@@ -473,7 +473,7 @@ from file_download_helper import download_skill_files
 multi_skill_agent = Agent(
     name="Multi-Skill Document Creator",
     model=Claude(
-        id="claude-sonnet-4-5-20250929",
+        id="claude-sonnet-4-6",
         skills=[
             {"type": "anthropic", "skill_id": "pptx", "version": "latest"},
             {"type": "anthropic", "skill_id": "xlsx", "version": "latest"},
@@ -557,8 +557,8 @@ if response.messages:
 
 ### Model Requirements
 
-- **Recommended**: `claude-sonnet-4-5-20250929` or later
-- **Minimum**: `claude-3-5-sonnet-20241022`
+- **Recommended**: `claude-sonnet-4-6` or later
+- **Minimum**: `claude-sonnet-4-6`
 - Skills require models with code execution capability
 
 ### Beta Version

--- a/models/providers/native/anthropic/usage/structured-output-stream.mdx
+++ b/models/providers/native/anthropic/usage/structured-output-stream.mdx
@@ -35,7 +35,7 @@ class MovieScript(BaseModel):
 
 # Agent that uses structured outputs
 structured_output_agent = Agent(
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     description="You write movie scripts.",
     output_schema=MovieScript,
 )

--- a/models/providers/native/anthropic/usage/structured-output-strict-tools.mdx
+++ b/models/providers/native/anthropic/usage/structured-output-strict-tools.mdx
@@ -50,7 +50,7 @@ weather_tool = Function(
 
 # Agent with both structured outputs and strict tool
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[weather_tool],
     output_schema=WeatherInfo,
     description="You help users get weather information.",

--- a/models/providers/native/anthropic/usage/structured-output.mdx
+++ b/models/providers/native/anthropic/usage/structured-output.mdx
@@ -31,7 +31,7 @@ class MovieScript(BaseModel):
     )
 
 movie_agent = Agent(
-    model=Claude(id="claude-sonnet-4-5-20250929"),
+    model=Claude(id="claude-sonnet-4-6"),
     description="You help people write movie scripts.",
     output_schema=MovieScript,
 )

--- a/models/providers/native/anthropic/usage/tool-use.mdx
+++ b/models/providers/native/anthropic/usage/tool-use.mdx
@@ -10,7 +10,7 @@ from agno.models.anthropic import Claude
 from agno.tools.hackernews import HackerNewsTools
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[HackerNewsTools()],
     markdown=True,
 )

--- a/models/providers/native/google/overview.mdx
+++ b/models/providers/native/google/overview.mdx
@@ -13,8 +13,8 @@ Gemini stands out with native multimodal understanding across images, video, and
 
 | Model | Best For | Key Strengths |
 |-------|----------|---------------|
-| `gemini-2.0-flash` | Most use-cases | Balanced speed and intelligence |
-| `gemini-2.0-flash-lite` | High-volume tasks | Most cost-effective |
+| `gemini-flash-latest` | Most use-cases | Balanced speed and intelligence |
+| `gemini-flash-latest-lite` | High-volume tasks | Most cost-effective |
 | `gemini-2.5-pro` | Complex tasks | Advanced reasoning, largest context |
 | `gemini-3-pro-preview` | Latest features | Thought signatures support |
 
@@ -76,7 +76,7 @@ from agno.models.google import Gemini
 
 agent = Agent(
     model=Gemini(
-        id="gemini-2.0-flash",
+        id="gemini-flash-latest",
         vertexai=True,
         project_id="your-project-id",
         location="us-central1",
@@ -97,7 +97,7 @@ from agno.agent import Agent
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 
@@ -142,7 +142,7 @@ from agno.media import Image
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 
@@ -201,7 +201,7 @@ from agno.agent import Agent
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp", search=True),
+    model=Gemini(id="gemini-flash-latest", search=True),
     markdown=True,
 )
 
@@ -213,7 +213,7 @@ For legacy models, use `grounding=True` instead:
 ```python
 agent = Agent(
     model=Gemini(
-        id="gemini-2.0-flash",
+        id="gemini-flash-latest",
         grounding=True,
         grounding_dynamic_threshold=0.7,  # Optional: set threshold
     ),
@@ -340,7 +340,7 @@ client = genai.Client()
 # Upload file and create cache
 txt_file = client.files.upload(file="large_document.txt")
 cache = client.caches.create(
-    model="gemini-2.0-flash-001",
+    model="gemini-flash-latest",
     config={
         "system_instruction": "You are an expert at analyzing transcripts.",
         "contents": [txt_file],
@@ -350,7 +350,7 @@ cache = client.caches.create(
 
 # Use the cached content - no need to resend the file
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001", cached_content=cache.name),
+    model=Gemini(id="gemini-flash-latest", cached_content=cache.name),
 )
 run_output = agent.run("Find a lighthearted moment from this transcript")
 ```
@@ -397,7 +397,7 @@ class MovieScript(BaseModel):
     storyline: str
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     output_schema=MovieScript,
 )
 ```
@@ -414,7 +414,7 @@ from agno.models.google import Gemini
 from agno.tools.hackernews import HackerNewsTools
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[HackerNewsTools()],
     markdown=True,
 )
@@ -428,7 +428,7 @@ Read more about tool use [here](/models/providers/native/google/usage/tool-use).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `id` | `str` | `"gemini-2.0-flash-001"` | The id of the Gemini model to use |
+| `id` | `str` | `"gemini-flash-latest"` | The id of the Gemini model to use |
 | `name` | `str` | `"Gemini"` | The name of the model |
 | `provider` | `str` | `"Google"` | The provider of the model |
 | `api_key` | `Optional[str]` | `None` | Google API key (defaults to `GOOGLE_API_KEY` env var) |

--- a/models/providers/native/google/usage/audio-input-bytes-content.mdx
+++ b/models/providers/native/google/usage/audio-input-bytes-content.mdx
@@ -11,7 +11,7 @@ from agno.media import Audio
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 

--- a/models/providers/native/google/usage/audio-input-file-upload.mdx
+++ b/models/providers/native/google/usage/audio-input-file-upload.mdx
@@ -11,7 +11,7 @@ from agno.agent import Agent
 from agno.media import Audio
 from agno.models.google import Gemini
 
-model = Gemini(id="gemini-2.0-flash-exp")
+model = Gemini(id="gemini-flash-latest")
 agent = Agent(
     model=model,
     markdown=True,

--- a/models/providers/native/google/usage/audio-input-local-file-upload.mdx
+++ b/models/providers/native/google/usage/audio-input-local-file-upload.mdx
@@ -11,7 +11,7 @@ from agno.media import Audio
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 

--- a/models/providers/native/google/usage/basic-stream.mdx
+++ b/models/providers/native/google/usage/basic-stream.mdx
@@ -9,7 +9,7 @@ from typing import Iterator  # noqa
 from agno.agent import Agent, RunOutputEvent  # noqa
 from agno.models.google import Gemini
 
-agent = Agent(model=Gemini(id="gemini-2.0-flash-001"), markdown=True)
+agent = Agent(model=Gemini(id="gemini-flash-latest"), markdown=True)
 
 # Get the response in a variable
 # run_response: Iterator[RunOutputEvent] = agent.run("Share a 2 sentence horror story", stream=True)

--- a/models/providers/native/google/usage/basic.mdx
+++ b/models/providers/native/google/usage/basic.mdx
@@ -8,7 +8,7 @@ title: Basic Agent
 from agno.agent import Agent, RunOutput  # noqa
 from agno.models.google import Gemini
 
-agent = Agent(model=Gemini(id="gemini-2.0-flash-001"), markdown=True)
+agent = Agent(model=Gemini(id="gemini-flash-latest"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/models/providers/native/google/usage/flash-thinking.mdx
+++ b/models/providers/native/google/usage/flash-thinking.mdx
@@ -15,7 +15,7 @@ task = (
     "How can all six people get across the river safely? Provide a step-by-step solution and show the solutions as an ascii diagram"
 )
 
-agent = Agent(model=Gemini(id="gemini-2.0-flash-thinking-exp-1219"), markdown=True)
+agent = Agent(model=Gemini(id="gemini-flash-latest"), markdown=True)
 agent.print_response(task, stream=True)
 ```
 

--- a/models/providers/native/google/usage/gcs-file-input.mdx
+++ b/models/providers/native/google/usage/gcs-file-input.mdx
@@ -17,7 +17,7 @@ from agno.models.google import Gemini
 
 agent = Agent(
     model=Gemini(
-        id="gemini-2.0-flash",
+        id="gemini-flash-latest",
         vertexai=True,
     ),
     markdown=True,

--- a/models/providers/native/google/usage/grounding.mdx
+++ b/models/providers/native/google/usage/grounding.mdx
@@ -18,7 +18,7 @@ from agno.models.google import Gemini
 
 agent = Agent(
     model=Gemini(
-        id="gemini-2.0-flash",
+        id="gemini-flash-latest",
         grounding=True,
         grounding_dynamic_threshold=0.7,  # Optional: set threshold for grounding
     ),

--- a/models/providers/native/google/usage/image-editing.mdx
+++ b/models/providers/native/google/usage/image-editing.mdx
@@ -15,7 +15,7 @@ from PIL import Image as PILImage
 # No system message should be provided (Gemini requires only the image)
 agent = Agent(
     model=Gemini(
-        id="gemini-2.0-flash-exp-image-generation",
+        id="gemini-2.5-flash-image",
         response_modalities=["Text", "Image"],
     )
 )

--- a/models/providers/native/google/usage/image-generation-stream.mdx
+++ b/models/providers/native/google/usage/image-generation-stream.mdx
@@ -14,7 +14,7 @@ from PIL import Image
 # No system message should be provided
 agent = Agent(
     model=Gemini(
-        id="gemini-2.0-flash-exp-image-generation",
+        id="gemini-2.5-flash-image",
         response_modalities=["Text", "Image"],
     )
 )

--- a/models/providers/native/google/usage/image-generation.mdx
+++ b/models/providers/native/google/usage/image-generation.mdx
@@ -14,7 +14,7 @@ from PIL import Image
 # No system message should be provided
 agent = Agent(
     model=Gemini(
-        id="gemini-2.0-flash-exp-image-generation",
+        id="gemini-2.5-flash-image",
         response_modalities=["Text", "Image"],
     )
 )

--- a/models/providers/native/google/usage/image-input-file-upload.mdx
+++ b/models/providers/native/google/usage/image-input-file-upload.mdx
@@ -15,7 +15,7 @@ from google.generativeai import upload_file
 from google.generativeai.types import file_types
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[HackerNewsTools()],
     markdown=True,
 )

--- a/models/providers/native/google/usage/image-input.mdx
+++ b/models/providers/native/google/usage/image-input.mdx
@@ -11,7 +11,7 @@ from agno.models.google import Gemini
 from agno.tools.hackernews import HackerNewsTools
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[HackerNewsTools()],
     markdown=True,
 )

--- a/models/providers/native/google/usage/knowledge.mdx
+++ b/models/providers/native/google/usage/knowledge.mdx
@@ -25,7 +25,7 @@ knowledge.insert(
     url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"
 )
 
-agent = Agent(model=Gemini(id="gemini-2.0-flash-001"), knowledge=knowledge)
+agent = Agent(model=Gemini(id="gemini-flash-latest"), knowledge=knowledge)
 agent.print_response("How to make Thai curry?", markdown=True)
 ```
 

--- a/models/providers/native/google/usage/pdf-input-local.mdx
+++ b/models/providers/native/google/usage/pdf-input-local.mdx
@@ -19,7 +19,7 @@ download_file(
 )
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
     add_history_to_context=True,
 )

--- a/models/providers/native/google/usage/pdf-input-url.mdx
+++ b/models/providers/native/google/usage/pdf-input-url.mdx
@@ -10,7 +10,7 @@ from agno.media import File
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 

--- a/models/providers/native/google/usage/storage.mdx
+++ b/models/providers/native/google/usage/storage.mdx
@@ -15,7 +15,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 db = PostgresDb(db_url=db_url)
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     db=db,
     tools=[HackerNewsTools()],
     add_history_to_context=True,

--- a/models/providers/native/google/usage/structured-output.mdx
+++ b/models/providers/native/google/usage/structured-output.mdx
@@ -31,7 +31,7 @@ class MovieScript(BaseModel):
     )
 
 structured_output_agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     description="You help people write movie scripts.",
     output_schema=MovieScript,
 )

--- a/models/providers/native/google/usage/tool-use.mdx
+++ b/models/providers/native/google/usage/tool-use.mdx
@@ -10,7 +10,7 @@ from agno.models.google import Gemini
 from agno.tools.hackernews import HackerNewsTools
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[HackerNewsTools()],
     markdown=True,
 )

--- a/models/providers/native/google/usage/vertexai.mdx
+++ b/models/providers/native/google/usage/vertexai.mdx
@@ -24,7 +24,7 @@ gemini = Gemini(
 from agno.agent import Agent, RunOutput  # noqa
 from agno.models.google import Gemini
 
-agent = Agent(model=Gemini(id="gemini-2.0-flash-001"), markdown=True)
+agent = Agent(model=Gemini(id="gemini-flash-latest"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/models/providers/native/google/usage/video-input-bytes-content.mdx
+++ b/models/providers/native/google/usage/video-input-bytes-content.mdx
@@ -11,7 +11,7 @@ from agno.media import Video
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 

--- a/models/providers/native/google/usage/video-input-file-upload.mdx
+++ b/models/providers/native/google/usage/video-input-file-upload.mdx
@@ -13,7 +13,7 @@ from agno.media import Video
 from agno.models.google import Gemini
 from agno.utils.log import logger
 
-model = Gemini(id="gemini-2.0-flash-exp")
+model = Gemini(id="gemini-flash-latest")
 agent = Agent(
     model=model,
     markdown=True,

--- a/models/providers/native/google/usage/video-input-local-file-upload.mdx
+++ b/models/providers/native/google/usage/video-input-local-file-upload.mdx
@@ -12,7 +12,7 @@ from agno.media import Video
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 

--- a/multimodal/agent/usage/audio-sentiment-analysis.mdx
+++ b/multimodal/agent/usage/audio-sentiment-analysis.mdx
@@ -13,7 +13,7 @@ from agno.models.google import Gemini
 
 db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     add_history_to_context=True,
     markdown=True,
     db=SqliteDb(

--- a/multimodal/agent/usage/audio-to-text.mdx
+++ b/multimodal/agent/usage/audio-to-text.mdx
@@ -13,7 +13,7 @@ from agno.media import Audio
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 

--- a/multimodal/agent/usage/image-output.mdx
+++ b/multimodal/agent/usage/image-output.mdx
@@ -21,7 +21,7 @@ from PIL import Image
 
 agent = Agent(
     model=Gemini(
-        id="gemini-2.0-flash-exp-image-generation",
+        id="gemini-2.5-flash-image",
         response_modalities=["Text", "Image"], # Generate both images and text in the response
     )
 )

--- a/multimodal/agent/usage/video-to-shorts.mdx
+++ b/multimodal/agent/usage/video-to-shorts.mdx
@@ -27,7 +27,7 @@ output_dir = Path("tmp/shorts")
 agent = Agent(
     name="Video2Shorts",
     description="Process videos and generate engaging shorts.",
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
     instructions=[
         "Analyze the provided video directly—do NOT reference or analyze any external sources or YouTube videos.",

--- a/multimodal/agent/usage/video_input.mdx
+++ b/multimodal/agent/usage/video_input.mdx
@@ -15,7 +15,7 @@ from agno.media import Video
 from agno.models.google import Gemini
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     markdown=True,
 )
 

--- a/multimodal/team/usage/audio-sentiment-analysis.mdx
+++ b/multimodal/team/usage/audio-sentiment-analysis.mdx
@@ -18,7 +18,7 @@ from agno.team import Team
 transcription_agent = Agent(
     name="Audio Transcriber",
     role="Transcribe audio conversations accurately",
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     instructions=[
         "Transcribe audio with speaker identification",
         "Maintain conversation structure and flow",
@@ -28,7 +28,7 @@ transcription_agent = Agent(
 sentiment_analyst = Agent(
     name="Sentiment Analyst",
     role="Analyze emotional tone and sentiment in conversations",
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     instructions=[
         "Analyze sentiment for each speaker separately",
         "Identify emotional patterns and conversation dynamics",
@@ -40,7 +40,7 @@ sentiment_analyst = Agent(
 sentiment_team = Team(
     name="Audio Sentiment Team",
     members=[transcription_agent, sentiment_analyst],
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     instructions=[
         "Analyze audio sentiment with conversation memory.",
         "Audio Transcriber: First transcribe audio with speaker identification.",

--- a/multimodal/team/usage/audio-to-text.mdx
+++ b/multimodal/team/usage/audio-to-text.mdx
@@ -17,7 +17,7 @@ from agno.team import Team
 transcription_specialist = Agent(
     name="Transcription Specialist",
     role="Convert audio to accurate text transcriptions",
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     instructions=[
         "Transcribe audio with high accuracy",
         "Identify speakers clearly as Speaker A, Speaker B, etc.",
@@ -28,7 +28,7 @@ transcription_specialist = Agent(
 content_analyzer = Agent(
     name="Content Analyzer",
     role="Analyze transcribed content for insights",
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     instructions=[
         "Analyze transcription for key themes and insights",
         "Provide summaries and extract important information",
@@ -38,7 +38,7 @@ content_analyzer = Agent(
 # Create a team for collaborative audio-to-text processing
 audio_team = Team(
     name="Audio Analysis Team",
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     members=[transcription_specialist, content_analyzer],
     instructions=[
         "Work together to transcribe and analyze audio content.",

--- a/reasoning/overview.mdx
+++ b/reasoning/overview.mdx
@@ -45,7 +45,7 @@ Agno gives you three ways to add reasoning to your agents, each suited for diffe
 
 ### 1. Reasoning Models
 
-**What:** Pre-trained models that natively think before answering (e.g. OpenAI gpt-5, Claude 4.5 Sonnet, Gemini 2.0 Flash Thinking, DeepSeek-R1).
+**What:** Pre-trained models that natively think before answering (e.g. OpenAI gpt-5, Claude 4.5 Sonnet, Gemini Flash Thinking, DeepSeek-R1).
 
 **How it works:** The model generates an internal chain of thought before producing its final response. This happens at the model layer: you simply use the model and reasoning happens automatically.
 

--- a/reasoning/usage/tools/claude-reasoning-tools.mdx
+++ b/reasoning/usage/tools/claude-reasoning-tools.mdx
@@ -17,7 +17,7 @@ title: Claude with Reasoning Tools
     from agno.tools.reasoning import ReasoningTools
 
     reasoning_agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-6"),
         tools=[
             ReasoningTools(add_instructions=True),
             HackerNewsTools(),

--- a/reference/models/anthropic.mdx
+++ b/reference/models/anthropic.mdx
@@ -9,7 +9,7 @@ The Claude model provides access to Anthropic's Claude models.
 
 | Parameter                       | Type                        | Default                        | Description                                                     |
 | ------------------------------ | --------------------------- | ------------------------------ | --------------------------------------------------------------- |
-| `id`                           | `str`                       | `"claude-3-5-sonnet-20241022"` | The id of the Anthropic Claude model to use                     |
+| `id`                           | `str`                       | `"claude-sonnet-4-6"` | The id of the Anthropic Claude model to use                     |
 | `name`                         | `str`                       | `"Claude"`                     | The name of the model                                           |
 | `provider`                     | `str`                       | `"Anthropic"`                  | The provider of the model                                       |
 | `max_tokens`                   | `Optional[int]`             | `4096`                         | Maximum number of tokens to generate in the chat completion     |

--- a/reference/models/bedrock-claude.mdx
+++ b/reference/models/bedrock-claude.mdx
@@ -9,7 +9,7 @@ The AWS Bedrock Claude model provides access to Anthropic's Claude models hosted
 
 | Parameter                 | Type                       | Default                        | Description                                                                                             |
 | ------------------------- | -------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `id`                      | `str`                      | `"anthropic.claude-3-5-sonnet-20241022-v2:0"` | The id of the AWS Bedrock Claude model to use                                  |
+| `id`                      | `str`                      | `"anthropic.claude-sonnet-4-6"` | The id of the AWS Bedrock Claude model to use                                  |
 | `name`                    | `str`                      | `"BedrockClaude"`              | The name of the model                                                                                   |
 | `provider`                | `str`                      | `"AWS"`                        | The provider of the model                                                                               |
 | `max_tokens`              | `Optional[int]`            | `4096`                         | Maximum number of tokens to generate in the chat completion                                             |

--- a/reference/models/gemini.mdx
+++ b/reference/models/gemini.mdx
@@ -9,7 +9,7 @@ The Gemini model provides access to Google's Gemini models.
 
 | Parameter                       | Type                          | Default                        | Description                                                                                   |
 | ------------------------------- | ----------------------------- | ------------------------------ | --------------------------------------------------------------------------------------------- |
-| `id`                            | `str`                         | `"gemini-1.5-flash"`           | The id of the Gemini model to use                                                            |
+| `id`                            | `str`                         | `"gemini-flash-latest"`           | The id of the Gemini model to use                                                            |
 | `name`                          | `str`                         | `"Gemini"`                     | The name of the model                                                                         |
 | `provider`                      | `str`                         | `"Google"`                     | The provider of the model                                                                     |
 | `api_key`                       | `Optional[str]`               | `None`                         | The API key for Google AI (defaults to GOOGLE_API_KEY env var)                               |

--- a/tools/mcp/usage/parallel.mdx
+++ b/tools/mcp/usage/parallel.mdx
@@ -43,7 +43,7 @@ async def run_agent(message: str) -> None:
         transport="streamable-http", server_params=server_params
     ) as parallel_mcp_server:
         agent = Agent(
-            model=Claude(id="claude-sonnet-4-20250514"),
+            model=Claude(id="claude-sonnet-4-6"),
             tools=[parallel_mcp_server],
             markdown=True,
         )

--- a/tools/reasoning_tools/reasoning-tools.mdx
+++ b/tools/reasoning_tools/reasoning-tools.mdx
@@ -23,7 +23,7 @@ from agno.tools.reasoning import ReasoningTools
 from agno.tools.yfinance import YFinanceTools
 
 thinking_agent = Agent(
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[
         ReasoningTools(add_instructions=True),
         YFinanceTools(
@@ -44,7 +44,7 @@ The toolkit comes with default instructions and few-shot examples to help the Ag
 
 ```python
 reasoning_agent = Agent(
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[
         ReasoningTools(
             think=True,

--- a/tools/toolkits/others/daytona.mdx
+++ b/tools/toolkits/others/daytona.mdx
@@ -34,7 +34,7 @@ daytona_tools = DaytonaTools()
 agent = Agent(
     name="Coding Agent with Daytona tools",
     id="coding-agent",
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-6"),
     tools=[daytona_tools],
     markdown=True,
         instructions=[

--- a/tools/toolkits/others/web-browser.mdx
+++ b/tools/toolkits/others/web-browser.mdx
@@ -12,7 +12,7 @@ from agno.tools.hackernews import HackerNewsTools
 from agno.tools.webbrowser import WebBrowserTools
 
 agent = Agent(
-    model=Gemini("gemini-2.0-flash"),
+    model=Gemini("gemini-flash-latest"),
     tools=[WebBrowserTools(), HackerNewsTools()],
     instructions=[
         "Find related articles using HackerNews",

--- a/tools/toolkits/social/whatsapp.mdx
+++ b/tools/toolkits/social/whatsapp.mdx
@@ -46,7 +46,7 @@ from agno.tools.whatsapp import WhatsAppTools
 
 agent = Agent(
     name="whatsapp",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WhatsAppTools()]
 )
 


### PR DESCRIPTION
removes gemini flash 2.0 and claude 3.x series and updates to latest models

## Description

Replace outdated model identifiers across docs and examples: update various Claude references (claude-3-7-sonnet-latest, claude-sonnet-4-5-20250929, claude-sonnet-4-20250514, etc.) to claude-sonnet-4-6; update Gemini references to gemini-flash-latest and adjust image-generation ID to gemini-2.5-flash-image; update AwsBedrock provider IDs to use anthropic.claude-sonnet-4-6 variants. Also update Streamlit model selection and a few descriptive lines to reflect the new model names. This brings documentation and examples in line with current model naming and releases.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#6827

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
