### PR TITLE
docs: add GitlabTools docs and navigation entry

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2027,6 +2027,7 @@
                           "tools/toolkits/others/financial-datasets",
                           "tools/toolkits/others/giphy",
                           "tools/toolkits/others/github",
+                          "tools/toolkits/others/gitlab",
                           "tools/toolkits/others/google-maps",
                           "tools/toolkits/others/googlecalendar",
                           "tools/toolkits/others/google-sheets",
@@ -12290,6 +12291,10 @@
     {
       "source": "/integrations/toolkits/others/github",
       "destination": "/tools/toolkits/others/github"
+    },
+    {
+      "source": "/integrations/toolkits/others/gitlab",
+      "destination": "/tools/toolkits/others/gitlab"
     },
     {
       "source": "/integrations/toolkits/others/composio",

--- a/tools/toolkits/others/gitlab.mdx
+++ b/tools/toolkits/others/gitlab.mdx
@@ -1,0 +1,74 @@
+---
+title: Gitlab
+description: GitlabTools provides read-focused access to GitLab projects, merge requests, and issues.
+---
+
+**GitlabTools** enables an Agent to read GitLab project, merge request, and issue data.
+
+## Prerequisites
+
+Install the required dependencies:
+
+```shell
+uv pip install -U python-gitlab httpx
+```
+
+Set environment variables:
+
+```shell
+export GITLAB_ACCESS_TOKEN="YOUR_GITLAB_ACCESS_TOKEN"
+export GITLAB_BASE_URL="https://gitlab.com"
+```
+
+`GITLAB_BASE_URL` is optional. If unset, `https://gitlab.com` is used.
+
+## Example
+
+```python cookbook/91_tools/gitlab_tools.py
+from agno.agent import Agent
+from agno.tools.gitlab import GitlabTools
+
+agent = Agent(
+    instructions=[
+        "Use GitLab tools to answer repository questions.",
+        "Use read-only operations unless explicitly asked to modify data.",
+    ],
+    tools=[GitlabTools()],
+)
+
+agent.print_response(
+    "List open merge requests for project 'gitlab-org/gitlab' and summarize the top 5 by recency.",
+    markdown=True,
+)
+```
+
+## Toolkit Params
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `access_token` | `Optional[str]` | `None` | GitLab access token. If not provided, uses `GITLAB_ACCESS_TOKEN`. |
+| `base_url` | `Optional[str]` | `None` | GitLab instance URL. If not provided, uses `GITLAB_BASE_URL`, then `https://gitlab.com`. |
+| `timeout` | `float` | `30` | HTTP timeout in seconds for API requests. |
+| `enable_list_projects` | `bool` | `True` | Register the `list_projects` tool. |
+| `enable_get_projects` | `bool` | `True` | Register the `get_project` tool. |
+| `enable_list_merge_requests` | `bool` | `True` | Register the `list_merge_requests` tool. |
+| `enable_get_merge_request` | `bool` | `True` | Register the `get_merge_request` tool. |
+| `enable_list_issues` | `bool` | `True` | Register the `list_issues` tool. |
+| `include_tools` | `Optional[list[str]]` | `None` | Optional inherited toolkit filter to include only specific tools. |
+| `exclude_tools` | `Optional[list[str]]` | `None` | Optional inherited toolkit filter to exclude specific tools. |
+
+## Toolkit Functions
+
+| Function | Description |
+| --- | --- |
+| `list_projects` | List projects visible to the authenticated user. Supports search, owned, membership, and pagination filters. |
+| `get_project` | Get details for one project by project ID or `group/project` path. |
+| `list_merge_requests` | List merge requests for a project with state, branch, author, and pagination filters. |
+| `get_merge_request` | Get details for one merge request by project and merge request IID. |
+| `list_issues` | List project issues with state, labels, author, assignee, search, and pagination filters. |
+
+Use the `enable_*` constructor toggles to register only selected GitLab tools. You can also use `include_tools` or `exclude_tools` to filter available tools. See [selecting tools](/tools/selecting-tools).
+
+## Developer Resources
+
+- [GitlabTools source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/gitlab.py)


### PR DESCRIPTION
## Description

GitlabTools is already merged in the Agno SDK ([agno-agi/agno#6721](https://github.com/agno-agi/agno/pull/6721)).  
This PR adds the official documentation page and navigation entry in the docs repo.

### Key changes
- Added `tools/toolkits/others/gitlab.mdx`
- Added `tools/toolkits/others/gitlab` to `docs.json` under:
  - `Tools -> Toolkits -> Additional Toolkits` (near GitHub/Jira)
- Added redirect in `docs.json`:
  - `/integrations/toolkits/others/gitlab` -> `/tools/toolkits/others/gitlab`
- Documented:
  - prerequisites and environment variables (`GITLAB_ACCESS_TOKEN`, `GITLAB_BASE_URL`)
  - minimal Agent usage example
  - toolkit params (including `enable_*` toggles and `include_tools` / `exclude_tools`)
  - toolkit functions
  - developer resource link to source

### Validation
- `mint.cmd validate` passes
- `mint.cmd dev` runs locally
- `curl -s -o NUL -w "%{http_code}\n" http://localhost:3000/tools/toolkits/others/gitlab` returns `200`

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [ ] Content improvement
- [ ] Other: ____

## Related Issues/PRs (if applicable)

- Related SDK PR: agno-agi/agno#6721

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable) (N/A: no UI/image asset changes)
