### PR TITLE
fix: correct AG-UI typescript-sdk path to sdks/typescript

### DIFF
--- a/agent-os/usage/interfaces/ag-ui/basic.mdx
+++ b/agent-os/usage/interfaces/ag-ui/basic.mdx
@@ -64,8 +64,7 @@ if __name__ == "__main__":
 ## Setup Frontend
 
 1. Clone AG-UI repository: `git clone https://github.com/ag-ui-protocol/ag-ui.git`
-2. Install dependencies: `cd ag-ui/typescript-sdk && pnpm install`
+2. Install dependencies: `cd ag-ui/sdks/typescript && pnpm install`
 3. Build integration: `cd integrations/agno && pnpm run build`
 4. Start Dojo: `cd ../../apps/dojo && pnpm run dev`
 5. Access at http://localhost:3000
-

--- a/agent-os/usage/interfaces/ag-ui/basic.mdx
+++ b/agent-os/usage/interfaces/ag-ui/basic.mdx
@@ -68,3 +68,4 @@ if __name__ == "__main__":
 3. Build integration: `cd integrations/agno && pnpm run build`
 4. Start Dojo: `cd ../../apps/dojo && pnpm run dev`
 5. Access at http://localhost:3000
+


### PR DESCRIPTION
## Problem

In the document `agent-os/usage/interfaces/ag-ui/basic.mdx`, the Setup Frontend section has an incorrect path:

```
2. Install dependencies: cd ag-ui/typescript-sdk && pnpm install
```

## Solution

The correct path should be:

```
2. Install dependencies: cd ag-ui/sdks/typescript && pnpm install
```

The directory structure in the [ag-ui repo](https://github.com/ag-ui-protocol/ag-ui) has changed.

Fixes #551