### PR TITLE
Docs updates for Agno v2.5.6

### DIFF
--- a/agent-os/client/agentos-client.mdx
+++ b/agent-os/client/agentos-client.mdx
@@ -88,6 +88,30 @@ except RemoteServerUnavailableError as e:
     print(f"URL: {e.base_url}")
 ```
 
+## Trace Search
+
+Search traces using the FilterExpr DSL:
+
+```python
+from agno.client import AgentOSClient
+from agno.os.routers.traces.schemas import TraceSearchGroupBy
+
+client = AgentOSClient(base_url="http://localhost:7777")
+
+result = await client.search_traces(
+    filter_expr={
+        "op": "AND",
+        "expressions": [
+            {"op": "EQ", "key": "status", "value": "OK"},
+            {"op": "CONTAINS", "key": "events", "value": "tool"},
+        ],
+    },
+    group_by=TraceSearchGroupBy.RUN,
+    page=1,
+    limit=20,
+)
+```
+
 ## API Reference
 
 For complete method documentation, parameters, and response types, see the [AgentOSClient Reference](/reference/clients/agentos-client).

--- a/agent-os/interfaces/slack/introduction.mdx
+++ b/agent-os/interfaces/slack/introduction.mdx
@@ -7,7 +7,7 @@ Use the Slack interface to serve Agents, Teams, or Workflows on Slack. It mounts
 
 ## Setup Steps
 
-Follow the Slack setup guide in the [cookbook](https://github.com/agno-agi/agno/blob/main/cookbook/06_agent_os/interfaces/slack/README.md).
+Follow the Slack setup guide in the [cookbook](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/interfaces/slack/README.md).
 
 Required configuration:
 
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     agent_os.serve(app="basic:app", port=8000, reload=True)
 ```
 
-A complete example is available at `cookbook/06_agent_os/interfaces/slack/basic.py`.
+A complete example is available at `cookbook/05_agent_os/interfaces/slack/basic.py`.
 
 ## Core Components
 
@@ -56,16 +56,28 @@ Main entry point for Agno Slack applications.
 
 ### Initialization Parameters
 
-| Parameter                | Type                    | Default     | Description                                                                                                                |
-| ------------------------ | ----------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `agent`                  | `Optional[Agent]`       | `None`      | Agno `Agent` instance.                                                                                                     |
-| `team`                   | `Optional[Team]`        | `None`      | Agno `Team` instance.                                                                                                      |
-| `workflow`               | `Optional[Workflow]`    | `None`      | Agno `Workflow` instance.                                                                                                  |
-| `prefix`                 | `str`                   | `"/slack"` | Custom FastAPI route prefix for the Slack interface.                                                                       |
-| `tags`                   | `Optional[List[str]]`   | `None`      | FastAPI route tags for API documentation. Defaults to `["Slack"]` if not provided.                                         |
-| `reply_to_mentions_only` | `bool`                  | `True`      | When `True` (default), bot responds to @mentions in channels and all direct messages. When `False`, responds to all messages in channels. |
+| Parameter                | Type                         | Default     | Description                                                                                                                |
+| ------------------------ | ---------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `agent`                  | `Optional[Agent]`            | `None`      | Agno `Agent` instance.                                                                                                     |
+| `team`                   | `Optional[Team]`             | `None`      | Agno `Team` instance.                                                                                                      |
+| `workflow`               | `Optional[Workflow]`         | `None`      | Agno `Workflow` instance.                                                                                                  |
+| `prefix`                 | `str`                        | `"/slack"` | Custom FastAPI route prefix for the Slack interface.                                                                       |
+| `tags`                   | `Optional[List[str]]`        | `None`      | FastAPI route tags for API documentation. Defaults to `["Slack"]` if not provided.                                       |
+| `reply_to_mentions_only` | `bool`                       | `True`      | When `True`, respond to @mentions in channels and all direct messages. When `False`, respond to all channel messages too. |
+| `token`                  | `Optional[str]`              | `None`      | Slack Bot User OAuth Token (`xoxb-...`). If omitted, the interface reads from environment configuration.                 |
+| `signing_secret`         | `Optional[str]`              | `None`      | Slack signing secret used to verify request signatures.                                                                    |
+| `streaming`              | `bool`                       | `True`      | Enable Slack `chat_stream` responses and event-driven streaming updates.                                                  |
+| `loading_messages`       | `Optional[List[str]]`        | `None`      | Optional rotating loading messages shown while processing streamed runs.                                                   |
+| `task_display_mode`      | `str`                        | `"plan"`    | Task card display mode used by Slack streaming UI.                                                                         |
+| `loading_text`           | `str`                        | `"Thinking..."` | Thread status text shown before streamed output starts.                                                               |
+| `suggested_prompts`      | `Optional[List[Dict[str, str]]]` | `None`  | Suggested prompts sent when Slack starts an assistant thread.                                                              |
+| `ssl`                    | `Optional[SSLContext]`       | `None`      | Custom SSL context for Slack SDK HTTP requests.                                                                            |
+| `buffer_size`            | `int`                        | `100`       | Stream buffer size for Slack `chat_stream`.                                                                                |
+| `max_file_size`          | `int`                        | `1073741824` | Maximum uploaded/downloaded file size in bytes (default 1 GB).                                                           |
 
 Provide `agent`, `team`, or `workflow`.
