### PR TITLE
docs: add Telegram interface documentation

### DIFF
--- a/agent-os/interfaces/overview.mdx
+++ b/agent-os/interfaces/overview.mdx
@@ -32,6 +32,13 @@ Interfaces enable exposing Agno agents, teams, and workflows through various com
     Serve agents via WhatsApp for direct messaging interactions
   </Card>
   <Card
+    title="Telegram"
+    icon="telegram"
+    href="/agent-os/interfaces/telegram/introduction"
+  >
+    Deploy agents as Telegram bots for direct and group chat conversations
+  </Card>
+  <Card
     title="A2A"
     icon="code"
     href="/agent-os/interfaces/a2a/introduction"

--- a/agent-os/interfaces/overview.mdx
+++ b/agent-os/interfaces/overview.mdx
@@ -2,7 +2,7 @@
 title: "Interfaces"
 sidebarTitle: "Overview"
 description: "Expose Agno agents through various communication protocols and platforms"
-keywords: [interfaces, a2a, ag-ui, slack, whatsapp, protocols, integration]
+keywords: [interfaces, a2a, ag-ui, slack, whatsapp, telegram, protocols, integration]
 ---
 
 Interfaces enable exposing Agno agents, teams, and workflows through various communication protocols and platforms. Each interface provides a standardized way to connect Agno agents to external systems, messaging platforms, and frontend applications.

--- a/agent-os/interfaces/telegram/introduction.mdx
+++ b/agent-os/interfaces/telegram/introduction.mdx
@@ -81,7 +81,7 @@ Main entry point for Agno Telegram applications.
 | `help_message` | `str` | `"Send me text, photos..."` | Message sent in response to the `/help` command. |
 | `error_message` | `str` | `"Sorry, there was an error..."` | Message sent when processing fails. |
 | `new_message` | `str` | `"New conversation started..."` | Message sent when a user starts a new session with `/new`. |
-| `commands` | `Optional[List[Dict]]` | `/start`, `/help`, `/new` | List of bot commands to register with Telegram. Each dict has `command` and `description` keys. |
+| `commands` | `Optional[List[Dict]]` | `None` | List of bot commands to register with Telegram. Each dict has `command` and `description` keys. Defaults to `/start`, `/help`, and `/new` when not provided. |
 | `register_commands` | `bool` | `True` | Automatically register commands with the Telegram Bot API on first message. |
 
 Provide `agent`, `team`, or `workflow`.

--- a/agent-os/interfaces/telegram/introduction.mdx
+++ b/agent-os/interfaces/telegram/introduction.mdx
@@ -1,18 +1,20 @@
 ---
 title: Telegram
-description: Host agents as Telegram bots.
+sidebarTitle: "Telegram"
+description: "Expose agents, teams, or workflows as Telegram bots with webhook endpoints."
+keywords: [telegram, bot, interface, webhook, streaming, group chat, media, tools]
 ---
 
-Use the Telegram interface to serve Agents, Teams, or Workflows on Telegram. It mounts webhook routes on a FastAPI app and sends responses back to Telegram chats.
+The Telegram interface exposes an Agno Agent, Team, or Workflow on Telegram via FastAPI webhook endpoints. It handles inbound messages (text, photos, audio, video, documents, stickers) and streams responses back to the originating chat.
 
 ## Setup
 
-Follow the Telegram setup guide in the [cookbook](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/interfaces/telegram/README.md).
+Follow the [Telegram deploy guide](/deploy/interfaces/telegram/overview) to set up your bot.
 
 Required configuration:
 
 - `TELEGRAM_TOKEN` (bot token from @BotFather)
-- Optional: `TELEGRAM_WEBHOOK_SECRET_TOKEN` (required in production when `APP_ENV` is not `development`)
+- `TELEGRAM_WEBHOOK_SECRET_TOKEN` -- required in production, skipped when `APP_ENV=development`
 - An ngrok tunnel (for local development) and webhook pointing to `/telegram/webhook`
 
 ## Example Usage
@@ -23,7 +25,7 @@ Create an agent, expose it with the `Telegram` interface, and serve via `AgentOS
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.google import Gemini
-from agno.os import AgentOS
+from agno.os.app import AgentOS
 from agno.os.interfaces.telegram import Telegram
 
 agent_db = SqliteDb(session_table="telegram_sessions", db_file="tmp/telegram_basic.db")
@@ -52,18 +54,11 @@ if __name__ == "__main__":
     agent_os.serve(app="basic:app", port=7777, reload=True)
 ```
 
-See the [Telegram Examples](/agent-os/usage/interfaces/telegram/basic) for more usage patterns.
+See the [Telegram examples](/agent-os/usage/interfaces/telegram/basic) for more usage patterns including [streaming](/agent-os/usage/interfaces/telegram/streaming), [teams](/agent-os/usage/interfaces/telegram/team), [workflows](/agent-os/usage/interfaces/telegram/workflow), and [multiple instances](/agent-os/usage/interfaces/telegram/multiple-instances).
 
-## Core Components
+## Parameters
 
-- `Telegram` (interface): Wraps an Agno `Agent`, `Team`, or `Workflow` for Telegram integration via FastAPI.
-- `AgentOS.serve`: Serves the FastAPI app using Uvicorn.
-
-## `Telegram` Interface
-
-Main entry point for Agno Telegram applications.
-
-### Initialization Parameters
+Provide `agent`, `team`, or `workflow`. Call `get_router()` to get the FastAPI `APIRouter` with all endpoints attached.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -74,7 +69,7 @@ Main entry point for Agno Telegram applications.
 | `tags` | `Optional[List[str]]` | `None` | FastAPI route tags for API documentation. Defaults to `["Telegram"]` if not provided. |
 | `token` | `Optional[str]` | `None` | Bot token. Falls back to `TELEGRAM_TOKEN` environment variable. |
 | `streaming` | `bool` | `True` | Enable token-by-token streaming with live message edits. |
-| `show_reasoning` | `bool` | `False` | Send reasoning content as a separate message before the response. |
+| `show_reasoning` | `bool` | `False` | Show the model's reasoning as a blockquote message. Works in both streaming and non-streaming modes. |
 | `reply_to_mentions_only` | `bool` | `True` | When `True` (default), bot responds to @mentions and replies in groups, and all messages in DMs. When `False`, responds to all messages in groups. |
 | `reply_to_bot_messages` | `bool` | `True` | When `True`, also responds when users reply to the bot's own messages in groups. |
 | `start_message` | `str` | `"Hello! I'm ready to help..."` | Message sent in response to the `/start` command. |
@@ -84,48 +79,46 @@ Main entry point for Agno Telegram applications.
 | `commands` | `Optional[List[Dict]]` | `None` | List of bot commands to register with Telegram. Each dict has `command` and `description` keys. Defaults to `/start`, `/help`, and `/new` when not provided. |
 | `register_commands` | `bool` | `True` | Automatically register commands with the Telegram Bot API on first message. |
 
-Provide `agent`, `team`, or `workflow`.
-
-### Key Method
-
-| Method | Parameters | Return Type | Description |
-| --- | --- | --- | --- |
-| `get_router` | None | `APIRouter` | Returns the FastAPI router and attaches endpoints. |
-
 ## Endpoints
 
-Mounted under the `/telegram` prefix:
+Mounted under the `/telegram` prefix (customizable via `prefix`):
 
 ### `GET /telegram/status`
 
-- Health/status check for the interface.
-- Returns `{"status": "available"}`.
+Health/status check for the interface. Returns `{"status": "available"}`.
 
 ### `POST /telegram/webhook`
 
