### PR TITLE
docs: Update Google Calendar and Gmail toolkits documentation

### DIFF
--- a/tools/toolkits/others/googlecalendar.mdx
+++ b/tools/toolkits/others/googlecalendar.mdx
@@ -210,5 +210,5 @@ The agno cookbook includes several Google Calendar examples demonstrating differ
 
 ## Developer Resources
 
-- View [Source Code](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/calendar.py)
-- View [Cookbook Examples](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/google)
+- [Source Code](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/calendar.py)
+- [Cookbook Examples](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/google)

--- a/tools/toolkits/others/googlecalendar.mdx
+++ b/tools/toolkits/others/googlecalendar.mdx
@@ -2,21 +2,21 @@
 title: Google Calendar
 ---
 
-Enable an Agent to work with Google Calendar to view and schedule meetings.
+Enable an Agent to work with Google Calendar to view, search, schedule meetings, check availability, and manage events.
 
 ## Prerequisites
 
 ### Install dependencies
 
 ```shell
-uv pip install tzlocal
+uv pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ### Setup Google Project and OAuth
 
 Reference: https://developers.google.com/calendar/api/quickstart/python
 
-1. Enable Google Calender API
+1. Enable Google Calendar API
 
    - Go to [Google Cloud Console](https://console.cloud.google.com/apis/enableflow?apiid=calendar-json.googleapis.com).
    - Select Project and Enable.
@@ -33,9 +33,10 @@ Reference: https://developers.google.com/calendar/api/quickstart/python
 5. Select Scope
 
    - Click on Add or Remove Scope.
-   - Search for Google Calender API (Make sure you've enabled Google calender API otherwise scopes wont be visible).
+   - Search for Google Calendar API (Make sure you've enabled Google Calendar API otherwise scopes won't be visible).
    - Select scopes accordingly
-     - From the dropdown check on `/auth/calendar` scope
+     - For read-only access: Select `/auth/calendar.readonly`
+     - For full access: Select `/auth/calendar`
    - Save and continue.
 
 6. Adding Test User
@@ -54,61 +55,160 @@ Reference: https://developers.google.com/calendar/api/quickstart/python
    - Select Application Type as Desktop app.
    - Download JSON.
 
-8. Using Google Calender Tool
-   - Pass the path of downloaded credentials as credentials_path to Google Calender tool.
+8. Using Google Calendar Tool
+   - Pass the path of downloaded credentials as credentials_path to Google Calendar tool.
    - Optional: Set the `token_path` parameter to specify where the tool should create the `token.json` file.
    - The `token.json` file is used to store the user's access and refresh tokens and is automatically created during the authorization flow if it doesn't already exist.
    - If `token_path` is not explicitly provided, the file will be created in the default location which is your current working directory.
    - If you choose to specify `token_path`, please ensure that the directory you provide has write access, as the application needs to create or update this file during the authentication process.
 
+### Service Account Authentication (Alternative)
+
+For server/bot deployments without browser access:
+
+1. Create a service account at **IAM & Admin > Service Accounts** in Google Cloud Console
+2. Download the JSON key file
+3. For accessing another user's calendar, configure **domain-wide delegation** in Google Workspace Admin Console
+4. Set environment variables:
+
+```shell
+export GOOGLE_SERVICE_ACCOUNT_FILE=/path/to/service-account-key.json
+export GOOGLE_DELEGATED_USER=user@yourdomain.com  # Optional for Calendar
+```
+
 ## Example
 
 The following agent will use GoogleCalendarTools to find today's events.
 
-```python cookbook/14_tools/googlecalendar_tools.py
+```python cookbook/91_tools/google/calendar_daily_briefing.py
 from agno.agent import Agent
-from agno.tools.googlecalendar import GoogleCalendarTools
-import datetime
-import os
-from tzlocal import get_localzone_name
+from agno.models.openai import OpenAIChat
+from agno.tools.google.calendar import GoogleCalendarTools
 
 agent = Agent(
-    tools=[GoogleCalendarTools(credentials_path="<PATH_TO_YOUR_CREDENTIALS_FILE>")],
-        instructions=[
-        f"""
-        You are scheduling assistant . Today is {datetime.datetime.now()} and the users timezone is {get_localzone_name()}.
-        You should help users to perform these actions in their Google calendar:
-            - get their scheduled events from a certain date and time
-            - create events based on provided details
-        """
-    ],
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[GoogleCalendarTools()],
     add_datetime_to_context=True,
+    markdown=True,
 )
 
-agent.print_response("Give me the list of today's events", markdown=True)
+agent.print_response("What meetings do I have tomorrow?", stream=True)
+```
+
+## Quick Start Example
+
+```python
+# Minimal example with OAuth
+from agno.agent import Agent
+from agno.tools.google.calendar import GoogleCalendarTools
+
+# OAuth authentication (browser-based)
+agent = Agent(
+    tools=[GoogleCalendarTools(
+        credentials_path="path/to/credentials.json"
+    )],
+    instructions=["You help users manage their Google Calendar."],
+)
+
+# Service account authentication (no browser needed)
+agent = Agent(
+    tools=[GoogleCalendarTools(
+        service_account_path="path/to/service-account.json",
+        delegated_user="user@domain.com"  # Optional
+    )],
+)
 ```
 
 ## Toolkit Params
 