+
+Use different `prefix`, `token`, and `signing_secret` values when mounting multiple Slack interface instances on one FastAPI app.
 
 ### Key Method
 

--- a/agent-os/tracing/overview.mdx
+++ b/agent-os/tracing/overview.mdx
@@ -181,3 +181,28 @@ app = agent_os.get_app()
   **Best Practice**: Always use a dedicated `db` in production, even with a single agent. This keeps observability data separate and makes it easier to scale or migrate later.
 </Tip>
 
+## Advanced Trace Search
+
+Use advanced filtering with `POST /traces/search`. The request body accepts the FilterExpr DSL and supports grouping:
+
+| group_by | Returns |
+| --- | --- |
+| `run` | Individual traces |
+| `session` | Aggregated session stats |
+
+```json
+{
+  "filter": {
+    "op": "AND",
+    "conditions": [
+      {"op": "EQ", "key": "status", "value": "OK"},
+      {"op": "CONTAINS", "key": "user_id", "value": "admin"}
+    ]
+  },
+  "group_by": "run",
+  "page": 1,
+  "limit": 20
+}
+```
+
+Fetch filterable fields and operators with `GET /traces/filter-schema`. Use this to build UI filters that match your database capabilities.

--- a/agent-os/usage/client/run-agents.mdx
+++ b/agent-os/usage/client/run-agents.mdx
@@ -107,6 +107,18 @@ mode: wide
     Make sure you have an AgentOS server running on port 7777. See [Creating Your First OS](/agent-os/run-your-os) for setup instructions.
   </Step>
 
+  <Step title="Supported Image Types">
+    AgentOS accepts the following image MIME types for uploads:
+
+    | Type | MIME |
+    | --- | --- |
+    | PNG | `image/png` |
+    | JPEG | `image/jpeg`, `image/jpg` |
+    | WebP | `image/webp` |
+    | HEIC | `image/heic` |
+    | HEIF | `image/heif` |
+  </Step>
+
   <Step title="Run the Client">
     <CodeGroup>
     ```bash Mac

--- a/agent-os/usage/client/run-teams.mdx
+++ b/agent-os/usage/client/run-teams.mdx
@@ -106,6 +106,18 @@ mode: wide
     Make sure you have an AgentOS server running with teams configured. See [Creating Your First OS](/agent-os/run-your-os) for setup instructions.
   </Step>
 
+  <Step title="Supported Image Types">
+    AgentOS accepts the following image MIME types for uploads:
+
+    | Type | MIME |
+    | --- | --- |
+    | PNG | `image/png` |
+    | JPEG | `image/jpeg`, `image/jpg` |
+    | WebP | `image/webp` |
+    | HEIC | `image/heic` |
+    | HEIF | `image/heif` |
+  </Step>
+
   <Step title="Run the Client">
     <CodeGroup>
     ```bash Mac

--- a/agent-os/usage/hitl.mdx
+++ b/agent-os/usage/hitl.mdx
@@ -91,7 +91,14 @@ curl -X POST http://localhost:7777/agents/data_manager/runs \
 
 # 2. Continue with approval (use the run_id and tool_call_id from response)
 curl -X POST http://localhost:7777/agents/data_manager/runs/{run_id}/continue \
-  -F "tools=[{\"tool_call_id\": \"{tool_call_id}\", \"tool_name\": \"delete_records\", \"tool_args\": {\"table_name\": \"users\", \"count\": 50}}, \"confirmed\": true}]" \
+  -F 'tools=[{"tool_call_id":"{tool_call_id}","tool_name":"delete_records","tool_args":{"table_name":"users","count":50},"confirmed":true}]' \
+  -F "session_id=test_session" \
+  -F "user_id=test_user" \
+  -F "stream=false"
+
+# 3. Continue after admin approval is resolved in DB
+curl -X POST http://localhost:7777/agents/data_manager/runs/{run_id}/continue \
+  -F "tools=" \
   -F "session_id=test_session" \
   -F "user_id=test_user" \
   -F "stream=false"