-- Receives Telegram updates (messages, edited messages).
+Receives Telegram updates (messages, edited messages).
+
 - Validates the `X-Telegram-Bot-Api-Secret-Token` header; bypassed when `APP_ENV=development`.
 - Deduplicates updates by `update_id`.
 - Processes text, photos, voice notes, audio, video, documents, stickers, and animations.
 - Streams or sends responses back to the originating chat (splits long messages at Telegram's 4096 character limit).
 - Responses: `200 {"status": "processing"}` or `{"status": "ignored"}`, `403` invalid secret token, `500` errors.
 
-## Session Management
+## Behavior
 
-Sessions are scoped by chat and entity:
+### Session Management
 
-- **DMs and basic groups**: `tg:{entity_id}:{chat_id}`
+Sessions are scoped by chat and entity. The `entity_id` is the agent, team, or workflow ID (falls back to name, then type).
+
+- **DMs and basic groups**: `tg:{entity_id}:{chat_id}` (e.g., `tg:Telegram Bot:123456789`)
 - **Supergroup threads and forum topics**: `tg:{entity_id}:{chat_id}:{message_thread_id}`
 
-When a database is configured on the agent/team, the `/new` command creates a fresh session. Without a database, the session scope string is used directly as the session ID.
+When a database is configured on the agent/team, the `/new` command creates a fresh session. Without a database, sessions reset on server restart. History and memory are not persisted.
 
-## Streaming
+<Note>
+The `/new` command only works when a database is configured. Without a database, each server restart already starts a fresh session.
+</Note>
+
+### Streaming
 
 When `streaming=True` (the default), the bot edits the response message in real time as tokens arrive. Edits are throttled to roughly once per second to stay within Telegram's rate limits. The user sees incremental output instead of waiting for the full response.
 
 For workflows, streaming also surfaces step progress (e.g., which agent in the workflow is currently running).
 
-## Group Chat Support
+### Group Chat Support
 
 By default, the bot only responds when mentioned (`@your_bot`) or replied to in group chats. This is controlled by two parameters:
 
@@ -136,16 +129,63 @@ To have the bot respond to all messages in a group, set `reply_to_mentions_only=
 
 **BotFather privacy mode:** By default, Telegram bots in groups only receive messages that mention them or are commands. To let the bot see all group messages (required for `reply_to_mentions_only=False`), message @BotFather, send `/setprivacy`, select your bot, and choose **Disable**.
 
-## Media Support
+### Media Support
 
 **Inbound** (user sends to bot): photos, stickers, voice notes, audio files, video, video notes, animations (GIFs), and documents. Media is downloaded and passed to the agent as images, audio, video, or file inputs.
 
 **Outbound** (agent sends to user): images, audio, video, and files generated by agent tools (e.g., DALL-E, ElevenLabs). Media is sent as native Telegram media messages alongside the text response.
 
+## TelegramTools
+
+`TelegramTools` is a standalone toolkit that lets agents proactively send messages and media to Telegram chats. It is independent from the Telegram interface. The interface handles inbound webhooks; the toolkit gives agents outbound actions.
+
+```python
+from agno.tools.telegram import TelegramTools
+
+agent = Agent(
+    tools=[TelegramTools(chat_id="123456789", all=True)],
+)
+```
+
+### Toolkit Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `chat_id` | `Optional[str]` | `None` | Default chat ID. Falls back to `TELEGRAM_CHAT_ID` env var. |
+| `token` | `Optional[str]` | `None` | Bot token. Falls back to `TELEGRAM_TOKEN` env var. |
+| `enable_send_message` | `bool` | `True` | Enable `send_message` tool. |
+| `enable_send_photo` | `bool` | `False` | Enable `send_photo` tool. |
+| `enable_send_document` | `bool` | `False` | Enable `send_document` tool. |
+| `enable_send_video` | `bool` | `False` | Enable `send_video` tool. |
+| `enable_send_audio` | `bool` | `False` | Enable `send_audio` tool. |
+| `enable_send_animation` | `bool` | `False` | Enable `send_animation` tool (GIFs). |
+| `enable_send_sticker` | `bool` | `False` | Enable `send_sticker` tool. |
+| `enable_edit_message` | `bool` | `False` | Enable `edit_message` tool. |
+| `enable_delete_message` | `bool` | `False` | Enable `delete_message` tool. |
+| `all` | `bool` | `False` | Enable all tools. Overrides individual flags. |
+
+### Toolkit Methods
+
+| Method | Description |
+| --- | --- |
+| `send_message` | Send a text message to a chat. |
+| `send_photo` | Send a photo (bytes) with optional caption. |
+| `send_document` | Send a document (bytes) with filename and optional caption. |
+| `send_video` | Send a video (bytes) with optional caption. |
+| `send_audio` | Send an audio file (bytes) with optional caption and title. |
+| `send_animation` | Send an animation/GIF (bytes) with optional caption. |
+| `send_sticker` | Send a sticker (bytes). |
+| `edit_message` | Edit a previously sent message by `message_id`. |
+| `delete_message` | Delete a message by `message_id`. |
+
+All methods return a JSON string with `{"status": "success", "message_id": ...}` on success or `{"status": "error", "message": ...}` on failure.
+
+For the full toolkit reference, see [TelegramTools](/tools/toolkits/social/telegram).
+
 ## Testing the Integration
 
 1. Run the app locally: `python <my-app>.py` (ensure ngrok is running)
-2. Register the webhook: `curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setWebhook?url=https://YOUR-NGROK-URL/telegram/webhook"`
+2. Register the webhook: `curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setWebhook?url=${NGROK_URL}/telegram/webhook"`
 3. Open your bot in Telegram and send `/start` or any message
 4. In a group: add the bot and mention it with `@your_bot hello`
 
@@ -156,5 +196,12 @@ To have the bot respond to all messages in a group, set `reply_to_mentions_only=
 | 403 errors on webhook | Running in production mode without a webhook secret | Set `APP_ENV=development` for local testing, or set `TELEGRAM_WEBHOOK_SECRET_TOKEN` and register the webhook with the matching `secret_token` |
 | No response from the bot | Server not running or webhook not set | Check server: `curl http://localhost:7777/telegram/status`. Check webhook: `curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/getWebhookInfo"` |
 | Bot ignores group messages | Privacy mode enabled (default) | Message @BotFather, send `/setprivacy`, select your bot, choose **Disable** |
-| Blank or missing streaming edits | `streaming=True` not set | Pass `streaming=True` when creating the `Telegram` instance (enabled by default) |
+| `/new` has no effect | No database configured | Add a `SqliteDb` (or other DB) to the agent/team. Without a DB, sessions are ephemeral and `/new` cannot create a new one. |
 | `TELEGRAM_TOKEN is not set` | Missing env var | Export `TELEGRAM_TOKEN` before running |
+
+## Developer Resources
+
+- [Telegram deploy guide](/deploy/interfaces/telegram/overview)
+- [Telegram examples](/agent-os/usage/interfaces/telegram/basic)
+- [TelegramTools reference](/tools/toolkits/social/telegram)
+- [Deployment templates](/production/templates/overview)

--- a/agent-os/interfaces/telegram/introduction.mdx
+++ b/agent-os/interfaces/telegram/introduction.mdx
@@ -1,0 +1,160 @@
+---
+title: Telegram
+description: Host agents as Telegram bots.
+---
+
+Use the Telegram interface to serve Agents, Teams, or Workflows on Telegram. It mounts webhook routes on a FastAPI app and sends responses back to Telegram chats.
+
+## Setup
+
+Follow the Telegram setup guide in the [cookbook](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/interfaces/telegram/README.md).
+
+Required configuration:
+
+- `TELEGRAM_TOKEN` (bot token from @BotFather)
+- Optional: `TELEGRAM_WEBHOOK_SECRET_TOKEN` (required in production when `APP_ENV` is not `development`)
+- An ngrok tunnel (for local development) and webhook pointing to `/telegram/webhook`
+
+## Example Usage
+
+Create an agent, expose it with the `Telegram` interface, and serve via `AgentOS`:
+
+```python basic.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.google import Gemini
+from agno.os import AgentOS
+from agno.os.interfaces.telegram import Telegram
+
+agent_db = SqliteDb(session_table="telegram_sessions", db_file="tmp/telegram_basic.db")
+
+telegram_agent = Agent(
+    name="Telegram Bot",
+    model=Gemini(id="gemini-2.5-pro"),
+    db=agent_db,
+    instructions=[
+        "You are a helpful assistant on Telegram.",
+        "Keep responses concise and friendly.",
+    ],
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+agent_os = AgentOS(
+    agents=[telegram_agent],
+    interfaces=[Telegram(agent=telegram_agent)],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="basic:app", port=7777, reload=True)
+```
+
+See the [Telegram Examples](/agent-os/usage/interfaces/telegram/basic) for more usage patterns.
+
+## Core Components
+
+- `Telegram` (interface): Wraps an Agno `Agent`, `Team`, or `Workflow` for Telegram integration via FastAPI.
+- `AgentOS.serve`: Serves the FastAPI app using Uvicorn.
+
+## `Telegram` Interface
+
+Main entry point for Agno Telegram applications.
+
+### Initialization Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `agent` | `Optional[Agent]` | `None` | Agno `Agent` instance. |
+| `team` | `Optional[Team]` | `None` | Agno `Team` instance. |
+| `workflow` | `Optional[Workflow]` | `None` | Agno `Workflow` instance. |
+| `prefix` | `str` | `"/telegram"` | Custom FastAPI route prefix for the Telegram interface. |
+| `tags` | `Optional[List[str]]` | `None` | FastAPI route tags for API documentation. Defaults to `["Telegram"]` if not provided. |
+| `token` | `Optional[str]` | `None` | Bot token. Falls back to `TELEGRAM_TOKEN` environment variable. |
+| `streaming` | `bool` | `True` | Enable token-by-token streaming with live message edits. |
+| `show_reasoning` | `bool` | `False` | Send reasoning content as a separate message before the response. |
+| `reply_to_mentions_only` | `bool` | `True` | When `True` (default), bot responds to @mentions and replies in groups, and all messages in DMs. When `False`, responds to all messages in groups. |
+| `reply_to_bot_messages` | `bool` | `True` | When `True`, also responds when users reply to the bot's own messages in groups. |
+| `start_message` | `str` | `"Hello! I'm ready to help..."` | Message sent in response to the `/start` command. |
+| `help_message` | `str` | `"Send me text, photos..."` | Message sent in response to the `/help` command. |
+| `error_message` | `str` | `"Sorry, there was an error..."` | Message sent when processing fails. |
+| `new_message` | `str` | `"New conversation started..."` | Message sent when a user starts a new session with `/new`. |
+| `commands` | `Optional[List[Dict]]` | `/start`, `/help`, `/new` | List of bot commands to register with Telegram. Each dict has `command` and `description` keys. |
+| `register_commands` | `bool` | `True` | Automatically register commands with the Telegram Bot API on first message. |
+
+Provide `agent`, `team`, or `workflow`.
+
+### Key Method
+
+| Method | Parameters | Return Type | Description |
+| --- | --- | --- | --- |
+| `get_router` | None | `APIRouter` | Returns the FastAPI router and attaches endpoints. |
+
+## Endpoints
+
+Mounted under the `/telegram` prefix:
+
+### `GET /telegram/status`
+
+- Health/status check for the interface.
+- Returns `{"status": "available"}`.
+
+### `POST /telegram/webhook`
+
+- Receives Telegram updates (messages, edited messages).
+- Validates the `X-Telegram-Bot-Api-Secret-Token` header; bypassed when `APP_ENV=development`.
+- Deduplicates updates by `update_id`.
+- Processes text, photos, voice notes, audio, video, documents, stickers, and animations.
+- Streams or sends responses back to the originating chat (splits long messages at Telegram's 4096 character limit).
+- Responses: `200 {"status": "processing"}` or `{"status": "ignored"}`, `403` invalid secret token, `500` errors.
+
+## Session Management
+
+Sessions are scoped by chat and entity:
+
+- **DMs and basic groups**: `tg:{entity_id}:{chat_id}`
+- **Supergroup threads and forum topics**: `tg:{entity_id}:{chat_id}:{message_thread_id}`
+
+When a database is configured on the agent/team, the `/new` command creates a fresh session. Without a database, the session scope string is used directly as the session ID.
+
+## Streaming
+
+When `streaming=True` (the default), the bot edits the response message in real time as tokens arrive. Edits are throttled to roughly once per second to stay within Telegram's rate limits. The user sees incremental output instead of waiting for the full response.
+
+For workflows, streaming also surfaces step progress (e.g., which agent in the workflow is currently running).
+
+## Group Chat Support
+
+By default, the bot only responds when mentioned (`@your_bot`) or replied to in group chats. This is controlled by two parameters:
+
+- `reply_to_mentions_only=True` (default): only respond to @mentions and direct replies
+- `reply_to_bot_messages=True` (default): also respond when users reply to the bot's own messages
+
+To have the bot respond to all messages in a group, set `reply_to_mentions_only=False`.
+
+**BotFather privacy mode:** By default, Telegram bots in groups only receive messages that mention them or are commands. To let the bot see all group messages (required for `reply_to_mentions_only=False`), message @BotFather, send `/setprivacy`, select your bot, and choose **Disable**.
+
+## Media Support
+
+**Inbound** (user sends to bot): photos, stickers, voice notes, audio files, video, video notes, animations (GIFs), and documents. Media is downloaded and passed to the agent as images, audio, video, or file inputs.
+
+**Outbound** (agent sends to user): images, audio, video, and files generated by agent tools (e.g., DALL-E, ElevenLabs). Media is sent as native Telegram media messages alongside the text response.
+
+## Testing the Integration
+
+1. Run the app locally: `python <my-app>.py` (ensure ngrok is running)
+2. Register the webhook: `curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setWebhook?url=https://YOUR-NGROK-URL/telegram/webhook"`
+3. Open your bot in Telegram and send `/start` or any message
+4. In a group: add the bot and mention it with `@your_bot hello`
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| 403 errors on webhook | Running in production mode without a webhook secret | Set `APP_ENV=development` for local testing, or set `TELEGRAM_WEBHOOK_SECRET_TOKEN` and register the webhook with the matching `secret_token` |
+| No response from the bot | Server not running or webhook not set | Check server: `curl http://localhost:7777/telegram/status`. Check webhook: `curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/getWebhookInfo"` |
+| Bot ignores group messages | Privacy mode enabled (default) | Message @BotFather, send `/setprivacy`, select your bot, choose **Disable** |
+| Blank or missing streaming edits | `streaming=True` not set | Pass `streaming=True` when creating the `Telegram` instance (enabled by default) |
+| `TELEGRAM_TOKEN is not set` | Missing env var | Export `TELEGRAM_TOKEN` before running |

--- a/agent-os/interfaces/telegram/introduction.mdx
+++ b/agent-os/interfaces/telegram/introduction.mdx
@@ -103,8 +103,8 @@ Receives Telegram updates (messages, edited messages).
 
 Sessions are scoped by chat and entity. The `entity_id` is the agent, team, or workflow ID (falls back to name, then type).
 
-- **DMs and basic groups**: `tg:{entity_id}:{chat_id}` (e.g., `tg:Telegram Bot:123456789`)
-- **Supergroup threads and forum topics**: `tg:{entity_id}:{chat_id}:{message_thread_id}`
+- **DMs and basic groups**: `tg:Telegram Bot:123456789`
+- **Supergroup threads and forum topics**: `tg:Telegram Bot:123456789:42`
 
 When a database is configured on the agent/team, the `/new` command creates a fresh session. Without a database, sessions reset on server restart. History and memory are not persisted.
 

--- a/agent-os/usage/interfaces/telegram/agent-with-media.mdx
+++ b/agent-os/usage/interfaces/telegram/agent-with-media.mdx
@@ -1,0 +1,96 @@
+---
+title: "Telegram Agent with Media"
+description: "Create a multimedia Telegram agent with image generation and text-to-speech"
+---
+
+## Code
+
+```python cookbook/os/interfaces/telegram/agent_with_media.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.google import Gemini
+from agno.os import AgentOS
+from agno.os.interfaces.telegram import Telegram
+from agno.tools.dalle import DalleTools
+from agno.tools.eleven_labs import ElevenLabsTools
+
+agent_db = SqliteDb(
+    session_table="telegram_media_sessions", db_file="tmp/telegram_media.db"
+)
+
+media_agent = Agent(
+    name="Media Agent",
+    model=Gemini(id="gemini-2.5-pro"),
+    db=agent_db,
+    tools=[
+        DalleTools(model="dall-e-3", size="1024x1024", quality="standard"),
+        ElevenLabsTools(
+            enable_text_to_speech=True,
+            enable_generate_sound_effect=True,
+            enable_get_voices=False,
+        ),
+    ],
+    instructions=[
+        "You are a helpful multimedia assistant on Telegram.",
+        "When asked to generate, create, or draw an image, use the DALL-E tool.",
+        "When asked to speak, read aloud, or convert text to speech, use the ElevenLabs text_to_speech tool.",
+        "When asked for a sound effect, use the ElevenLabs generate_sound_effect tool.",
+        "Keep text responses concise and friendly.",
+        "You can also analyze images, audio, and video that users send you.",
+    ],
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+agent_os = AgentOS(
+    agents=[media_agent],
+    interfaces=[
+        Telegram(
+            agent=media_agent,
+            reply_to_mentions_only=True,
+        )
+    ],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="agent_with_media:app", reload=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set Environment Variables">
+    ```bash
+    export TELEGRAM_TOKEN=your-bot-token-from-botfather
+    export GOOGLE_API_KEY=your-google-api-key
+    export OPENAI_API_KEY=your-openai-api-key
+    export ELEVENLABS_API_KEY=your-elevenlabs-api-key
+    export APP_ENV=development
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[telegram]" openai elevenlabs
+    ```
+  </Step>
+
+  <Step title="Run Example">
+    ```bash
+    python cookbook/os/interfaces/telegram/agent_with_media.py
+    ```
+  </Step>
+</Steps>
+
+## Key Features
+
+- **Image Generation**: DALL-E 3 generates images from text prompts, sent as native Telegram photos
+- **Text-to-Speech**: ElevenLabs converts text to audio, sent as Telegram voice messages
+- **Sound Effects**: Generate sound effects from descriptions
+- **Inbound Media Analysis**: Analyze images, audio, video, and documents sent by users
+- **Persistent Memory**: SQLite database for session storage

--- a/agent-os/usage/interfaces/telegram/agent-with-media.mdx
+++ b/agent-os/usage/interfaces/telegram/agent-with-media.mdx
@@ -5,7 +5,7 @@ description: "DALL-E image generation and ElevenLabs TTS on Telegram"
 
 ## Code
 
-```python cookbook/os/interfaces/telegram/agent_with_media.py
+```python agent_with_media.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.google import Gemini

--- a/agent-os/usage/interfaces/telegram/agent-with-media.mdx
+++ b/agent-os/usage/interfaces/telegram/agent-with-media.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Telegram Agent with Media"
-description: "Create a multimedia Telegram agent with image generation and text-to-speech"
+description: "DALL-E image generation and ElevenLabs TTS on Telegram"
 ---
 
 ## Code
@@ -9,7 +9,7 @@ description: "Create a multimedia Telegram agent with image generation and text-
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.google import Gemini
-from agno.os import AgentOS
+from agno.os.app import AgentOS
 from agno.os.interfaces.telegram import Telegram
 from agno.tools.dalle import DalleTools
 from agno.tools.eleven_labs import ElevenLabsTools

--- a/agent-os/usage/interfaces/telegram/agent-with-media.mdx
+++ b/agent-os/usage/interfaces/telegram/agent-with-media.mdx
@@ -82,7 +82,7 @@ if __name__ == "__main__":
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/telegram/agent_with_media.py
+    python agent_with_media.py
     ```
   </Step>
 </Steps>

--- a/agent-os/usage/interfaces/telegram/agent-with-user-memory.mdx
+++ b/agent-os/usage/interfaces/telegram/agent-with-user-memory.mdx
@@ -79,7 +79,7 @@ if __name__ == "__main__":
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/telegram/agent_with_user_memory.py
+    python agent_with_user_memory.py
     ```
   </Step>
 </Steps>

--- a/agent-os/usage/interfaces/telegram/agent-with-user-memory.mdx
+++ b/agent-os/usage/interfaces/telegram/agent-with-user-memory.mdx
@@ -5,7 +5,7 @@ description: "MemoryManager for cross-session user recall on Telegram"
 
 ## Code
 
-```python cookbook/os/interfaces/telegram/agent_with_user_memory.py
+```python agent_with_user_memory.py
 from textwrap import dedent
 
 from agno.agent import Agent

--- a/agent-os/usage/interfaces/telegram/agent-with-user-memory.mdx
+++ b/agent-os/usage/interfaces/telegram/agent-with-user-memory.mdx
@@ -22,7 +22,7 @@ memory_manager = MemoryManager(
     memory_capture_instructions="""\
                     Collect User's name,
                     Collect Information about user's passion and hobbies,
-                    Collect Information about the users likes and dislikes,
+                    Collect Information about the user's likes and dislikes,
                     Collect information about what the user is doing with their life right now
                 """,
     model=Gemini(id="gemini-2.0-flash"),

--- a/agent-os/usage/interfaces/telegram/agent-with-user-memory.mdx
+++ b/agent-os/usage/interfaces/telegram/agent-with-user-memory.mdx
@@ -1,0 +1,92 @@
+---
+title: "Telegram Agent with User Memory"
+description: "Create a Telegram agent that remembers user preferences across conversations"
+---
+
+## Code
+
+```python cookbook/os/interfaces/telegram/agent_with_user_memory.py
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.memory.manager import MemoryManager
+from agno.models.google import Gemini
+from agno.os import AgentOS
+from agno.os.interfaces.telegram import Telegram
+from agno.tools.websearch import WebSearchTools
+
+agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
+
+memory_manager = MemoryManager(
+    memory_capture_instructions="""\
+                    Collect User's name,
+                    Collect Information about user's passion and hobbies,
+                    Collect Information about the users likes and dislikes,
+                    Collect information about what the user is doing with their life right now
+                """,
+    model=Gemini(id="gemini-2.0-flash"),
+)
+
+
+personal_agent = Agent(
+    name="Basic Agent",
+    model=Gemini(id="gemini-2.0-flash"),
+    tools=[WebSearchTools()],
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
+    db=agent_db,
+    memory_manager=memory_manager,
+    enable_agentic_memory=True,
+    instructions=dedent("""
+        You are a personal AI friend of the user, your purpose is to chat with the user about things and make them feel good.
+        First introduce yourself and ask for their name then, ask about themselves, their hobbies, what they like to do and what they like to talk about.
+        Use web search to find latest information about things in the conversations
+    """),
+)
+
+
+agent_os = AgentOS(
+    agents=[personal_agent],
+    interfaces=[Telegram(agent=personal_agent)],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="agent_with_user_memory:app", reload=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set Environment Variables">
+    ```bash
+    export TELEGRAM_TOKEN=your-bot-token-from-botfather
+    export GOOGLE_API_KEY=your-google-api-key
+    export APP_ENV=development
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[telegram]"
+    ```
+  </Step>
+
+  <Step title="Run Example">
+    ```bash
+    python cookbook/os/interfaces/telegram/agent_with_user_memory.py
+    ```
+  </Step>
+</Steps>
+
+## Key Features
+
+- **Agentic Memory**: MemoryManager captures user preferences, hobbies, and personal details
+- **Cross-Session Recall**: Remembers user information across conversations
+- **Web Search**: Uses WebSearchTools to find up-to-date information during conversations
+- **Persistent Storage**: SQLite database for both sessions and memory

--- a/agent-os/usage/interfaces/telegram/agent-with-user-memory.mdx
+++ b/agent-os/usage/interfaces/telegram/agent-with-user-memory.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Telegram Agent with User Memory"
-description: "Create a Telegram agent that remembers user preferences across conversations"
+description: "MemoryManager for cross-session user recall on Telegram"
 ---
 
 ## Code
@@ -12,19 +12,19 @@ from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.memory.manager import MemoryManager
 from agno.models.google import Gemini
-from agno.os import AgentOS
+from agno.os.app import AgentOS
 from agno.os.interfaces.telegram import Telegram
 from agno.tools.websearch import WebSearchTools
 
 agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 
 memory_manager = MemoryManager(
-    memory_capture_instructions="""\
-                    Collect User's name,
-                    Collect Information about user's passion and hobbies,
-                    Collect Information about the user's likes and dislikes,
-                    Collect information about what the user is doing with their life right now
-                """,
+    memory_capture_instructions=(
+        "Collect User's name,"
+        "Collect Information about user's passion and hobbies,"
+        "Collect Information about the user's likes and dislikes,"
+        "Collect information about what the user is doing with their life right now"
+    ),
     model=Gemini(id="gemini-2.0-flash"),
 )
 

--- a/agent-os/usage/interfaces/telegram/basic.mdx
+++ b/agent-os/usage/interfaces/telegram/basic.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Basic Telegram Agent"
-description: "Create a basic AI agent that integrates with Telegram for conversations"
+description: "Gemini agent with session persistence on Telegram"
 ---
 
 ## Code
@@ -9,7 +9,7 @@ description: "Create a basic AI agent that integrates with Telegram for conversa
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.google import Gemini
-from agno.os import AgentOS
+from agno.os.app import AgentOS
 from agno.os.interfaces.telegram import Telegram
 
 agent_db = SqliteDb(session_table="telegram_sessions", db_file="tmp/telegram_basic.db")

--- a/agent-os/usage/interfaces/telegram/basic.mdx
+++ b/agent-os/usage/interfaces/telegram/basic.mdx
@@ -1,0 +1,79 @@
+---
+title: "Basic Telegram Agent"
+description: "Create a basic AI agent that integrates with Telegram for conversations"
+---
+
+## Code
+
+```python cookbook/os/interfaces/telegram/basic.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.google import Gemini
+from agno.os import AgentOS
+from agno.os.interfaces.telegram import Telegram
+
+agent_db = SqliteDb(session_table="telegram_sessions", db_file="tmp/telegram_basic.db")
+
+telegram_agent = Agent(
+    name="Telegram Bot",
+    model=Gemini(id="gemini-2.5-pro"),
+    db=agent_db,
+    instructions=[
+        "You are a helpful assistant on Telegram.",
+        "Keep responses concise and friendly.",
+        "When in a group, you respond only when mentioned with @.",
+    ],
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+agent_os = AgentOS(
+    agents=[telegram_agent],
+    interfaces=[
+        Telegram(
+            agent=telegram_agent,
+            reply_to_mentions_only=True,
+        )
+    ],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="basic:app", reload=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set Environment Variables">
+    ```bash
+    export TELEGRAM_TOKEN=your-bot-token-from-botfather
+    export GOOGLE_API_KEY=your-google-api-key
+    export APP_ENV=development
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[telegram]"
+    ```
+  </Step>
+
+  <Step title="Run Example">
+    ```bash
+    python cookbook/os/interfaces/telegram/basic.py
+    ```
+  </Step>
+</Steps>
+
+## Key Features
+
+- **Telegram Integration**: Responds to direct messages and group @mentions
+- **Conversation History**: Maintains context with last 3 interactions
+- **Persistent Memory**: SQLite database for session storage
+- **Group Chat Support**: Only responds when mentioned in groups
+- **DateTime Context**: Time-aware responses

--- a/agent-os/usage/interfaces/telegram/basic.mdx
+++ b/agent-os/usage/interfaces/telegram/basic.mdx
@@ -5,7 +5,7 @@ description: "Gemini agent with session persistence on Telegram"
 
 ## Code
 
-```python cookbook/os/interfaces/telegram/basic.py
+```python basic.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.google import Gemini

--- a/agent-os/usage/interfaces/telegram/basic.mdx
+++ b/agent-os/usage/interfaces/telegram/basic.mdx
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/telegram/basic.py
+    python basic.py
     ```
   </Step>
 </Steps>

--- a/agent-os/usage/interfaces/telegram/multiple-instances.mdx
+++ b/agent-os/usage/interfaces/telegram/multiple-instances.mdx
@@ -5,7 +5,7 @@ description: "Two agents behind one bot using prefix-based routing"
 
 ## Code
 
-```python cookbook/os/interfaces/telegram/multiple_instances.py
+```python multiple_instances.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat

--- a/agent-os/usage/interfaces/telegram/multiple-instances.mdx
+++ b/agent-os/usage/interfaces/telegram/multiple-instances.mdx
@@ -1,0 +1,95 @@
+---
+title: "Multiple Instances"
+description: "Two agents behind one bot using prefix-based routing"
+---
+
+## Code
+
+```python cookbook/os/interfaces/telegram/multiple_instances.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os.app import AgentOS
+from agno.os.interfaces.telegram import Telegram
+from agno.tools.websearch import WebSearchTools
+
+agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
+
+basic_agent = Agent(
+    name="Basic Agent",
+    model=OpenAIChat(id="gpt-5.2"),
+    db=agent_db,
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+web_research_agent = Agent(
+    name="Web Research Agent",
+    model=OpenAIChat(id="gpt-5.2"),
+    db=agent_db,
+    tools=[WebSearchTools()],
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+)
+
+# Each Telegram interface can use a different prefix (and optionally a different bot token).
+# If you want truly separate bots, pass token= to each instance:
+#   Telegram(agent=basic_agent, prefix="/basic", token="BOT_TOKEN_1"),
+#   Telegram(agent=web_research_agent, prefix="/web-research", token="BOT_TOKEN_2"),
+# When token is omitted, TELEGRAM_TOKEN env var is used for all instances.
+agent_os = AgentOS(
+    agents=[basic_agent, web_research_agent],
+    interfaces=[
+        Telegram(agent=basic_agent, prefix="/basic"),
+        Telegram(agent=web_research_agent, prefix="/web-research"),
+    ],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="multiple_instances:app", reload=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set Environment Variables">
+    ```bash
+    export TELEGRAM_TOKEN=your-bot-token-from-botfather
+    export OPENAI_API_KEY=your-openai-api-key
+    export APP_ENV=development
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[telegram]"
+    ```
+  </Step>
+
+  <Step title="Run Example">
+    ```bash
+    python cookbook/os/interfaces/telegram/multiple_instances.py
+    ```
+  </Step>
+
+  <Step title="Register Webhooks">
+    Register a separate webhook for each prefix:
+    ```bash
+    curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setWebhook?url=${NGROK_URL}/basic/webhook"
+    curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setWebhook?url=${NGROK_URL}/web-research/webhook"
+    ```
+  </Step>
+</Steps>
+
+## Key Features
+
+- **Prefix-Based Routing**: Each agent gets its own webhook path (`/basic/webhook`, `/web-research/webhook`)
+- **Shared Server**: Both agents run on a single AgentOS instance
+- **Optional Token Isolation**: Pass `token=` per instance to use separate bot tokens for full isolation
+- **Shared Database**: Both agents share the same SQLite database

--- a/agent-os/usage/interfaces/telegram/multiple-instances.mdx
+++ b/agent-os/usage/interfaces/telegram/multiple-instances.mdx
@@ -74,7 +74,7 @@ if __name__ == "__main__":
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/telegram/multiple_instances.py
+    python multiple_instances.py
     ```
   </Step>
 

--- a/agent-os/usage/interfaces/telegram/multiple-instances.mdx
+++ b/agent-os/usage/interfaces/telegram/multiple-instances.mdx
@@ -1,11 +1,13 @@
 ---
 title: "Multiple Instances"
-description: "Two agents behind one bot using prefix-based routing"
+description: "Multiple Telegram bots on a single AgentOS server"
 ---
 
 ## Code
 
 ```python multiple_instances.py
+import os
+
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
@@ -35,16 +37,13 @@ web_research_agent = Agent(
     add_datetime_to_context=True,
 )
 
-# Each Telegram interface can use a different prefix (and optionally a different bot token).
-# If you want truly separate bots, pass token= to each instance:
-#   Telegram(agent=basic_agent, prefix="/basic", token="BOT_TOKEN_1"),
-#   Telegram(agent=web_research_agent, prefix="/web-research", token="BOT_TOKEN_2"),
-# When token is omitted, TELEGRAM_TOKEN env var is used for all instances.
+# Telegram only supports one webhook per bot token, so each interface needs its own bot.
+# Create two bots via @BotFather and pass each token explicitly.
 agent_os = AgentOS(
     agents=[basic_agent, web_research_agent],
     interfaces=[
-        Telegram(agent=basic_agent, prefix="/basic"),
-        Telegram(agent=web_research_agent, prefix="/web-research"),
+        Telegram(agent=basic_agent, prefix="/basic", token=os.getenv("TELEGRAM_TOKEN_BASIC")),
+        Telegram(agent=web_research_agent, prefix="/web-research", token=os.getenv("TELEGRAM_TOKEN_RESEARCH")),
     ],
 )
 app = agent_os.get_app()
@@ -60,7 +59,8 @@ if __name__ == "__main__":
 
   <Step title="Set Environment Variables">
     ```bash
-    export TELEGRAM_TOKEN=your-bot-token-from-botfather
+    export TELEGRAM_TOKEN_BASIC=bot-token-for-basic-agent
+    export TELEGRAM_TOKEN_RESEARCH=bot-token-for-research-agent
     export OPENAI_API_KEY=your-openai-api-key
     export APP_ENV=development
     ```
@@ -79,10 +79,10 @@ if __name__ == "__main__":
   </Step>
 
   <Step title="Register Webhooks">
-    Register a separate webhook for each prefix:
+    Register a webhook for each bot token:
     ```bash
-    curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setWebhook?url=${NGROK_URL}/basic/webhook"
-    curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setWebhook?url=${NGROK_URL}/web-research/webhook"
+    curl "https://api.telegram.org/bot${TELEGRAM_TOKEN_BASIC}/setWebhook?url=${NGROK_URL}/basic/webhook"
+    curl "https://api.telegram.org/bot${TELEGRAM_TOKEN_RESEARCH}/setWebhook?url=${NGROK_URL}/web-research/webhook"
     ```
   </Step>
 </Steps>
@@ -91,5 +91,5 @@ if __name__ == "__main__":
 
 - **Prefix-Based Routing**: Each agent gets its own webhook path (`/basic/webhook`, `/web-research/webhook`)
 - **Shared Server**: Both agents run on a single AgentOS instance
-- **Optional Token Isolation**: Pass `token=` per instance to use separate bot tokens for full isolation
+- **Separate Bot Tokens**: Each interface uses its own BotFather bot (Telegram allows only one webhook per token)
 - **Shared Database**: Both agents share the same SQLite database

--- a/agent-os/usage/interfaces/telegram/reasoning-agent.mdx
+++ b/agent-os/usage/interfaces/telegram/reasoning-agent.mdx
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/telegram/reasoning_agent.py
+    python reasoning_agent.py
     ```
   </Step>
 </Steps>

--- a/agent-os/usage/interfaces/telegram/reasoning-agent.mdx
+++ b/agent-os/usage/interfaces/telegram/reasoning-agent.mdx
@@ -1,0 +1,74 @@
+---
+title: "Telegram Reasoning Agent"
+description: "Create a Telegram agent with chain-of-thought reasoning and web search"
+---
+
+## Code
+
+```python cookbook/os/interfaces/telegram/reasoning_agent.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.interfaces.telegram import Telegram
+from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.tools.reasoning import ReasoningTools
+
+agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
+
+reasoning_agent = Agent(
+    name="Reasoning Research Agent",
+    model=OpenAIChat(id="gpt-5.2"),
+    db=agent_db,
+    tools=[
+        ReasoningTools(add_instructions=True),
+        DuckDuckGoTools(),
+    ],
+    instructions="Use tables to display data. When you use thinking tools, keep the thinking brief.",
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+
+agent_os = AgentOS(
+    agents=[reasoning_agent],
+    interfaces=[Telegram(agent=reasoning_agent)],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="reasoning_agent:app", reload=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set Environment Variables">
+    ```bash
+    export TELEGRAM_TOKEN=your-bot-token-from-botfather
+    export OPENAI_API_KEY=your-openai-api-key
+    export APP_ENV=development
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[telegram]" duckduckgo-search
+    ```
+  </Step>
+
+  <Step title="Run Example">
+    ```bash
+    python cookbook/os/interfaces/telegram/reasoning_agent.py
+    ```
+  </Step>
+</Steps>
+
+## Key Features
+
+- **Chain-of-Thought Reasoning**: ReasoningTools enables structured thinking for complex queries
+- **Web Search**: DuckDuckGo integration for up-to-date information retrieval
+- **Data Presentation**: Uses tables to display structured data
+- **Persistent Memory**: SQLite database for session storage

--- a/agent-os/usage/interfaces/telegram/reasoning-agent.mdx
+++ b/agent-os/usage/interfaces/telegram/reasoning-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Telegram Reasoning Agent"
-description: "Create a Telegram agent with chain-of-thought reasoning and web search"
+description: "ReasoningTools + DuckDuckGo search on Telegram"
 ---
 
 ## Code
@@ -9,7 +9,7 @@ description: "Create a Telegram agent with chain-of-thought reasoning and web se
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
-from agno.os import AgentOS
+from agno.os.app import AgentOS
 from agno.os.interfaces.telegram import Telegram
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.reasoning import ReasoningTools

--- a/agent-os/usage/interfaces/telegram/reasoning-agent.mdx
+++ b/agent-os/usage/interfaces/telegram/reasoning-agent.mdx
@@ -5,7 +5,7 @@ description: "ReasoningTools + DuckDuckGo search on Telegram"
 
 ## Code
 
-```python cookbook/os/interfaces/telegram/reasoning_agent.py
+```python reasoning_agent.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat

--- a/agent-os/usage/interfaces/telegram/streaming-workflow.mdx
+++ b/agent-os/usage/interfaces/telegram/streaming-workflow.mdx
@@ -97,7 +97,7 @@ if __name__ == "__main__":
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/telegram/streaming_workflow.py
+    python streaming_workflow.py
     ```
   </Step>
 </Steps>

--- a/agent-os/usage/interfaces/telegram/streaming-workflow.mdx
+++ b/agent-os/usage/interfaces/telegram/streaming-workflow.mdx
@@ -1,0 +1,110 @@
+---
+title: "Streaming Workflow"
+description: "Research + Write workflow with live step progress on Telegram"
+---
+
+## Code
+
+```python cookbook/os/interfaces/telegram/streaming_workflow.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os.app import AgentOS
+from agno.os.interfaces.telegram import Telegram
+from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.workflow.step import Step
+from agno.workflow.steps import Steps
+from agno.workflow.workflow import Workflow
+
+db = SqliteDb(
+    session_table="telegram_streaming_wf_sessions",
+    db_file="tmp/telegram_streaming_workflow.db",
+)
+
+researcher = Agent(
+    name="Researcher",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    tools=[DuckDuckGoTools()],
+    instructions=[
+        "Research the topic using web search.",
+        "Provide bullet-point findings with sources.",
+    ],
+)
+
+writer = Agent(
+    name="Writer",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions=[
+        "Write a clear, concise summary from the research.",
+        "Use **bold** for key terms and keep it under 300 words.",
+        "Suitable for reading on a phone screen.",
+    ],
+)
+
+research_write_workflow = Workflow(
+    name="Research and Write",
+    description="Two-step workflow: research a topic, then write a polished summary",
+    steps=[
+        Steps(
+            name="research_and_write",
+            description="Research then write",
+            steps=[
+                Step(
+                    name="research", agent=researcher, description="Research the topic"
+                ),
+                Step(name="write", agent=writer, description="Write the summary"),
+            ],
+        )
+    ],
+    db=db,
+)
+
+agent_os = AgentOS(
+    workflows=[research_write_workflow],
+    interfaces=[
+        Telegram(
+            workflow=research_write_workflow,
+            reply_to_mentions_only=False,
+            streaming=True,
+            start_message="Research bot ready. Send me a topic and I will research and summarize it.",
+        )
+    ],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="streaming_workflow:app", reload=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set Environment Variables">
+    ```bash
+    export TELEGRAM_TOKEN=your-bot-token-from-botfather
+    export OPENAI_API_KEY=your-openai-api-key
+    export APP_ENV=development
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[telegram]" duckduckgo-search
+    ```
+  </Step>
+
+  <Step title="Run Example">
+    ```bash
+    python cookbook/os/interfaces/telegram/streaming_workflow.py
+    ```
+  </Step>
+</Steps>
+
+## Key Features
+
+- **Live Step Progress**: Users see which step is running in real time (e.g., "Running step: research...")
+- **Web Search**: Researcher agent uses DuckDuckGo to find current information
+- **Streaming Output**: Writer output streams token-by-token with live message edits
+- **Custom Start Message**: Overrides the default `/start` response

--- a/agent-os/usage/interfaces/telegram/streaming-workflow.mdx
+++ b/agent-os/usage/interfaces/telegram/streaming-workflow.mdx
@@ -5,7 +5,7 @@ description: "Research + Write workflow with live step progress on Telegram"
 
 ## Code
 
-```python cookbook/os/interfaces/telegram/streaming_workflow.py
+```python streaming_workflow.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat

--- a/agent-os/usage/interfaces/telegram/streaming.mdx
+++ b/agent-os/usage/interfaces/telegram/streaming.mdx
@@ -1,0 +1,81 @@
+---
+title: "Streaming Telegram Agent"
+description: "Create a Telegram agent with real-time streaming responses"
+---
+
+## Code
+
+```python cookbook/os/interfaces/telegram/streaming.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.interfaces.telegram import Telegram
+
+agent_db = SqliteDb(
+    session_table="telegram_sessions", db_file="tmp/telegram_streaming.db"
+)
+
+telegram_agent = Agent(
+    name="Telegram Streaming Bot",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    db=agent_db,
+    instructions=[
+        "You are a helpful assistant on Telegram.",
+        "Keep responses concise and friendly.",
+        "When in a group, you respond only when mentioned with @.",
+    ],
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+agent_os = AgentOS(
+    agents=[telegram_agent],
+    interfaces=[
+        Telegram(
+            agent=telegram_agent,
+            reply_to_mentions_only=True,
+            streaming=True,
+        )
+    ],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="streaming:app", reload=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set Environment Variables">
+    ```bash
+    export TELEGRAM_TOKEN=your-bot-token-from-botfather
+    export OPENAI_API_KEY=your-openai-api-key
+    export APP_ENV=development
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[telegram]"
+    ```
+  </Step>
+
+  <Step title="Run Example">
+    ```bash
+    python cookbook/os/interfaces/telegram/streaming.py
+    ```
+  </Step>
+</Steps>
+
+## Key Features
+
+- **Token-by-Token Streaming**: Responses appear incrementally as they are generated
+- **Live Message Edits**: The bot edits its message in real time, throttled to stay within Telegram rate limits
+- **Conversation History**: Maintains context with last 3 interactions
+- **Persistent Memory**: SQLite database for session storage

--- a/agent-os/usage/interfaces/telegram/streaming.mdx
+++ b/agent-os/usage/interfaces/telegram/streaming.mdx
@@ -5,7 +5,7 @@ description: "OpenAI agent with token-by-token streaming via live message edits"
 
 ## Code
 
-```python cookbook/os/interfaces/telegram/streaming.py
+```python streaming.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat

--- a/agent-os/usage/interfaces/telegram/streaming.mdx
+++ b/agent-os/usage/interfaces/telegram/streaming.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Streaming Telegram Agent"
-description: "Create a Telegram agent with real-time streaming responses"
+description: "OpenAI agent with token-by-token streaming via live message edits"
 ---
 
 ## Code
@@ -9,7 +9,7 @@ description: "Create a Telegram agent with real-time streaming responses"
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
-from agno.os import AgentOS
+from agno.os.app import AgentOS
 from agno.os.interfaces.telegram import Telegram
 
 agent_db = SqliteDb(

--- a/agent-os/usage/interfaces/telegram/streaming.mdx
+++ b/agent-os/usage/interfaces/telegram/streaming.mdx
@@ -68,7 +68,7 @@ if __name__ == "__main__":
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/telegram/streaming.py
+    python streaming.py
     ```
   </Step>
 </Steps>

--- a/agent-os/usage/interfaces/telegram/team.mdx
+++ b/agent-os/usage/interfaces/telegram/team.mdx
@@ -5,7 +5,7 @@ description: "Researcher + Writer team coordinating on Telegram"
 
 ## Code
 
-```python cookbook/os/interfaces/telegram/team.py
+```python team.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat

--- a/agent-os/usage/interfaces/telegram/team.mdx
+++ b/agent-os/usage/interfaces/telegram/team.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multi-Agent Telegram Team"
-description: "Deploy a multi-agent team on Telegram with specialized researcher and writer agents"
+description: "Researcher + Writer team coordinating on Telegram"
 ---
 
 ## Code
@@ -9,7 +9,7 @@ description: "Deploy a multi-agent team on Telegram with specialized researcher 
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
-from agno.os import AgentOS
+from agno.os.app import AgentOS
 from agno.os.interfaces.telegram import Telegram
 from agno.team import Team
 

--- a/agent-os/usage/interfaces/telegram/team.mdx
+++ b/agent-os/usage/interfaces/telegram/team.mdx
@@ -83,7 +83,7 @@ if __name__ == "__main__":
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/telegram/team.py
+    python team.py
     ```
   </Step>
 </Steps>

--- a/agent-os/usage/interfaces/telegram/team.mdx
+++ b/agent-os/usage/interfaces/telegram/team.mdx
@@ -1,0 +1,97 @@
+---
+title: "Multi-Agent Telegram Team"
+description: "Deploy a multi-agent team on Telegram with specialized researcher and writer agents"
+---
+
+## Code
+
+```python cookbook/os/interfaces/telegram/team.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.interfaces.telegram import Telegram
+from agno.team import Team
+
+agent_db = SqliteDb(
+    session_table="telegram_team_sessions", db_file="tmp/telegram_team.db"
+)
+
+researcher = Agent(
+    name="Researcher",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    role="Researches topics and provides detailed factual information.",
+    instructions=["Provide well-researched, factual information on the given topic."],
+)
+
+writer = Agent(
+    name="Writer",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    role="Takes research and writes clear, engaging summaries.",
+    instructions=["Write concise, engaging summaries based on the research provided."],
+)
+
+telegram_team = Team(
+    name="Telegram Research Team",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    members=[researcher, writer],
+    db=agent_db,
+    instructions=[
+        "You coordinate a research team on Telegram.",
+        "Use the Researcher to gather facts, then the Writer to create a response.",
+        "Keep responses concise for Telegram.",
+    ],
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+agent_os = AgentOS(
+    teams=[telegram_team],
+    interfaces=[
+        Telegram(
+            team=telegram_team,
+            reply_to_mentions_only=True,
+        )
+    ],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="team:app", reload=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set Environment Variables">
+    ```bash
+    export TELEGRAM_TOKEN=your-bot-token-from-botfather
+    export OPENAI_API_KEY=your-openai-api-key
+    export APP_ENV=development
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[telegram]"
+    ```
+  </Step>
+
+  <Step title="Run Example">
+    ```bash
+    python cookbook/os/interfaces/telegram/team.py
+    ```
+  </Step>
+</Steps>
+
+## Key Features
+
+- **Multi-Agent Coordination**: Team leader delegates to Researcher and Writer agents
+- **Specialized Roles**: Each agent has a focused responsibility
+- **Team on Telegram**: The `Team` is passed directly to the Telegram interface
+- **Persistent Memory**: SQLite database for session storage
+- **Group Chat Support**: Only responds when mentioned in groups

--- a/agent-os/usage/interfaces/telegram/workflow.mdx
+++ b/agent-os/usage/interfaces/telegram/workflow.mdx
@@ -1,0 +1,108 @@
+---
+title: "Telegram Workflow"
+description: "Draft + Edit two-step workflow on Telegram"
+---
+
+## Code
+
+```python cookbook/os/interfaces/telegram/workflow.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os.app import AgentOS
+from agno.os.interfaces.telegram import Telegram
+from agno.workflow.step import Step
+from agno.workflow.steps import Steps
+from agno.workflow.workflow import Workflow
+
+agent_db = SqliteDb(
+    session_table="telegram_workflow_sessions", db_file="tmp/telegram_workflow.db"
+)
+
+drafter = Agent(
+    name="Drafter",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="Draft a response to the user's message. Be helpful and informative.",
+)
+
+editor = Agent(
+    name="Editor",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions=[
+        "Review and polish the draft for clarity and conciseness.",
+        "Keep it short and suitable for a Telegram message.",
+    ],
+)
+
+draft_step = Step(
+    name="draft",
+    agent=drafter,
+    description="Draft an initial response",
+)
+
+edit_step = Step(
+    name="edit",
+    agent=editor,
+    description="Edit and polish the draft",
+)
+
+telegram_workflow = Workflow(
+    name="Telegram Draft-Edit Workflow",
+    description="A two-step workflow that drafts and then edits responses for Telegram",
+    steps=[
+        Steps(
+            name="draft_and_edit",
+            description="Draft then edit a response",
+            steps=[draft_step, edit_step],
+        )
+    ],
+    db=agent_db,
+)
+
+agent_os = AgentOS(
+    workflows=[telegram_workflow],
+    interfaces=[
+        Telegram(
+            workflow=telegram_workflow,
+            reply_to_mentions_only=True,
+        )
+    ],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="workflow:app", reload=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set Environment Variables">
+    ```bash
+    export TELEGRAM_TOKEN=your-bot-token-from-botfather
+    export OPENAI_API_KEY=your-openai-api-key
+    export APP_ENV=development
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[telegram]"
+    ```
+  </Step>
+
+  <Step title="Run Example">
+    ```bash
+    python cookbook/os/interfaces/telegram/workflow.py
+    ```
+  </Step>
+</Steps>
+
+## Key Features
+
+- **Two-Step Pipeline**: Drafter writes an initial response, Editor polishes it
+- **Workflow on Telegram**: The `Workflow` (not individual agents) is passed to the Telegram interface
+- **Sequential Steps**: `Steps` chains `Step` objects in order
+- **Persistent Sessions**: SQLite database for conversation history across restarts

--- a/agent-os/usage/interfaces/telegram/workflow.mdx
+++ b/agent-os/usage/interfaces/telegram/workflow.mdx
@@ -5,7 +5,7 @@ description: "Draft + Edit two-step workflow on Telegram"
 
 ## Code
 
-```python cookbook/os/interfaces/telegram/workflow.py
+```python workflow.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat

--- a/agent-os/usage/interfaces/telegram/workflow.mdx
+++ b/agent-os/usage/interfaces/telegram/workflow.mdx
@@ -95,7 +95,7 @@ if __name__ == "__main__":
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/telegram/workflow.py
+    python workflow.py
     ```
   </Step>
 </Steps>

--- a/deploy/interfaces/telegram/overview.mdx
+++ b/deploy/interfaces/telegram/overview.mdx
@@ -31,7 +31,7 @@ if __name__ == "__main__":
 ```
 
 <Note>
-Install the dependency: `pip install 'agno[telegram]'`
+Install the dependency: `uv pip install 'agno[telegram]'`
 </Note>
 
 <Note>

--- a/deploy/interfaces/telegram/overview.mdx
+++ b/deploy/interfaces/telegram/overview.mdx
@@ -35,7 +35,7 @@ Install the dependency: `uv pip install 'agno[telegram]'`
 </Note>
 
 <Note>
-The chat ID is automatically used as the session scope (e.g., `tg:Telegram Bot:123456789`), so each Telegram chat maintains its own conversation context.
+Each Telegram chat gets its own session scope (e.g., `tg:Telegram Bot:123456789`), so conversations stay isolated across chats.
 </Note>
 
 ## Setup and Configuration

--- a/deploy/interfaces/telegram/overview.mdx
+++ b/deploy/interfaces/telegram/overview.mdx
@@ -71,7 +71,10 @@ ngrok http 7777
 # Or, if you have a paid ngrok plan with a static domain:
 # ngrok http --domain=your-custom-domain.ngrok-free.app 7777
 ```
-Copy the `https://` URL provided by ngrok.
+Copy the `https://` forwarding URL provided by ngrok and set it as an environment variable:
+```bash
+export NGROK_URL=https://your-subdomain.ngrok-free.app
+```
 </Step>
 
 <Step title="Run the App">
@@ -84,7 +87,7 @@ The server starts on `http://localhost:7777`.
 <Step title="Register the Webhook">
 Tell Telegram to send updates to your tunnel URL:
 ```bash
-curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setWebhook?url=https://YOUR-NGROK-URL/telegram/webhook"
+curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setWebhook?url=${NGROK_URL}/telegram/webhook"
 ```
 You should see `{"ok":true,"result":true,"description":"Webhook was set"}`.
 

--- a/deploy/interfaces/telegram/overview.mdx
+++ b/deploy/interfaces/telegram/overview.mdx
@@ -1,7 +1,107 @@
 ---
-title: "Overview"
+title: "Telegram Bot"
+description: "Deploy agents on Telegram for direct and group chat interactions."
 ---
 
-<Info>
-  This page is coming soon. If you have any questions or need help, see [getting help](/get-help).
-</Info>
+Agno and AgentOS make it easy to deploy your agents on Telegram with just 2 extra lines of code.
+
+This example creates a simple agent for answering questions:
+
+```python
+from agno.agent import Agent
+from agno.models.google import Gemini
+from agno.os import AgentOS
+from agno.os.interfaces.telegram import Telegram
+
+telegram_agent = Agent(
+    name="Telegram Bot",
+    model=Gemini(id="gemini-2.5-pro"), # Ensure GOOGLE_API_KEY is set
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+agent_os = AgentOS(
+    agents=[telegram_agent],
+    interfaces=[Telegram(agent=telegram_agent)],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="telegram_bot:app", port=7777, reload=True)
+```
+
+<Note>
+Install pyTelegramBotAPI: `pip install pyTelegramBotAPI` or `pip install 'agno[telegram]'`
+</Note>
+
+<Note>
+The chat ID is automatically used as the session scope, so each Telegram chat maintains its own conversation context.
+</Note>
+
+## Setup and Configuration
+
+<Steps>
+
+<Step title="Prerequisites">
+Ensure you have the following:
+- A Telegram account
+- ngrok (for development)
+- Python 3.7+
+</Step>
+
+<Step title="Create a Telegram Bot">
+1. Open Telegram and message [@BotFather](https://t.me/BotFather)
+2. Send `/newbot` and follow the prompts to choose a display name and username (username must end in `bot`, e.g. `my_agno_bot`)
+3. Copy the bot token (looks like `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`)
+</Step>
+
+<Step title="Set Environment Variables">
+```bash
+export TELEGRAM_TOKEN="your-bot-token-from-botfather"
+export APP_ENV="development"  # Bypasses webhook secret validation for local testing
+```
+</Step>
+
+<Step title="Start a Tunnel with ngrok">
+Telegram needs a public HTTPS URL to deliver webhook events:
+```bash
+ngrok http 7777
+# Or, if you have a paid ngrok plan with a static domain:
+# ngrok http --domain=your-custom-domain.ngrok-free.app 7777
+```
+Copy the `https://` URL provided by ngrok.
+</Step>
+
+<Step title="Run the App">
+```bash
+python telegram_bot.py
+```
+The server starts on `http://localhost:7777`.
+</Step>
+
+<Step title="Register the Webhook">
+Tell Telegram to send updates to your tunnel URL:
+```bash
+curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setWebhook?url=https://YOUR-NGROK-URL/telegram/webhook"
+```
+You should see `{"ok":true,"result":true,"description":"Webhook was set"}`.
+
+Verify anytime with:
+```bash
+curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/getWebhookInfo"
+```
+</Step>
+
+</Steps>
+
+<Note>
+ngrok is used only for local development and testing. For production deployments, see the [deployment tutorials](/production/templates/overview).
+</Note>
+
+## Developer Resources
+
+- [Telegram Interface](/agent-os/interfaces/telegram/introduction)
+- [Deployment Templates](/production/templates/overview)
+- [Discord](https://agno.link/discord)

--- a/deploy/interfaces/telegram/overview.mdx
+++ b/deploy/interfaces/telegram/overview.mdx
@@ -3,14 +3,12 @@ title: "Telegram Bot"
 description: "Deploy agents on Telegram for direct and group chat interactions."
 ---
 
-Agno and AgentOS make it easy to deploy your agents on Telegram with just 2 extra lines of code.
-
-This example creates a simple agent for answering questions:
+This example creates a simple agent for answering questions on Telegram:
 
 ```python
 from agno.agent import Agent
 from agno.models.google import Gemini
-from agno.os import AgentOS
+from agno.os.app import AgentOS
 from agno.os.interfaces.telegram import Telegram
 
 telegram_agent = Agent(
@@ -33,11 +31,11 @@ if __name__ == "__main__":
 ```
 
 <Note>
-Install pyTelegramBotAPI: `pip install pyTelegramBotAPI` or `pip install 'agno[telegram]'`
+Install the dependency: `pip install 'agno[telegram]'`
 </Note>
 
 <Note>
-The chat ID is automatically used as the session scope, so each Telegram chat maintains its own conversation context.
+The chat ID is automatically used as the session scope (e.g., `tg:Telegram Bot:123456789`), so each Telegram chat maintains its own conversation context.
 </Note>
 
 ## Setup and Configuration

--- a/docs.json
+++ b/docs.json
@@ -4394,7 +4394,10 @@
                       "agent-os/usage/interfaces/telegram/team",
                       "agent-os/usage/interfaces/telegram/agent-with-media",
                       "agent-os/usage/interfaces/telegram/agent-with-user-memory",
-                      "agent-os/usage/interfaces/telegram/reasoning-agent"
+                      "agent-os/usage/interfaces/telegram/reasoning-agent",
+                      "agent-os/usage/interfaces/telegram/workflow",
+                      "agent-os/usage/interfaces/telegram/streaming-workflow",
+                      "agent-os/usage/interfaces/telegram/multiple-instances"
                     ]
                   }
                 ]

--- a/docs.json
+++ b/docs.json
@@ -4263,7 +4263,8 @@
                   "agent-os/interfaces/whatsapp/introduction",
                   "agent-os/interfaces/a2a/introduction",
                   "agent-os/interfaces/ag-ui/introduction",
-                  "agent-os/interfaces/slack/introduction"
+                  "agent-os/interfaces/slack/introduction",
+                  "agent-os/interfaces/telegram/introduction"
                 ]
               },
               {
@@ -4383,6 +4384,17 @@
                       "agent-os/usage/interfaces/slack/agent-with-user-memory",
                       "agent-os/usage/interfaces/slack/reasoning-agent",
                       "agent-os/usage/interfaces/slack/research-workflow"
+                    ]
+                  },
+                  {
+                    "group": "Telegram",
+                    "pages": [
+                      "agent-os/usage/interfaces/telegram/basic",
+                      "agent-os/usage/interfaces/telegram/streaming",
+                      "agent-os/usage/interfaces/telegram/team",
+                      "agent-os/usage/interfaces/telegram/agent-with-media",
+                      "agent-os/usage/interfaces/telegram/agent-with-user-memory",
+                      "agent-os/usage/interfaces/telegram/reasoning-agent"
                     ]
                   }
                 ]

--- a/tools/toolkits/social/telegram.mdx
+++ b/tools/toolkits/social/telegram.mdx
@@ -2,12 +2,12 @@
 title: Telegram
 ---
 
-**TelegramTools** enable an Agent to send messages to a Telegram chat using the Telegram Bot API.
+**TelegramTools** enable an Agent to send messages and media to Telegram chats using the Telegram Bot API. 9 tool methods cover text, photos, documents, video, audio, animations, stickers, editing, and deleting messages.
 
 ## Prerequisites
 
 ```shell
-uv pip install -U agno httpx
+uv pip install -U "agno[telegram]"
 ```
 
 ```shell
@@ -44,17 +44,36 @@ agent.print_response("Send message to telegram chat a paragraph about the moon")
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `token` | `Optional[str]` | `None` | Telegram Bot API token. If not provided, will check TELEGRAM_TOKEN environment variable. |
-| `chat_id` | `Union[str, int]` | - | The ID of the chat to send messages to. |
-| `enable_send_message` | `bool` | `True` | Enable the send_message functionality. |
-| `all` | `bool` | `False` | Enable all functionality. |
+| `chat_id` | `Optional[str]` | `None` | Default chat ID. Falls back to `TELEGRAM_CHAT_ID` env var. |
+| `token` | `Optional[str]` | `None` | Bot token. Falls back to `TELEGRAM_TOKEN` env var. |
+| `enable_send_message` | `bool` | `True` | Enable `send_message` tool. |
+| `enable_send_photo` | `bool` | `False` | Enable `send_photo` tool. |
+| `enable_send_document` | `bool` | `False` | Enable `send_document` tool. |
+| `enable_send_video` | `bool` | `False` | Enable `send_video` tool. |
+| `enable_send_audio` | `bool` | `False` | Enable `send_audio` tool. |
+| `enable_send_animation` | `bool` | `False` | Enable `send_animation` tool (GIFs). |
+| `enable_send_sticker` | `bool` | `False` | Enable `send_sticker` tool. |
+| `enable_edit_message` | `bool` | `False` | Enable `edit_message` tool. |
+| `enable_delete_message` | `bool` | `False` | Enable `delete_message` tool. |
+| `all` | `bool` | `False` | Enable all tools. Overrides individual flags. |
 
 ## Toolkit Functions
 
 | Function | Description |
 |----------|-------------|
-| `send_message` | Sends a message to the specified Telegram chat. Takes a message string as input and returns the API response as text. If an error occurs, returns an error message. |
+| `send_message` | Send a text message to a chat. |
+| `send_photo` | Send a photo (bytes) with optional caption. |
+| `send_document` | Send a document (bytes) with filename and optional caption. |
+| `send_video` | Send a video (bytes) with optional caption. |
+| `send_audio` | Send an audio file (bytes) with optional caption and title. |
+| `send_animation` | Send an animation/GIF (bytes) with optional caption. |
+| `send_sticker` | Send a sticker (bytes). |
+| `edit_message` | Edit a previously sent message by `message_id`. |
+| `delete_message` | Delete a message by `message_id`. |
+
+All methods return a JSON string with `{"status": "success", "message_id": ...}` on success or `{"status": "error", "message": ...}` on failure.
 
 ## Developer Resources
 
 - View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/telegram.py)
+- [Telegram interface docs](/agent-os/interfaces/telegram/introduction)


### PR DESCRIPTION
## Description

Add complete documentation for the Telegram interface, which was merged in agno-agi/agno#6377. This replaces the placeholder "coming soon" page and adds the full reference docs, deploy guide, and usage examples following the same structure as Slack and WhatsApp.

### Changes

**Deploy guide** (`deploy/interfaces/telegram/overview.mdx`):
- Replace placeholder with full setup walkthrough
- BotFather bot creation, env vars, ngrok tunnel, webhook registration
- Dependency install note, session scoping note, developer resource links

**Interface reference** (`agent-os/interfaces/telegram/introduction.mdx`):
- All 16 initialization parameters documented in table
- Endpoint details (GET /status, POST /webhook)
- Session management (scope format, /new command)
- Streaming behavior (edit throttling, workflow step progress)
- Group chat support (mention filtering, BotFather privacy mode)
- Media support (inbound and outbound types)
- Troubleshooting table

**Usage examples** (6 files in `agent-os/usage/interfaces/telegram/`):
- `basic.mdx` — Gemini agent with conversation history
- `streaming.mdx` — OpenAI agent with live message edits
- `team.mdx` — Multi-agent team (Researcher + Writer)
- `agent-with-media.mdx` — DALL-E image generation + ElevenLabs TTS
- `agent-with-user-memory.mdx` — MemoryManager for cross-session recall
- `reasoning-agent.mdx` — ReasoningTools + DuckDuckGo search

**Navigation updates**:
- Added Telegram card to `agent-os/interfaces/overview.mdx`
- Added interface reference and all 6 usage pages to `docs.json`

## Type of Change

- [x] New content

## Related Issues/PRs (if applicable)

- Related SDK PR: agno-agi/agno#6377

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)