-| Parameter          | Type        | Default      | Description                                                                   |
-| ------------------ | ----------- | ------------ | ----------------------------------------------------------------------------- |
-| `scopes`           | `List[str]` | `None`       | List of OAuth scopes for Google Calendar API access                           |
-| `credentials_path` | `str`       | `None`       | Path of the file credentials.json file which contains OAuth 2.0 Client ID     |
-| `token_path`       | `str`       | `token.json` | Path of the file token.json which stores the user's access and refresh tokens |
-| `access_token`     | `str`       | `None`       | Direct access token for authentication (alternative to OAuth flow)            |
-| `calendar_id`      | `str`       | `primary`    | The calendar ID to use for operations                                         |
-| `oauth_port`       | `int`       | `8080`       | Port number for OAuth callback server                                         |
-| `allow_update`     | `bool`      | `False`      | Whether to allow write operations (create/update/delete events)               |
+| Parameter               | Type                          | Default        | Description                                                                   |
+| ----------------------- | ----------------------------- | -------------- | ----------------------------------------------------------------------------- |
+| `creds`                 | `Credentials`                 | `None`         | Pre-fetched credentials to skip a new auth flow                              |
+| `credentials_path`      | `str`                         | `None`         | Path of the file credentials.json file which contains OAuth 2.0 Client ID     |
+| `token_path`            | `str`                         | `"token.json"` | Path of the file token.json which stores the user's access and refresh tokens |
+| `service_account_path`  | `str`                         | `None`         | Path to service account JSON key. When set, OAuth is skipped                 |
+| `delegated_user`        | `str`                         | `None`         | Email to impersonate via domain-wide delegation. Optional for Calendar        |
+| `scopes`                | `List[str]`                   | `None`         | List of OAuth scopes for Google Calendar API access                           |
+| `oauth_port`            | `int`                         | `8080`         | Port number for OAuth callback server                                         |
+| `login_hint`            | `str`                         | `None`         | Email to pre-select in the OAuth consent screen                              |
+| `calendar_id`           | `str`                         | `"primary"`    | The calendar ID to use for operations                                         |
+| `allow_update`          | `bool`                        | `None`         | Deprecated: Use individual tool boolean flags                                 |
+| `list_events`           | `bool`                        | `True`         | Enable list_events tool                                                       |
+| `get_event`             | `bool`                        | `True`         | Enable get_event tool                                                         |
+| `fetch_all_events`      | `bool`                        | `True`         | Enable fetch_all_events tool                                                  |
+| `find_available_slots`  | `bool`                        | `True`         | Enable find_available_slots tool                                              |
+| `list_calendars`        | `bool`                        | `True`         | Enable list_calendars tool                                                    |
+| `check_availability`    | `bool`                        | `True`         | Enable check_availability tool                                                |
+| `get_event_attendees`   | `bool`                        | `True`         | Enable get_event_attendees tool                                               |
+| `search_events`         | `bool`                        | `True`         | Enable search_events tool                                                     |
+| `create_event`          | `bool`                        | `True`         | Enable create_event tool                                                      |
+| `update_event`          | `bool`                        | `True`         | Enable update_event tool                                                      |
+| `delete_event`          | `bool`                        | `True`         | Enable delete_event tool                                                      |
+| `quick_add_event`       | `bool`                        | `False`        | Enable quick_add_event tool                                                   |
+| `move_event`            | `bool`                        | `False`        | Enable move_event tool                                                        |
+| `respond_to_event`      | `bool`                        | `False`        | Enable respond_to_event tool                                                  |
 
 ## Toolkit Functions
 