--- a/agent-os/usage/hitl.mdx
+++ b/agent-os/usage/hitl.mdx
@@ -97,6 +97,18 @@ curl -X POST http://localhost:7777/agents/data_manager/runs/{run_id}/continue \
   -F "stream=false"
 ```
 
+If an admin resolves a required approval in the database, you can continue with an empty `tools` value. Non-admin users receive `403` if a required approval is still pending.
+
+## Approval Status API
+
+Poll a single approval record:
+
+```bash
+GET /approvals/{approval_id}/status
+```
+
+When a run pauses, each tool that requires approval is stamped with `approval_id`. Store that ID and poll for status changes. Admins with the `approvals:write` scope can continue once the approval is resolved.
+
 ## Usage
 
 <Steps>

--- a/cookbook/tools/built-in.mdx
+++ b/cookbook/tools/built-in.mdx
@@ -78,7 +78,7 @@ agent.print_response("Analyze AAPL's recent performance")
 | SQL | `from agno.tools.sql import SQLTools` | Generic SQL |
 | CSV | `from agno.tools.csv_toolkit import CsvTools` | CSV analysis |
 | Pandas | `from agno.tools.pandas import PandasTools` | DataFrame operations |
-| BigQuery | `from agno.tools.google_bigquery import BigQueryTools` | Google BigQuery |
+| BigQuery | `from agno.tools.google import GoogleBigQueryTools` | Google BigQuery |
 | Redshift | `from agno.tools.redshift import RedshiftTools` | AWS Redshift |
 
 ```python
@@ -119,7 +119,7 @@ agent.print_response("Scrape and summarize https://example.com/blog")
 | X (Twitter) | `from agno.tools.x import XTools` | Twitter/X API |
 | Reddit | `from agno.tools.reddit import RedditTools` | Reddit posts |
 | Email | `from agno.tools.email import EmailTools` | Send emails |
-| Gmail | `from agno.tools.gmail import GmailTools` | Gmail integration |
+| Gmail | `from agno.tools.google import GmailTools` | Gmail integration |
 | Twilio | `from agno.tools.twilio import TwilioTools` | SMS messaging |
 | WhatsApp | `from agno.tools.whatsapp import WhatsAppTools` | WhatsApp messages |
 | Telegram | `from agno.tools.telegram import TelegramTools` | Telegram bot |
@@ -137,9 +137,9 @@ agent.print_response("Send a message to #general saying 'Hello from AI!'")
 
 | Tool | Import | Description |
 |------|--------|-------------|
-| Google Calendar | `from agno.tools.googlecalendar import GoogleCalendarTools` | Calendar events |
-| Google Sheets | `from agno.tools.googlesheets import GoogleSheetsTools` | Spreadsheets |
-| Google Drive | `from agno.tools.google_drive import GoogleDriveTools` | File storage |
+| Google Calendar | `from agno.tools.google import GoogleCalendarTools` | Calendar events |
+| Google Sheets | `from agno.tools.google import GoogleSheetsTools` | Spreadsheets |
+| Google Drive | `from agno.tools.google import GoogleDriveTools` | File storage |
 | Notion | `from agno.tools.notion import NotionTools` | Notion pages |
 | Todoist | `from agno.tools.todoist import TodoistTools` | Task management |
 | Trello | `from agno.tools.trello import TrelloTools` | Kanban boards |
@@ -152,7 +152,7 @@ agent.print_response("Send a message to #general saying 'Hello from AI!'")
 
 ```python
 from agno.agent import Agent
-from agno.tools.googlecalendar import GoogleCalendarTools
+from agno.tools.google import GoogleCalendarTools
 
 agent = Agent(tools=[GoogleCalendarTools()])
 agent.print_response("What meetings do I have tomorrow?")
@@ -212,7 +212,7 @@ agent.print_response("Generate an image of a futuristic city at sunset")
 | Calculator | `from agno.tools.calculator import CalculatorTools` | Math operations |
 | Sleep | `from agno.tools.sleep import SleepTools` | Add delays |
 | Weather | `from agno.tools.openweather import OpenWeatherTools` | Weather data |
-| Maps | `from agno.tools.google_maps import GoogleMapsTools` | Location services |
+| Maps | `from agno.tools.google import GoogleMapTools` | Location services |
 | Visualization | `from agno.tools.visualization import VisualizationTools` | Charts and plots |
 | WebBrowser | `from agno.tools.webbrowser import WebBrowserTools` | Browser automation |
 
@@ -231,4 +231,3 @@ python 02_agents/finance/yfinance_agent.py
 # Web scraping
 python 02_agents/web/firecrawl_agent.py
 ```
