### PR TITLE
Sync learning docs with current Learning Store APIs

### DIFF
--- a/examples/learning/basics/b-user-profile-agentic.mdx
+++ b/examples/learning/basics/b-user-profile-agentic.mdx
@@ -31,7 +31,7 @@ from agno.models.openai import OpenAIResponses
 db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 
 # AGENTIC mode: Agent gets profile tools and decides when to use them.
-# You'll see tool calls like "update_user_profile" in responses.
+# You'll see tool calls like "update_profile" in responses.
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.2"),
     db=db,

--- a/examples/learning/user-profile/agentic-mode.mdx
+++ b/examples/learning/user-profile/agentic-mode.mdx
@@ -31,7 +31,7 @@ agent = Agent(
     db=db,
     instructions=(
         "You are a helpful assistant. "
-        "When users share their name or preferences, use update_user_profile to save it."
+        "When users share their name or preferences, use update_profile to save it."
     ),
     learning=LearningMachine(
         user_profile=UserProfileConfig(

--- a/learning/learning-modes.mdx
+++ b/learning/learning-modes.mdx
@@ -37,7 +37,7 @@ agent.print_response(
 )
 ```
 
-Best for: User Profile, User Memory, Session Context
+Best for: User Profile, User Memory, Session Context, Entity Memory
 
 ## Agentic Mode
 
@@ -60,7 +60,7 @@ agent.print_response(
 )
 ```
 
-Best for: Learned Knowledge, Entity Memory, Decision Log
+Best for: Learned Knowledge, Decision Log
 
 ### Tools by Store
 
@@ -140,7 +140,7 @@ agent = Agent(
 | Build user memory automatically | Always |
 | Track session progress | Always |
 | Agent-driven knowledge capture | Agentic |
-| Build entity knowledge graphs | Agentic |
+| Build entity knowledge graphs | Always |
 | Audit agent decisions | Agentic |
 | High-value collective knowledge | Propose |
 | Compliance-sensitive learning | Propose |

--- a/learning/learning-modes.mdx
+++ b/learning/learning-modes.mdx
@@ -53,7 +53,7 @@ agent = Agent(
     ),
 )
 
-# Agent decides to call update_user_profile tool
+# Agent decides to call update_profile tool
 agent.print_response(
     "Remember that I prefer dark mode interfaces.",
     user_id="alice@example.com",
@@ -66,9 +66,9 @@ Best for: Learned Knowledge, Entity Memory, Decision Log
 
 | Store | Tools |
 |-------|-------|
-| User Profile | `update_user_profile` |
-| User Memory | `save_user_memory`, `delete_user_memory` |
-| Entity Memory | `search_entities`, `create_entity`, `update_entity`, `add_fact`, `add_event` |
+| User Profile | `update_profile` |
+| User Memory | `update_user_memory` |
+| Entity Memory | `search_entities`, `create_entity`, `update_entity`, `add_fact`, `update_fact`, `delete_fact`, `add_event`, `add_relationship` |
 | Learned Knowledge | `search_learnings`, `save_learning` |
 | Decision Log | `log_decision`, `record_outcome`, `search_decisions` |
 
@@ -93,6 +93,8 @@ agent.print_response(
     user_id="alice@example.com",
 )
 ```
+
+Note: Propose mode is currently intended for Learned Knowledge.
 
 Best for: High-stakes knowledge, regulated environments, quality control
 
@@ -126,9 +128,9 @@ agent = Agent(
 | User Profile | Always | Names and preferences should be captured consistently |
 | User Memory | Always | Observations accumulate passively |
 | Session Context | Always | Session state needs continuous tracking |
-| Entity Memory | Agentic | Agent builds knowledge graph as needed |
+| Entity Memory | Always | Continuous extraction captures entity facts/events from normal conversations |
 | Learned Knowledge | Agentic | Agent decides what insights are worth saving |
-| Decision Log | Agentic | Agent logs significant decisions explicitly |
+| Decision Log | Always (`DecisionLogConfig()`), Agentic (`decision_log=True`) | Supports both automatic logging and explicit logging workflows |
 
 ## Choosing a Mode
 

--- a/learning/stores/decision-log.mdx
+++ b/learning/stores/decision-log.mdx
@@ -11,7 +11,7 @@ The Decision Log Store records decisions made by agents with reasoning, context,
 |--------|-------|
 | **Scope** | Per agent |
 | **Persistence** | Long-term |
-| **Default mode** | Agentic |
+| **Default mode** | Always (`DecisionLogConfig()`), Agentic (`decision_log=True`) |
 | **Supported modes** | Always, Agentic |
 
 ## Basic Usage
@@ -26,7 +26,7 @@ agent = Agent(
     model=OpenAIChat(id="gpt-4o"),
     db=PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai"),
     learning=LearningMachine(
-        decision_log=DecisionLogConfig(),
+        decision_log=DecisionLogConfig(),  # defaults to LearningMode.ALWAYS
     ),
     instructions=[
         "When you make a significant choice, use log_decision to record it.",

--- a/learning/stores/user-memory.mdx
+++ b/learning/stores/user-memory.mdx
@@ -81,7 +81,7 @@ agent.print_response(
 )
 ```
 
-Available tools: `update_user_memory`
+Available tool: `update_user_memory` (supports add, update, delete, and clear operations)
 
 Tradeoff: agent may miss implicit observations.
 

--- a/learning/stores/user-memory.mdx
+++ b/learning/stores/user-memory.mdx
@@ -81,7 +81,7 @@ agent.print_response(
 )
 ```
 
-Available tools: `save_user_memory`, `delete_user_memory`
+Available tools: `update_user_memory`
 
 Tradeoff: agent may miss implicit observations.
 
@@ -98,10 +98,10 @@ Tradeoff: agent may miss implicit observations.
 
 | Field | Description |
 |-------|-------------|
-| `memory_id` | Unique identifier |
-| `memory` | The observation text |
-| `topics` | Extracted topics for categorization |
 | `user_id` | User this memory belongs to |
+| `memories` | List of memory entries (`id`, `content`, optional metadata) |
+| `agent_id` | Agent context for audit trail |
+| `team_id` | Team context for audit trail |
 | `created_at` | When created |
 | `updated_at` | Last update |
 
@@ -110,9 +110,10 @@ Tradeoff: agent may miss implicit observations.
 lm = agent.get_learning_machine()
 
 # Get all memories
-memories = lm.user_memory_store.get_memories(user_id="alice@example.com")
-for memory in memories:
-    print(f"- {memory.memory}")
+memories = lm.user_memory_store.get(user_id="alice@example.com")
+if memories:
+    for memory in memories.memories:
+        print(f"- {memory.get('content')}")
 
 # Debug output
 lm.user_memory_store.print(user_id="alice@example.com")
@@ -122,12 +123,12 @@ lm.user_memory_store.print(user_id="alice@example.com")
 
 Relevant memories are injected into the system prompt:
 ```
-<user_memories>
+<user_memory>
 - Prefers code examples over explanations
 - Working on a machine learning project
 - Uses Python 3.11
 - Prefers concise responses
-</user_memories>
+</user_memory>
 ```
 
 ## Curation

--- a/learning/stores/user-profile.mdx
+++ b/learning/stores/user-profile.mdx
@@ -61,7 +61,7 @@ Tradeoff: extra LLM call per interaction.
 
 ## Agentic Mode
 
-The agent receives an `update_user_profile` tool and decides when to update.
+The agent receives an `update_profile` tool and decides when to update.
 ```python
 from agno.learn import LearningMachine, LearningMode, UserProfileConfig
 


### PR DESCRIPTION
## Summary
- update Learning Modes tool names and defaults to match current store behavior
- fix User Profile agentic tool name (update_profile)
- fix User Memory tool name, data model table, API example, and context tag
- clarify Decision Log default mode behavior in the store guide