-| Function       | Description                                        |
-| -------------- | -------------------------------------------------- |
-| `list_events`  | List events from the user's primary calendar.      |
-| `create_event` | Create a new event in the user's primary calendar. |
+### Reading Events
+
+| Function               | Description                                                                             |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| `list_events`          | List upcoming events from the calendar. Parameters: `limit` (int), `start_date` (str)   |
+| `get_event`            | Get full details of a single event by ID. Parameters: `event_id` (str)                  |
+| `fetch_all_events`     | Fetch all events in a date range with pagination. Parameters: `max_results` (int), `start_date` (str), `end_date` (str) |
+| `search_events`        | Search events by text across all fields. Parameters: `query` (str), `start_date` (str), `end_date` (str), `max_results` (int) |
+| `get_event_attendees`  | Get attendee list and RSVP statuses for an event. Parameters: `event_id` (str)         |
+
+### Scheduling & Availability
+
+| Function               | Description                                                                             |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| `find_available_slots` | Find free time slots based on working hours and existing events. Parameters: `start_date` (str), `end_date` (str), `duration_minutes` (int) |
+| `check_availability`   | Check busy/free status for multiple people using FreeBusy API. Parameters: `start_date` (str), `end_date` (str), `attendee_emails` (List[str]), `timezone` (str) |
+| `list_calendars`       | List all available calendars with access roles. No parameters required                  |
+
+### Creating & Managing Events
+
+| Function           | Description                                                                                   |
+| ------------------ | --------------------------------------------------------------------------------------------- |
+| `create_event`     | Create a detailed event with attendees and conferencing. Parameters: `start_date` (str), `end_date` (str), `title` (str), `description` (str), `location` (str), `timezone` (str), `attendees` (List[str]), `add_google_meet_link` (bool), `notify_attendees` (bool) |
+| `update_event`     | Update existing event details. Parameters: `event_id` (str), `title` (str), `description` (str), `location` (str), `start_date` (str), `end_date` (str), `timezone` (str), `attendees` (List[str]), `notify_attendees` (bool) |
+| `delete_event`     | Delete an event with optional notifications. Parameters: `event_id` (str), `notify_attendees` (bool) |
+| `quick_add_event`  | Create event from natural language (e.g., "Lunch with Sarah tomorrow noon"). Parameters: `text` (str) |
+| `move_event`       | Move event to a different calendar. Parameters: `event_id` (str), `destination_calendar_id` (str), `notify_attendees` (bool) |
+| `respond_to_event` | Set attendance response (accepted/declined/tentative). Parameters: `event_id` (str), `response` (str) |
 
 You can use `include_tools` or `exclude_tools` to modify the list of tools the agent has access to. Learn more about [selecting tools](/tools/selecting-tools).
 
+## Cookbook Examples
+
+The agno cookbook includes several Google Calendar examples demonstrating different use cases:
+
+| Example                           | Description                                                    |
+| --------------------------------- | -------------------------------------------------------------- |
+| `calendar_event_creator.py`       | Create events with attendees, Google Meet, and timezone handling |
+| `calendar_daily_briefing.py`      | Generate structured daily briefings with conflict detection    |
+| `calendar_meeting_scheduler.py`   | Multi-person scheduling with availability checking             |
+| `calendar_gmail_meeting_prep.py`  | Combined Calendar + Gmail agent for meeting preparation        |
+
+## Tips for Using Google Calendar Tools
+
+1. **Date/Time Formats**: All dates use ISO format (YYYY-MM-DDTHH:MM:SS). Always specify timezone when creating events.
+
+2. **Working with Attendees**: Use `check_availability` before scheduling meetings with multiple people to find suitable times.
+
+3. **Natural Language Events**: Use `quick_add_event` for simple event creation from natural language descriptions.
+
+4. **Event Search**: Use `search_events` for full-text search across event titles, descriptions, locations, and attendees.
+
+5. **Authentication**: 
+   - Use OAuth for user-facing applications (requires browser)
+   - Use service accounts for server/bot deployments (no browser needed)
+
+6. **Calendar IDs**: Use "primary" for the user's main calendar, or get specific calendar IDs using `list_calendars`.
+
 ## Developer Resources
 
-- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/googlecalendar.py)
+- View [Source Code](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/calendar.py)
+- View [Cookbook Examples](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/google)

--- a/tools/toolkits/social/gmail.mdx
+++ b/tools/toolkits/social/gmail.mdx
@@ -6,26 +6,69 @@ title: Gmail
 
 ## Prerequisites
 