-

--- a/docs.json
+++ b/docs.json
@@ -5825,6 +5825,7 @@
                   "examples/models/openai/responses/memory",
                   "examples/models/openai/responses/pdf-input-local",
                   "examples/models/openai/responses/pdf-input-url",
+                  "examples/models/openai/responses/file-input-direct",
                   "examples/models/openai/responses/reasoning-o3-mini",
                   "examples/models/openai/responses/structured-output",
                   "examples/models/openai/responses/structured-output-with-tools",

--- a/examples/knowledge/cloud/cloud-agentos.mdx
+++ b/examples/knowledge/cloud/cloud-agentos.mdx
@@ -60,6 +60,10 @@ github_docs = GitHubConfig(
     name="My Repository",
     repo="private/repo",
     token=getenv("GITHUB_TOKEN"),  # Fine-grained PAT with Contents: read
+    # GitHub App auth requires PyJWT with cryptography and a PEM private key
+    app_id=getenv("GITHUB_APP_ID"),
+    installation_id=getenv("GITHUB_INSTALLATION_ID"),
+    private_key=getenv("GITHUB_PRIVATE_KEY"),
     branch="main",
 )
 
@@ -147,6 +151,9 @@ source .venvs/demo/bin/activate
 
 # Export relevant API keys
 export SHAREPOINT_TENANT_ID="***"