-The Gmail toolkit requires Google API client libraries and proper authentication setup. Install the required dependencies:
+### Install dependencies
 
 ```shell
 uv pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
-### OAuth Authentication Setup
+### Setup Google Project and OAuth
 
-1. Go to [Google Cloud Console](https://console.cloud.google.com)
-2. Create a project or select an existing one
-3. Enable the Gmail API
-4. Create OAuth 2.0 credentials (choose Desktop app)
-5. Go to **APIs & Services > OAuth consent screen > Test users** and add your Google account
-6. Set up environment variables:
+Reference: https://developers.google.com/gmail/api/quickstart/python
 
-```shell
-export GOOGLE_CLIENT_ID=your_client_id_here
-export GOOGLE_CLIENT_SECRET=your_client_secret_here
-export GOOGLE_PROJECT_ID=your_project_id_here
-```
+1. Enable Gmail API
+
+   - Go to [Google Cloud Console](https://console.cloud.google.com/apis/enableflow?apiid=gmail.googleapis.com).
+   - Select Project and Enable.
+
+2. Go To API & Service -> OAuth Consent Screen
+
+3. Select User Type
+
+   - If you are a Google Workspace user, select Internal.
+   - Otherwise, select External.
+
+4. Fill in the app details (App name, logo, support email, etc).
+
+5. Select Scope
+
+   - Click on Add or Remove Scope.
+   - Search for Gmail API (Make sure you've enabled Gmail API otherwise scopes won't be visible).
+   - Select scopes accordingly
+     - For read-only access: Select `/auth/gmail.readonly`
+     - For full access: Select `/auth/gmail.modify` and `/auth/gmail.compose`
+   - Save and continue.
+
+6. Adding Test User
+
+   - Click Add Users and enter the email addresses of the users you want to allow during testing.
+   - NOTE: Only these users can access the app's OAuth functionality when the app is in "Testing" mode.
+     Any other users will receive access denied errors.
+   - To make the app available to all users, you'll need to move the app's status to "In Production".
+     Before doing so, ensure the app is fully verified by Google if it uses sensitive or restricted scopes.
+   - Click on Go back to Dashboard.
+
+7. Generate OAuth 2.0 Client ID
+
+   - Go to Credentials.
+   - Click on Create Credentials -> OAuth Client ID
+   - Select Application Type as Desktop app.
+   - Download JSON.
+
+8. Using Gmail Tool
+   - Pass the path of downloaded credentials as `credentials_path` to GmailTools.
+   - Optional: Set the `token_path` parameter to specify where the tool should create the `token.json` file.
+   - The `token.json` file is used to store the user's access and refresh tokens and is automatically created during the authorization flow if it doesn't already exist.
+   - If `token_path` is not explicitly provided, the file will be created as `token.json` in your current working directory.
+   - If you choose to specify `token_path`, please ensure that the directory you provide has write access, as the application needs to create or update this file during the authentication process.
+
+   Alternatively, if you prefer environment variables over a credentials file:
+
+   ```shell
+   export GOOGLE_CLIENT_ID=your_client_id_here
+   export GOOGLE_CLIENT_SECRET=your_client_secret_here
+   export GOOGLE_PROJECT_ID=your_project_id_here
+   ```
 
 ### Service Account Authentication (Alternative)
 
@@ -84,8 +127,45 @@ agent = Agent(
 | `service_account_path`  | `str`         | `None`         | Path to service account JSON key. When set, OAuth is skipped |
 | `delegated_user`        | `str`         | `None`         | Email to impersonate (required for Gmail with service account) |
 | `scopes`                | `List[str]`   | `None`         | Custom OAuth scopes                                        |
-| `oauth_port`            | `int`         | `8080`         | Port for OAuth authentication callback                     |
+| `port`                  | `int`         | `None`         | Port for OAuth authentication callback                     |
 | `login_hint`            | `str`         | `None`         | Email to pre-select in OAuth consent screen                |
+| `include_html`          | `bool`        | `False`        | Return raw HTML body instead of stripping tags             |
+| `max_body_length`       | `int`         | `None`         | Truncate message bodies to this length                     |
+| `attachment_dir`        | `str`         | `None`         | Directory to save downloaded attachments                   |
+| `max_batch_size`        | `int`         | `10`           | Max items per Gmail API batch request (max 100)            |
+| `get_latest_emails`     | `bool`        | `True`         | Enable get_latest_emails tool                              |
+| `get_emails_from_user`  | `bool`        | `True`         | Enable get_emails_from_user tool                           |
+| `get_unread_emails`     | `bool`        | `True`         | Enable get_unread_emails tool                              |
+| `get_starred_emails`    | `bool`        | `True`         | Enable get_starred_emails tool                             |
+| `get_emails_by_context` | `bool`        | `True`         | Enable get_emails_by_context tool                          |
+| `get_emails_by_date`    | `bool`        | `True`         | Enable get_emails_by_date tool                             |
+| `get_emails_by_thread`  | `bool`        | `True`         | Enable get_emails_by_thread tool                           |
+| `search_emails`         | `bool`        | `True`         | Enable search_emails tool                                  |
+| `mark_email_as_read`    | `bool`        | `True`         | Enable mark_email_as_read tool                             |
+| `mark_email_as_unread`  | `bool`        | `True`         | Enable mark_email_as_unread tool                           |
+| `star_email`            | `bool`        | `True`         | Enable star_email tool                                     |
+| `unstar_email`          | `bool`        | `True`         | Enable unstar_email tool                                   |
+| `archive_email`         | `bool`        | `False`        | Enable archive_email tool                                  |
+| `create_draft_email`    | `bool`        | `True`         | Enable create_draft_email tool                             |
+| `send_email`            | `bool`        | `True`         | Enable send_email tool                                     |
+| `send_email_reply`      | `bool`        | `True`         | Enable send_email_reply tool                               |
+| `list_custom_labels`    | `bool`        | `True`         | Enable list_custom_labels tool                             |
+| `apply_label`           | `bool`        | `True`         | Enable apply_label tool                                    |
+| `remove_label`          | `bool`        | `True`         | Enable remove_label tool                                   |
+| `delete_custom_label`   | `bool`        | `True`         | Enable delete_custom_label tool                            |
+| `get_message`           | `bool`        | `True`         | Enable get_message tool                                    |
+| `get_thread`            | `bool`        | `True`         | Enable get_thread tool                                     |
+| `search_threads`        | `bool`        | `True`         | Enable search_threads tool                                 |
+| `modify_thread_labels`  | `bool`        | `False`        | Enable modify_thread_labels tool                           |
+| `trash_thread`          | `bool`        | `False`        | Enable trash_thread tool                                   |
+| `get_draft`             | `bool`        | `True`         | Enable get_draft tool                                      |
+| `list_drafts`           | `bool`        | `True`         | Enable list_drafts tool                                    |
+| `send_draft`            | `bool`        | `False`        | Enable send_draft tool                                     |
+| `update_draft`          | `bool`        | `True`         | Enable update_draft tool                                   |
+| `list_labels`           | `bool`        | `False`        | Enable list_labels tool                                    |
+| `modify_message_labels` | `bool`        | `False`        | Enable modify_message_labels tool                          |
+| `trash_message`         | `bool`        | `False`        | Enable trash_message tool                                  |
+| `download_attachment`   | `bool`        | `False`        | Enable download_attachment tool                            |
 
 ## Toolkit Functions
 
@@ -98,10 +178,10 @@ agent = Agent(
 | `get_unread_emails`     | Get unread emails. Parameters: `count` (int) |
 | `get_starred_emails`    | Get starred emails. Parameters: `count` (int) |
 | `get_emails_by_context` | Get emails matching a context. Parameters: `context` (str), `count` (int) |
-| `get_emails_by_date`    | Get emails within a date range. Parameters: `start_date` (int), `range_in_days` (int), `num_emails` (int) |
+| `get_emails_by_date`    | Get emails within a date range. Parameters: `start_date` (str), `range_in_days` (int), `num_emails` (int) |
 | `get_emails_by_thread`  | Get all emails from a thread. Parameters: `thread_id` (str) |
 | `search_emails`         | Search emails using natural language. Parameters: `query` (str), `count` (int) |
-| `get_message`           | Get a specific message by ID. Parameters: `message_id` (str) |
+| `get_message`           | Get a specific message by ID. Parameters: `message_id` (str), `download_attachments` (bool) |
 | `get_thread`            | Get all messages in a thread. Parameters: `thread_id` (str) |
 | `search_threads`        | Search email threads. Parameters: `query` (str), `count` (int) |
 
@@ -114,7 +194,7 @@ agent = Agent(
 | `star_email`            | Star an email. Parameters: `message_id` (str) |
 | `unstar_email`          | Unstar an email. Parameters: `message_id` (str) |
 | `archive_email`         | Archive an email. Parameters: `message_id` (str) |
-| `trash_message`         | Move message to trash. Parameters: `message_id` (str) |
+| `trash_message`         | Move message to trash, or restore with undo. Parameters: `message_id` (str), `undo` (bool) |
 | `trash_thread`          | Move thread to trash. Parameters: `thread_id` (str) |
 | `download_attachment`   | Download email attachment. Parameters: `message_id` (str), `attachment_id` (str), `filename` (str) |
 
@@ -122,13 +202,13 @@ agent = Agent(
 
 | Function             | Description                                        |
 | -------------------- | -------------------------------------------------- |
-| `create_draft_email` | Create draft with attachments. Parameters: `to` (str), `subject` (str), `body` (str), `cc` (str), `attachments` (List[str]) |
-| `send_email`         | Send email with attachments. Parameters: `to` (str), `subject` (str), `body` (str), `cc` (str), `attachments` (List[str]) |
+| `create_draft_email` | Create draft with attachments. Parameters: `to` (str), `subject` (str), `body` (str), `cc` (str), `bcc` (str), `attachments` (List[str]), `thread_id` (str), `message_id` (str) |
+| `send_email`         | Send email with attachments. Parameters: `to` (str), `subject` (str), `body` (str), `cc` (str), `bcc` (str), `attachments` (List[str]), `thread_id` (str), `message_id` (str) |
 | `send_email_reply`   | Reply to email thread. Parameters: `thread_id` (str), `message_id` (str), `to` (str), `subject` (str), `body` (str), `cc` (str), `attachments` (List[str]) |
 | `get_draft`          | Get draft by ID. Parameters: `draft_id` (str) |
 | `list_drafts`        | List all drafts. Parameters: `count` (int) |
 | `send_draft`         | Send a draft. Parameters: `draft_id` (str) |
-| `update_draft`       | Update draft content. Parameters: `draft_id` (str), `to` (str), `subject` (str), `body` (str), `cc` (str), `attachments` (List[str]) |
+| `update_draft`       | Update draft content. Parameters: `draft_id` (str), `to` (str), `subject` (str), `body` (str), `cc` (str), `bcc` (str), `attachments` (List[str]), `thread_id` (str), `message_id` (str) |
 
 ### Label Management
 
@@ -151,9 +231,9 @@ The agno cookbook includes several Gmail examples demonstrating different use ca
 | Example                      | Description                                       |
 | ---------------------------- | ------------------------------------------------- |
 | `gmail_tools.py`             | Core examples: read-only agent, safe agent, label manager, full agent, thread reply |
-| `gmail_structured_output.py` | Extract structured data from emails              |
-| `gmail_vacation.py`          | Vacation responder with calendar integration      |
-| `gmail_thread_summary.py`    | Comprehensive thread summarizer                   |
+| `gmail_daily_digest.py`      | Summarize recent emails into a structured daily digest grouped by priority |
+| `gmail_draft_reply.py`       | Read a conversation thread and draft a contextual reply for human review |
+| `gmail_inbox_triage.py`      | Personal inbox triage agent with Learning Machine for persistent preferences |
 | `gmail_followup_tracker.py`  | Find unanswered sent emails, draft follow-ups     |
 | `gmail_action_items.py`      | Extract structured action items from email threads |
 
@@ -175,5 +255,5 @@ The agno cookbook includes several Gmail examples demonstrating different use ca
 
 ## Developer Resources
 
-- View [Source Code](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/gmail.py)
-- View [Cookbook Examples](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/google)
+- [Source Code](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/gmail.py)
+- [Cookbook Examples](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/google)

--- a/tools/toolkits/social/gmail.mdx
+++ b/tools/toolkits/social/gmail.mdx
@@ -2,7 +2,7 @@
 title: Gmail
 ---
 
-**Gmail** enables an Agent to interact with Gmail, allowing it to read, search, send, manage emails, and organize them with labels.
+**Gmail** enables an Agent to interact with Gmail, allowing it to read, search, send, manage emails, and organize them with labels. Supports both OAuth and service account authentication.
 
 ## Prerequisites
 
@@ -12,65 +12,168 @@ The Gmail toolkit requires Google API client libraries and proper authentication
 uv pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
-You'll also need to set up Google Cloud credentials:
+### OAuth Authentication Setup
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com)
 2. Create a project or select an existing one
 3. Enable the Gmail API
-4. Create OAuth 2.0 credentials
-5. Set up environment variables:
+4. Create OAuth 2.0 credentials (choose Desktop app)
+5. Go to **APIs & Services > OAuth consent screen > Test users** and add your Google account
+6. Set up environment variables:
 
 ```shell
 export GOOGLE_CLIENT_ID=your_client_id_here
 export GOOGLE_CLIENT_SECRET=your_client_secret_here
 export GOOGLE_PROJECT_ID=your_project_id_here