+export GITHUB_APP_ID="***"
+export GITHUB_INSTALLATION_ID="***"
+export GITHUB_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 
 python cloud_agentos.py
 ```

--- a/examples/knowledge/cloud/github.mdx
+++ b/examples/knowledge/cloud/github.mdx
@@ -2,7 +2,7 @@
 title: "GitHub Content Source for Knowledge"
 description: "Load files and folders from GitHub repositories into your Knowledge base."
 ---
-Load files and folders from GitHub repositories into your Knowledge base. Supports both public and private repositories using fine-grained personal access tokens.
+Load files and folders from GitHub repositories into your Knowledge base. Supports public repos, fine-grained PATs, and GitHub App authentication.
 
 ```python
 """
@@ -10,7 +10,7 @@ GitHub Content Source for Knowledge
 ====================================
 
 Load files and folders from GitHub repositories into your Knowledge base.
-Supports both public and private repositories using fine-grained personal access tokens.
+Supports both public and private repositories using fine-grained personal access tokens or GitHub App auth.
 
 Features:
 - Load single files or entire folders recursively
@@ -20,9 +20,11 @@ Features:
 
 Requirements:
 - For private repos: GitHub fine-grained PAT with "Contents: read" permission
+- For GitHub App auth: PyJWT with cryptography and a PEM private key
+- `private_key` must start with `-----BEGIN RSA PRIVATE KEY-----` or `-----BEGIN PRIVATE KEY-----`
 
 Usage:
-    1. Configure GitHubConfig with repo and optional token
+    1. Configure GitHubConfig with repo and optional token or GitHub App credentials
     2. Register the config on Knowledge via content_sources
     3. Use .file() or .folder() to create content references
     4. Insert into knowledge with knowledge.insert()
@@ -39,11 +41,15 @@ from agno.vectordb.pgvector import PgVector
 
 # Configure GitHub content source
 # For private repos, set GITHUB_TOKEN env var to a fine-grained PAT with "Contents: read"
+# For GitHub App auth, set GITHUB_APP_ID, GITHUB_INSTALLATION_ID, GITHUB_PRIVATE_KEY
 github_config = GitHubConfig(
     id="my-repo",
     name="My Repository",
     repo="private/repo",  # Format: owner/repo
     token=getenv("GITHUB_TOKEN"),  # Optional for public repos
+    app_id=getenv("GITHUB_APP_ID"),
+    installation_id=getenv("GITHUB_INSTALLATION_ID"),
+    private_key=getenv("GITHUB_PRIVATE_KEY"),
     branch="main",  # Default branch
 )
 

--- a/examples/models/openai/responses/file-input-direct.mdx
+++ b/examples/models/openai/responses/file-input-direct.mdx
@@ -1,0 +1,70 @@
+---
+title: "OpenAI Responses Direct File Input"
+description: "Cookbook example for `openai/responses/file_input_direct.py`."
+---
+```python
+"""
+Openai File Input Direct
+========================
+
+Cookbook example for `openai/responses/file_input_direct.py`.
+"""
+
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.media import File
+from agno.models.openai.responses import OpenAIResponses
+from agno.utils.media import download_file
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-4o"),
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # File via URL
+    agent.print_response(
+        "Summarize the key contribution of this paper in 2-3 sentences.",
+        files=[File(url="https://arxiv.org/pdf/1706.03762")],
+    )
+
+    # File via local filepath
+    pdf_path = Path(__file__).parent.joinpath("ThaiRecipes.pdf")
+    download_file(
+        "https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf", str(pdf_path)
+    )
+
+    agent.print_response(
+        "List the first 3 recipes from this cookbook.",
+        files=[File(filepath=pdf_path, mime_type="application/pdf")],
+    )
+
+    # File via raw bytes
+    csv_content = b"name,role,team\nAlice,Engineer,Platform\nBob,Designer,Product\nCharlie,PM,Growth"
+
+    agent.print_response(
+        "Describe the team structure from this CSV.",
+        files=[File(content=csv_content, filename="team.csv", mime_type="text/csv")],
+    )
+```
+
+## Run the Example
+```bash
+# Clone and setup repo
+git clone https://github.com/agno-agi/agno.git
+cd agno/cookbook/90_models/openai/responses
+
+# Create and activate virtual environment
+./scripts/demo_setup.sh
+source .venvs/demo/bin/activate
+
+python file_input_direct.py
+```

--- a/examples/models/openai/responses/overview.mdx
+++ b/examples/models/openai/responses/overview.mdx
@@ -9,6 +9,7 @@ description: "Cookbook examples for `cookbook/90_models/openai/responses`."
 | [Openai Basic](/examples/models/openai/responses/basic) | Cookbook example for `openai/responses/basic.py`. |
 | [Db](/examples/models/openai/responses/db) | Openai model example. |
 | [Openai Deep Research Agent](/examples/models/openai/responses/deep-research-agent) | Cookbook example for `openai/responses/deep_research_agent.py`. |
+| [OpenAI Responses Direct File Input](/examples/models/openai/responses/file-input-direct) | Cookbook example for `openai/responses/file_input_direct.py`. |
 | [Openai Image Agent](/examples/models/openai/responses/image-agent) | Cookbook example for `openai/responses/image_agent.py`. |
 | [Openai Image Agent Bytes](/examples/models/openai/responses/image-agent-bytes) | Cookbook example for `openai/responses/image_agent_bytes.py`. |
 | [Openai Image Agent With Memory](/examples/models/openai/responses/image-agent-with-memory) | Cookbook example for `openai/responses/image_agent_with_memory.py`. |

--- a/examples/teams/streaming/team-events.mdx
+++ b/examples/teams/streaming/team-events.mdx
@@ -84,6 +84,32 @@ async def run_team_with_events(prompt: str) -> None:
         ]:
             print(f"\nTEAM EVENT: {run_output_event.event}")
 
+        if run_output_event.event in [
+            TeamRunEvent.task_iteration_started,
+            TeamRunEvent.task_iteration_completed,
+        ]:
+            print(f"\nTEAM EVENT: {run_output_event.event}")
+
+        if run_output_event.event == TeamRunEvent.task_created:
+            print(f"\nTEAM EVENT: {run_output_event.event}")
+            print(f"TASK ID: {run_output_event.task_id}")
+            print(f"TITLE: {run_output_event.title}")
+            print(f"STATUS: {run_output_event.status}")
+
+        if run_output_event.event == TeamRunEvent.task_updated:
+            print(f"\nTEAM EVENT: {run_output_event.event}")
+            print(f"TASK ID: {run_output_event.task_id}")
+            print(f"TITLE: {run_output_event.title}")
+            print(f"STATUS: {run_output_event.status}")
+            if run_output_event.result:
+                print(f"RESULT: {run_output_event.result}")
+
+        if run_output_event.event == TeamRunEvent.task_state_updated:
+            print(f"\nTEAM EVENT: {run_output_event.event}")
+            print(f"TASK COUNT: {len(run_output_event.tasks)}")
+            if run_output_event.completion_summary:
+                print(f"SUMMARY: {run_output_event.completion_summary}")
+
         if run_output_event.event in [TeamRunEvent.tool_call_started]:
             print(f"\nTEAM EVENT: {run_output_event.event}")
             print(f"TOOL CALL: {run_output_event.tool.tool_name}")

--- a/examples/tools/file-tools.mdx
+++ b/examples/tools/file-tools.mdx
@@ -85,6 +85,26 @@ agent_writer = Agent(
     markdown=True,
 )
 
+# Example 5: Content search agent using enable_search_content
+agent_content_search = Agent(
+    tools=[
+        FileTools(
+            Path("tmp/file"),
+            enable_read_file=True,
+            enable_search_content=True,
+            enable_list_files=True,
+            enable_save_file=False,
+        )
+    ],
+    description="You are a content search specialist that finds information within files.",
+    instructions=[
+        "Search through file contents to find relevant information",
+        "Use search_content to locate files containing specific terms",
+        "Summarize the matches and provide context from the snippets",
+    ],
+    markdown=True,
+)
+
 # Example usage
 
 # ---------------------------------------------------------------------------
@@ -112,6 +132,12 @@ if __name__ == "__main__":
     print("\n=== File Search Example ===")
     agent_full.print_response(
         "Search for all files which have an extension '.txt' and save the answer to a new file named 'all_txt_files.txt'",
+        markdown=True,
+    )
+
+    print("\n=== Content Search Example ===")
+    agent_content_search.print_response(
+        "Search inside all files for the word 'Python' and summarize what you find",
         markdown=True,
     )
 ```

--- a/examples/tools/gmail-tools.mdx
+++ b/examples/tools/gmail-tools.mdx
@@ -8,7 +8,7 @@ Enable Agno agents to read, draft, and send emails using the Gmail API.
 
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
-from agno.tools.gmail import GmailTools
+from agno.tools.google import GmailTools
 from pydantic import BaseModel, Field
 
 # ---------------------------------------------------------------------------

--- a/examples/tools/google-bigquery-tools.mdx
+++ b/examples/tools/google-bigquery-tools.mdx
@@ -21,7 +21,7 @@ Enable Agno agents to perform petabyte-scale data analysis, execute complex SQL,
 
 from agno.agent import Agent
 from agno.models.google import Gemini
-from agno.tools.google_bigquery import GoogleBigQueryTools
+from agno.tools.google import GoogleBigQueryTools
 
 # ---------------------------------------------------------------------------
 # Create Agent

--- a/examples/tools/google-drive.mdx
+++ b/examples/tools/google-drive.mdx
@@ -25,7 +25,7 @@ Enable Agno agents to read, create, update and duplicate Google Drive files.
 ```python
 
 from agno.agent import Agent
-from agno.tools.google_drive import GoogleDriveTools
+from agno.tools.google import GoogleDriveTools
 
 # ---------------------------------------------------------------------------
 # Create Agent

--- a/examples/tools/google-maps-tools.mdx
+++ b/examples/tools/google-maps-tools.mdx
@@ -17,7 +17,7 @@ Enable Agno agents with location intelligence with various Google Maps API funct
 
 from agno.agent import Agent
 from agno.tools.crawl4ai import Crawl4aiTools
-from agno.tools.google_maps import GoogleMapTools
+from agno.tools.google import GoogleMapTools
 
 # ---------------------------------------------------------------------------
 # Create Agent

--- a/examples/tools/googlecalendar-tools.mdx
+++ b/examples/tools/googlecalendar-tools.mdx
@@ -58,7 +58,7 @@ Enable Agno agents the "executive assistance" capability to move beyond just rea
 ```python
 
 from agno.agent import Agent
-from agno.tools.googlecalendar import GoogleCalendarTools
+from agno.tools.google import GoogleCalendarTools
 
 # ---------------------------------------------------------------------------
 # Create Agent

--- a/examples/tools/googlesheets-tools.mdx
+++ b/examples/tools/googlesheets-tools.mdx
@@ -22,7 +22,7 @@ The ID is the URL of the spreadsheet and the range is the sheet name and the ran
 """
 
 from agno.agent import Agent