-export GOOGLE_REDIRECT_URI=http://localhost  # Default value
+```
+
+### Service Account Authentication (Alternative)
+
+For server/bot deployments without browser access:
+
+1. Create a service account at **IAM & Admin > Service Accounts** in Google Cloud Console
+2. Download the JSON key file
+3. Configure **domain-wide delegation** in Google Workspace Admin Console (required for Gmail)
+4. Set environment variables:
+
+```shell
+export GOOGLE_SERVICE_ACCOUNT_FILE=/path/to/service-account-key.json
+export GOOGLE_DELEGATED_USER=user@yourdomain.com  # Required for Gmail
 ```
 
 ## Example
 
-```python cookbook/14_tools/gmail_tools.py
+```python cookbook/91_tools/google/gmail_tools.py
 from agno.agent import Agent
-from agno.tools.gmail import GmailTools
+from agno.tools.google.gmail import GmailTools
 
 agent = Agent(tools=[GmailTools()])
 agent.print_response("Show me my latest 5 unread emails", markdown=True)
 ```
 
+## Quick Start Examples
+
+```python
+# OAuth authentication (browser-based)
+from agno.agent import Agent
+from agno.tools.google.gmail import GmailTools
+
+agent = Agent(
+    tools=[GmailTools(
+        credentials_path="path/to/credentials.json"
+    )],
+    instructions=["You help users manage their Gmail inbox."],
+)
+
+# Service account authentication (no browser needed)
+agent = Agent(
+    tools=[GmailTools(
+        service_account_path="path/to/service-account.json",
+        delegated_user="user@domain.com"  # Required for Gmail
+    )],
+)
+```
+
 ## Toolkit Params
 
-| Parameter          | Type          | Default | Description                          |
-| ------------------ | ------------- | ------- | ------------------------------------ |
-| `creds`            | `Credentials` | `None`  | Pre-fetched OAuth credentials        |
-| `credentials_path` | `str`         | `None`  | Path to credentials file             |
-| `token_path`       | `str`         | `None`  | Path to token file                   |
-| `scopes`           | `List[str]`   | `None`  | Custom OAuth scopes                  |
-| `port`             | `int`         | `None`  | Port to use for OAuth authentication |
+| Parameter               | Type          | Default        | Description                                                |
+| ----------------------- | ------------- | -------------- | ---------------------------------------------------------- |
+| `creds`                 | `Credentials` | `None`         | Pre-fetched OAuth credentials to skip auth flow           |
+| `credentials_path`      | `str`         | `None`         | Path to OAuth credentials JSON file                        |
+| `token_path`            | `str`         | `"token.json"` | Path to token file for storing access/refresh tokens       |
+| `service_account_path`  | `str`         | `None`         | Path to service account JSON key. When set, OAuth is skipped |
+| `delegated_user`        | `str`         | `None`         | Email to impersonate (required for Gmail with service account) |
+| `scopes`                | `List[str]`   | `None`         | Custom OAuth scopes                                        |
+| `oauth_port`            | `int`         | `8080`         | Port for OAuth authentication callback                     |
+| `login_hint`            | `str`         | `None`         | Email to pre-select in OAuth consent screen                |
 
 ## Toolkit Functions
 