-from agno.tools.googlesheets import GoogleSheetsTools
+from agno.tools.google import GoogleSheetsTools
 
 # ---------------------------------------------------------------------------
 # Create Agent

--- a/hitl/approval.mdx
+++ b/hitl/approval.mdx
@@ -99,4 +99,3 @@ There are three distinct phases in the approval flow:
 * Example code: [Approvals cookbook](https://github.com/agno-agi/agno/blob/main/cookbook/02_agents/11_approvals).
 * [Approval reference](/reference-api/schema/approvals/list-approvals)
 * [Tool decorator](/reference/tools/decorator)
-

--- a/models/providers/native/openai/responses/overview.mdx
+++ b/models/providers/native/openai/responses/overview.mdx
@@ -49,6 +49,15 @@ agent.print_response(
 
 </CodeGroup>
 
+## File Handling
+
+OpenAI Responses accepts files in two ways depending on tools:
+
+| Setup | Behavior |
+| --- | --- |
+| `file_search` tool included | Files upload to a vector store and are referenced by `file_search`. |
+| No `file_search` tool | Files are sent as `input_file` blocks using `file_url`, `file_data`, or `file_id`. |
+
 <Note> View more examples [here](/models/providers/native/openai/responses/usage/basic-stream). </Note>
 
 ## Parameters

--- a/teams/running-teams.mdx
+++ b/teams/running-teams.mdx
@@ -83,7 +83,7 @@ for chunk in stream:
 ```
 
 <Note>
-Streaming is not supported in `TeamMode.tasks`. If you set `stream=True`, the run falls back to non-streaming execution.
+`TeamMode.tasks` supports streaming. Set `stream_events=True` to receive task lifecycle events with structured task data.
 </Note>
 
 ### Stream All Events

--- a/tools/toolkits/database/google-bigquery.mdx
+++ b/tools/toolkits/database/google-bigquery.mdx
@@ -11,7 +11,7 @@ The following agent can query and analyze BigQuery datasets:
 
 ```python
 from agno.agent import Agent
-from agno.tools.google_bigquery import GoogleBigQueryTools
+from agno.tools.google import GoogleBigQueryTools
 
 agent = Agent(
     instructions=[
@@ -48,6 +48,6 @@ agent.print_response("List all tables in the dataset and describe the sales tabl
 
 ## Developer Resources
 
-- View [Tools Source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google_bigquery.py)
+- [Tools Source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/bigquery.py)
 - [BigQuery Documentation](https://cloud.google.com/bigquery/docs)
 - [BigQuery SQL Reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/)

--- a/tools/toolkits/local/file.mdx
+++ b/tools/toolkits/local/file.mdx
@@ -23,15 +23,16 @@ agent.print_response("What is the most advanced LLM currently? Save the answer t
 | `enable_save_file`    | `bool` | `True`  | Enables functionality to save files                           |
 | `enable_delete_file`  | `bool` | `False` | Enables functionality to delete files                         |
 | `enable_read_file`    | `bool` | `True`  | Enables functionality to read files                           |
-| `enable_read_file_chunks` | `bool` | `True` | Enables functionality to read files in chunks              |
-| `enable_replace_file_chunk` | `bool` | `True` | Enables functionality to update files in chunks          |
+| `enable_read_file_chunk` | `bool` | `True` | Enables functionality to read files in line ranges         |
+| `enable_replace_file_chunk` | `bool` | `True` | Enables functionality to update files in line ranges     |
 | `enable_list_files`   | `bool` | `True`  | Enables functionality to list files in directories            |
-| `enable_search_files` | `bool` | `True`  | Enables functionality to search for files                     |
+| `enable_search_files` | `bool` | `True`  | Enables functionality to search for files by glob pattern     |
+| `enable_search_content` | `bool` | `True` | Enables functionality to search inside file contents        |
 | `all`                 | `bool` | `False` | Enables all functionality when set to True                    |
-| `expose_base_directory` | `bool` | `False` | Adds 'base_directory' to the tool responses if set to True  |
-| `max_file_length` | `int` | `10000000` | Maximum file length to read in bytes. Reading will fail if the file is larger. |
-| `max_file_lines` | `int` | `100000` | Maximum number of lines to read from a file. Reading will fail if the file has more lines. |
-| `line_separator` | `str` | `"\n"` | The separator to use when interacting with chunks. |
+| `expose_base_directory` | `bool` | `False` | Adds `base_directory` to the tool responses if set to `True` |
+| `max_file_length` | `int` | `10000000` | Maximum file length to read in bytes. Reading fails if the file is larger. |
+| `max_file_lines` | `int` | `100000` | Maximum number of lines to read from a file. Reading fails if the file has more lines. |
+| `line_separator` | `str` | `"\n"` | The separator to use when interacting with file chunks. |
 
 ## Toolkit Functions
 
@@ -39,10 +40,12 @@ agent.print_response("What is the most advanced LLM currently? Save the answer t
 | ------------ | ---------------------------------------------------------------------------------------- |
 | `save_file`  | Saves the contents to a file called `file_name` and returns the file name if successful. |
 | `read_file`  | Reads the contents of the file `file_name` and returns the contents if successful.       |
-| `read_file_chunks` | Reads the contents of the file `file_name` in chunks and returns the contents if successful. |
-| `replace_file_chunk` | Partial replace of the contents of the file `file_name`  |
+| `read_file_chunk` | Reads selected lines from `file_name` (`start_line` to `end_line`).                |
+| `replace_file_chunk` | Replaces a selected line range in `file_name`.                                   |
 | `delete_file` | Deletes the file `file_name` if successful. |
 | `list_files` | Returns a list of files in the base directory                                            |
+| `search_files` | Searches for files by glob pattern (for example `**/*.py`).                          |
+| `search_content` | Searches text file contents and returns matching files with snippets.                |
 
 ## Developer Resources
 

--- a/tools/toolkits/others/google-maps.mdx
+++ b/tools/toolkits/others/google-maps.mdx
@@ -33,7 +33,7 @@ Basic usage of the Google Maps toolkit:
 
 ```python
 from agno.agent import Agent
-from agno.tools.google_maps import GoogleMapTools
+from agno.tools.google import GoogleMapTools
 
 agent = Agent(tools=[GoogleMapTools()])
 agent.print_response("Find coffee shops in San Francisco")
@@ -68,4 +68,4 @@ Google Maps APIs have usage limits and quotas that vary by service and billing p
 
 ## Developer Resources
 
-- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google_maps.py)
+- [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/maps.py)

--- a/tools/toolkits/others/google-sheets.mdx
+++ b/tools/toolkits/others/google-sheets.mdx
@@ -46,7 +46,7 @@ The following agent will use Google Sheets to read and update spreadsheet data.
 
 ```python cookbook/14_tools/googlesheets_tools.py
 from agno.agent import Agent
-from agno.tools.googlesheets import GoogleSheetsTools
+from agno.tools.google import GoogleSheetsTools
 
 SAMPLE_SPREADSHEET_ID = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
 SAMPLE_RANGE_NAME = "Class Data!A2:E"
@@ -95,4 +95,4 @@ agent.print_response("Please tell me about the contents of the spreadsheet")
 
 ## Developer Resources
 
-- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/googlesheets.py)
+- [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/sheets.py)

--- a/tools/toolkits/others/googlecalendar.mdx
+++ b/tools/toolkits/others/googlecalendar.mdx
@@ -67,7 +67,7 @@ The following agent will use GoogleCalendarTools to find today's events.
 
 ```python cookbook/14_tools/googlecalendar_tools.py
 from agno.agent import Agent
-from agno.tools.googlecalendar import GoogleCalendarTools
+from agno.tools.google import GoogleCalendarTools
 import datetime
 import os
 from tzlocal import get_localzone_name
@@ -111,4 +111,4 @@ You can use `include_tools` or `exclude_tools` to modify the list of tools the a
 
 ## Developer Resources
 
-- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/googlecalendar.py)
+- [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/calendar.py)

--- a/tools/toolkits/social/gmail.mdx
+++ b/tools/toolkits/social/gmail.mdx
@@ -31,7 +31,7 @@ export GOOGLE_REDIRECT_URI=http://localhost  # Default value
 
 ```python cookbook/14_tools/gmail_tools.py
 from agno.agent import Agent
-from agno.tools.gmail import GmailTools
+from agno.tools.google import GmailTools
 
 agent = Agent(tools=[GmailTools()])
 agent.print_response("Show me my latest 5 unread emails", markdown=True)
@@ -73,4 +73,4 @@ You can use `include_tools` or `exclude_tools` to modify the list of tools the a
 
 ## Developer Resources
 
-- View [Example](https://github.com/agno-agi/agno/tree/main/cookbook/91_models/others/gmail)
+- [Example](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/gmail_tools.py)


### PR DESCRIPTION
## Description

Doc Updates for v2.5.6

  - GitHub auth update besides PAT
  -  Approval Status API
  - Traces search filter
  -  Teams streaming support
  - Slack interface page now reflects current SDK params from source (token,
    signing_secret, streaming, loading_messages, task_display_mode,
    loading_text, suggested_prompts, ssl, buffer_size, max_file_size) and fixed
    cookbook path 05_agent_os.
  - File toolkit page fixed stale names (enable_read_file_chunk,
    read_file_chunk)and added missing enable_search_content / search_content.
  - File tools example now includes the `enable_search_content `usage pattern and
    runtime example.
  - AgentOS client page now includes search_traces(...) usage with FilterExpr
    DSL.
  - HITL page fixed malformed /continue curl payload and added the admin-
    resolved continuation example with empty tools.
  - OpenAI Responses examples overview now links to direct file input.
  - Added missing file-input-direct example page based on ../agno/
    cookbook/90_models/openai/responses/file_input_direct.py.
    
    

**Note:** Your PR title must follow conventional commit format (e.g., `docs: add auth guide`, `fix: correct broken links`, `style: update formatting`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