+### Reading Emails
+
 | Function                | Description                                        |
 | ----------------------- | -------------------------------------------------- |
-| `get_latest_emails`     | Get the latest X emails from the user's inbox. Parameters include `count` (int) for number of emails to retrieve. |
-| `get_emails_from_user`  | Get X number of emails from a specific sender. Parameters include `user` (str) for sender name or email, and `count` (int) for maximum number of emails. |
-| `get_unread_emails`     | Get the latest X unread emails. Parameters include `count` (int) for maximum number of unread emails. |
-| `get_starred_emails`    | Get X number of starred emails. Parameters include `count` (int) for maximum number of starred emails. |
-| `get_emails_by_context` | Get X number of emails matching a specific context. Parameters include `context` (str) for search term, and `count` (int) for maximum number of emails. |
-| `get_emails_by_date`    | Get emails within a specific date range. Parameters include `start_date` (int) for unix timestamp, `range_in_days` (Optional[int]) for date range, and `num_emails` (Optional[int], default=10). |
-| `get_emails_by_thread`  | Retrieve all emails from a specific thread. Parameters include `thread_id` (str) for the thread ID. |
-| `search_emails`         | Search emails using natural language queries. Parameters include `query` (str) for search query, and `count` (int) for number of emails to retrieve. |
-| `create_draft_email`    | Create and save an email draft with attachments. Parameters include `to` (str), `subject` (str), `body` (str), `cc` (Optional[str]), and `attachments` (Optional[Union[str, List[str]]]). |
-| `send_email`            | Send an email with attachments. Parameters include `to` (str), `subject` (str), `body` (str), `cc` (Optional[str]), and `attachments` (Optional[Union[str, List[str]]]). |
-| `send_email_reply`      | Reply to an existing email thread. Parameters include `thread_id` (str), `message_id` (str), `to` (str), `subject` (str), `body` (str), `cc` (Optional[str]), and `attachments` (Optional[Union[str, List[str]]]). |
-| `mark_email_as_read`    | Mark a specific email as read. Parameters include `message_id` (str) for the message ID. |
-| `mark_email_as_unread`  | Mark a specific email as unread. Parameters include `message_id` (str) for the message ID. |
-| `list_custom_labels`    | List all user-created custom labels. No parameters required. |
-| `apply_label`           | Apply labels to emails (creates if needed). Parameters include `context` (str) for search query, `label_name` (str) for label name, and `count` (int, default=10). |
-| `remove_label`          | Remove labels from emails. Parameters include `context` (str) for search query, `label_name` (str) for label name, and `count` (int, default=10). |
-| `delete_custom_label`   | Delete a custom label with confirmation. Parameters include `label_name` (str) and `confirm` (bool, default=False) for safety confirmation. |
+| `get_latest_emails`     | Get the latest X emails from the user's inbox. Parameters: `count` (int) |
+| `get_emails_from_user`  | Get emails from a specific sender. Parameters: `user` (str), `count` (int) |
+| `get_unread_emails`     | Get unread emails. Parameters: `count` (int) |
+| `get_starred_emails`    | Get starred emails. Parameters: `count` (int) |
+| `get_emails_by_context` | Get emails matching a context. Parameters: `context` (str), `count` (int) |
+| `get_emails_by_date`    | Get emails within a date range. Parameters: `start_date` (int), `range_in_days` (int), `num_emails` (int) |
+| `get_emails_by_thread`  | Get all emails from a thread. Parameters: `thread_id` (str) |
+| `search_emails`         | Search emails using natural language. Parameters: `query` (str), `count` (int) |
+| `get_message`           | Get a specific message by ID. Parameters: `message_id` (str) |
+| `get_thread`            | Get all messages in a thread. Parameters: `thread_id` (str) |
+| `search_threads`        | Search email threads. Parameters: `query` (str), `count` (int) |
+
+### Managing Emails
+
+| Function                | Description                                        |
+| ----------------------- | -------------------------------------------------- |
+| `mark_email_as_read`    | Mark email as read. Parameters: `message_id` (str) |
+| `mark_email_as_unread`  | Mark email as unread. Parameters: `message_id` (str) |
+| `star_email`            | Star an email. Parameters: `message_id` (str) |
+| `unstar_email`          | Unstar an email. Parameters: `message_id` (str) |
+| `archive_email`         | Archive an email. Parameters: `message_id` (str) |
+| `trash_message`         | Move message to trash. Parameters: `message_id` (str) |
+| `trash_thread`          | Move thread to trash. Parameters: `thread_id` (str) |
+| `download_attachment`   | Download email attachment. Parameters: `message_id` (str), `attachment_id` (str), `filename` (str) |
+
+### Composing & Sending
+
+| Function             | Description                                        |
+| -------------------- | -------------------------------------------------- |
+| `create_draft_email` | Create draft with attachments. Parameters: `to` (str), `subject` (str), `body` (str), `cc` (str), `attachments` (List[str]) |
+| `send_email`         | Send email with attachments. Parameters: `to` (str), `subject` (str), `body` (str), `cc` (str), `attachments` (List[str]) |
+| `send_email_reply`   | Reply to email thread. Parameters: `thread_id` (str), `message_id` (str), `to` (str), `subject` (str), `body` (str), `cc` (str), `attachments` (List[str]) |
+| `get_draft`          | Get draft by ID. Parameters: `draft_id` (str) |
+| `list_drafts`        | List all drafts. Parameters: `count` (int) |
+| `send_draft`         | Send a draft. Parameters: `draft_id` (str) |
+| `update_draft`       | Update draft content. Parameters: `draft_id` (str), `to` (str), `subject` (str), `body` (str), `cc` (str), `attachments` (List[str]) |
+
+### Label Management
+
+| Function                | Description                                        |
+| ----------------------- | -------------------------------------------------- |
+| `list_labels`           | List all labels in the account. No parameters |
+| `list_custom_labels`    | List user-created labels. No parameters |
+| `apply_label`           | Apply label to emails. Parameters: `context` (str), `label_name` (str), `count` (int) |
+| `remove_label`          | Remove label from emails. Parameters: `context` (str), `label_name` (str), `count` (int) |
+| `delete_custom_label`   | Delete a custom label. Parameters: `label_name` (str), `confirm` (bool) |
+| `modify_message_labels` | Modify message labels. Parameters: `message_id` (str), `add_labels` (List[str]), `remove_labels` (List[str]) |
+| `modify_thread_labels`  | Modify thread labels. Parameters: `thread_id` (str), `add_labels` (List[str]), `remove_labels` (List[str]) |
 
 You can use `include_tools` or `exclude_tools` to modify the list of tools the agent has access to. Learn more about [selecting tools](/tools/selecting-tools).
 
+## Cookbook Examples
+
+The agno cookbook includes several Gmail examples demonstrating different use cases:
+
+| Example                      | Description                                       |
+| ---------------------------- | ------------------------------------------------- |
+| `gmail_tools.py`             | Core examples: read-only agent, safe agent, label manager, full agent, thread reply |
+| `gmail_structured_output.py` | Extract structured data from emails              |
+| `gmail_vacation.py`          | Vacation responder with calendar integration      |
+| `gmail_thread_summary.py`    | Comprehensive thread summarizer                   |
+| `gmail_followup_tracker.py`  | Find unanswered sent emails, draft follow-ups     |
+| `gmail_action_items.py`      | Extract structured action items from email threads |
+
+## Tips for Using Gmail Tools
+
+1. **Authentication**: 
+   - Use OAuth for user-facing applications (requires browser)
+   - Use service accounts for server/bot deployments (requires domain-wide delegation)
+   
+2. **Search Queries**: The `search_emails` function supports natural language queries that get converted to Gmail's search syntax.
+
+3. **Attachments**: When sending emails with attachments, provide file paths as strings or a list of strings.
+
+4. **Thread Management**: Use thread operations (`get_thread`, `trash_thread`, etc.) to manage entire conversations.
+
+5. **Label Operations**: Gmail's label system is hierarchical - use forward slashes for nested labels (e.g., "Work/Projects").
+
+6. **Rate Limits**: Be mindful of Gmail API quotas when performing bulk operations.
+
 ## Developer Resources
 
-- View [Example](https://github.com/agno-agi/agno/tree/main/cookbook/91_models/others/gmail)
+- View [Source Code](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/gmail.py)
+- View [Cookbook Examples](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/google)


### PR DESCRIPTION
## Summary

This PR updates the documentation for Google Calendar and Gmail toolkits based on the significant enhancements made in agno-agi/agno#6926.

### What was added

#### Google Calendar Documentation Updates:
- Added documentation for **7 new tools**:
  - `get_event` - Fetch single event by ID
  - `quick_add_event` - Natural language event creation
  - `check_availability` - Multi-person FreeBusy API
  - `search_events` - Full-text search across event fields
  - `move_event` - Move event to different calendar
  - `get_event_attendees` - Attendee list with RSVP statuses
  - `respond_to_event` - Accept/decline/tentative RSVP
- Added **service account authentication** documentation
- Added all new authentication parameters (`login_hint`, `service_account_path`, `delegated_user`)
- Added cookbook examples references
- Organized functions into logical categories (Reading, Scheduling, Creating)
- Added tips section for best practices

#### Gmail Documentation Updates:
- Added **service account authentication** section
- Updated with new authentication parameters
- Added documentation for all new tools from the PR:
  - `get_message`, `get_thread`, `search_threads`
  - `modify_thread_labels`, `trash_thread`
  - `get_draft`, `list_drafts`, `send_draft`, `update_draft`
  - `list_labels`, `modify_message_labels`, `trash_message`
  - `download_attachment`
- Organized functions into categories
- Added tips section

### Related to

- Source PR: agno-agi/agno#6926

### Changes made
- Extended GoogleCalendarTools documentation from ~5KB to ~13KB with comprehensive coverage
- Extended GmailTools documentation from ~5KB to ~9.6KB with all new features
- Both docs now follow consistent structure with OAuth and service account auth sections