### PR TITLE
docs: add Docling Reader integration documentation

### DIFF
--- a/_snippets/docling-reader-reference.mdx
+++ b/_snippets/docling-reader-reference.mdx
@@ -1,0 +1,6 @@
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `output_format` | `str` | `"markdown"` | Export format (`"markdown"`, `"text"`, `"json"`, `"yaml"`, `"html"`, `"html_split_page"`, `"doctags"`, `"vtt"`) |
+| `converter` | `Optional[DocumentConverter]` | `None` | Custom Docling converter configuration |
+| `format_options` | `Optional[dict]` | `None` | Format options dictionary for DocumentConverter |
+| `chunking_strategy` | `Optional[ChunkingStrategy]` | `DocumentChunking()` | Strategy for chunking the document |

--- a/docs.json
+++ b/docs.json
@@ -5358,7 +5358,7 @@
                       "examples/knowledge/readers/doc-kb-async",
                       "examples/knowledge/readers/docling-reader",
                       "examples/knowledge/readers/docling-reader-async",
-                      "examples/knowledge/readers/docling-reader-multiple-format",
+                      "examples/knowledge/readers/docling-multi-formats",
                       "examples/knowledge/readers/docling-reader-url",
                       "examples/knowledge/readers/excel-legacy-xls",
                       "examples/knowledge/readers/excel-reader",

--- a/docs.json
+++ b/docs.json
@@ -627,6 +627,7 @@
                         "group": "Readers",
                         "pages": [
                           "knowledge/concepts/readers/pdf-reader",
+                          "knowledge/concepts/readers/docling-reader",
                           "knowledge/concepts/readers/csv-reader",
                           "knowledge/concepts/readers/json-reader",
                           "knowledge/concepts/readers/markdown-reader",
@@ -5355,6 +5356,10 @@
                       "examples/knowledge/readers/csv-reader-custom-encodings",
                       "examples/knowledge/readers/csv-reader-url-async",
                       "examples/knowledge/readers/doc-kb-async",
+                      "examples/knowledge/readers/docling-reader",
+                      "examples/knowledge/readers/docling-reader-async",
+                      "examples/knowledge/readers/docling-reader-multiple-format",
+                      "examples/knowledge/readers/docling-reader-url",
                       "examples/knowledge/readers/excel-legacy-xls",
                       "examples/knowledge/readers/excel-reader",
                       "examples/knowledge/readers/firecrawl-reader",

--- a/examples/knowledge/readers/docling-multi-formats.mdx
+++ b/examples/knowledge/readers/docling-multi-formats.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Docling Reader Multiple Format"
+title: "Docling Multiple Formats"
 description: "Process multiple document formats with Docling Reader."
 ---
 ```python
@@ -77,10 +77,13 @@ source .venvs/demo/bin/activate
 # Install additional dependencies for audio/video processing
 uv pip install -U openai-whisper
 
-# Install FFmpeg from https://www.ffmpeg.org/download.html
-
 # Optional: Run PgVector (needs docker)
 ./cookbook/scripts/run_pgvector.sh
 
 python docling_reader_multi_format.py
 ```
+
+**Install `ffmpeg`** (required for audio/video processing):
+- **macOS**: `brew install ffmpeg`
+- **Ubuntu**: `sudo apt-get install ffmpeg`
+- **Windows**: Download from https://ffmpeg.org/download.html

--- a/examples/knowledge/readers/docling-reader-async.mdx
+++ b/examples/knowledge/readers/docling-reader-async.mdx
@@ -26,20 +26,21 @@ agent = Agent(
     search_knowledge=True,
 )
 
-if __name__ == "__main__":
-    asyncio.run(
-        knowledge.ainsert(
-            path="cookbook/07_knowledge/testing_resources/research_paper.tex",
-            reader=DoclingReader(output_format="text"),
-        )
+
+async def main():
+    await knowledge.ainsert(
+        path="cookbook/07_knowledge/testing_resources/research_paper.tex",
+        reader=DoclingReader(output_format="text"),
     )
 
-    asyncio.run(
-        agent.aprint_response(
-            "What are the key findings of the Advanced Machine Learning Techniques for Natural Language Processing paper?",
-            markdown=True,
-        )
+    await agent.aprint_response(
+        "What are the key findings of the Advanced Machine Learning Techniques for Natural Language Processing paper?",
+        markdown=True,
     )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Run the Example

--- a/examples/knowledge/readers/docling-reader-async.mdx
+++ b/examples/knowledge/readers/docling-reader-async.mdx
@@ -1,0 +1,59 @@
+---
+title: "Docling Reader Async"
+description: "Process documents asynchronously with Docling Reader."
+---
+```python
+import asyncio
+
+from agno.agent import Agent
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.docling_reader import DoclingReader
+from agno.vectordb.pgvector import PgVector
+
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+# Create a knowledge base with docling reader
+knowledge = Knowledge(
+    vector_db=PgVector(
+        table_name="docling_documents",
+        db_url=db_url,
+    )
+)
+
+# Create an agent with the knowledge base
+agent = Agent(
+    knowledge=knowledge,
+    search_knowledge=True,
+)
+
+if __name__ == "__main__":
+    asyncio.run(
+        knowledge.ainsert(
+            path="cookbook/07_knowledge/testing_resources/research_paper.tex",
+            reader=DoclingReader(output_format="text"),
+        )
+    )
+
+    asyncio.run(
+        agent.aprint_response(
+            "What are the key finding of the Advanced Machine Learning Techniques for Natural Language Processing paper?",
+            markdown=True,
+        )
+    )
+```
+
+## Run the Example
+```bash
+# Clone and setup repo
+git clone https://github.com/agno-agi/agno.git
+cd agno/cookbook/07_knowledge/05_integrations/readers
+
+# Create and activate virtual environment
+./scripts/demo_setup.sh
+source .venvs/demo/bin/activate
+
+# Optional: Run PgVector (needs docker)
+./cookbook/scripts/run_pgvector.sh
+
+python docling_reader_async.py
+```

--- a/examples/knowledge/readers/docling-reader-async.mdx
+++ b/examples/knowledge/readers/docling-reader-async.mdx
@@ -36,7 +36,7 @@ if __name__ == "__main__":
 
     asyncio.run(
         agent.aprint_response(
-            "What are the key finding of the Advanced Machine Learning Techniques for Natural Language Processing paper?",
+            "What are the key findings of the Advanced Machine Learning Techniques for Natural Language Processing paper?",
             markdown=True,
         )
     )

--- a/examples/knowledge/readers/docling-reader-multiple-format.mdx
+++ b/examples/knowledge/readers/docling-reader-multiple-format.mdx
@@ -1,0 +1,86 @@
+---
+title: "Docling Reader Multiple Format"
+description: "Process multiple document formats with Docling Reader."
+---
+```python
+from agno.agent import Agent
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.docling_reader import DoclingReader
+from agno.vectordb.pgvector import PgVector
+
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+# Create a knowledge base with docling reader
+knowledge = Knowledge(
+    vector_db=PgVector(
+        table_name="docling_documents",
+        db_url=db_url,
+    )
+)
+
+reader = DoclingReader()
+
+# Add docx document
+knowledge.insert(
+    path="cookbook/07_knowledge/testing_resources/project_proposal.docx",
+    reader=reader,
+)
+
+# Add pptx presentation
+knowledge.insert(
+    path="cookbook/07_knowledge/testing_resources/ai_presentation.pptx",
+    reader=reader,
+)
+
+# Add xlsx spreadsheet
+knowledge.insert(
+    path="cookbook/07_knowledge/testing_resources/sample_products.xlsx",
+    reader=reader,
+)
+
+# Add JPEG file
+knowledge.insert(
+    path="cookbook/07_knowledge/testing_resources/restaurant_invoice.jpeg",
+    reader=reader,
+)
+
+# Add MP4 file (requires FFmpeg and openai-whisper)
+knowledge.insert(
+    path="cookbook/07_knowledge/testing_resources/agno_description.mp4",
+    reader=DoclingReader(output_format="vtt"),
+)
+
+# Create an agent with the knowledge base
+agent = Agent(
+    knowledge=knowledge,
+    search_knowledge=True,
+)
+
+# Query across all document types
+agent.print_response(
+    "Summarize the key information from all documents",
+    markdown=True,
+)
+```
+
+## Run the Example
+
+```bash
+# Clone and setup repo
+git clone https://github.com/agno-agi/agno.git
+cd agno/cookbook/07_knowledge/05_integrations/readers
+
+# Create and activate virtual environment
+./scripts/demo_setup.sh
+source .venvs/demo/bin/activate
+
+# Install additional dependencies for audio/video processing
+uv pip install -U openai-whisper
+
+# Install FFmpeg from https://www.ffmpeg.org/download.html
+
+# Optional: Run PgVector (needs docker)
+./cookbook/scripts/run_pgvector.sh
+
+python docling_reader_multi_format.py
+```

--- a/examples/knowledge/readers/docling-reader-url.mdx
+++ b/examples/knowledge/readers/docling-reader-url.mdx
@@ -20,7 +20,7 @@ knowledge = Knowledge(
 
 # Process document from URL
 knowledge.insert(
-    path="https://arxiv.org/pdf/2408.09869",
+    url="https://arxiv.org/pdf/2408.09869",
     reader=DoclingReader(),
 )
 

--- a/examples/knowledge/readers/docling-reader-url.mdx
+++ b/examples/knowledge/readers/docling-reader-url.mdx
@@ -1,0 +1,54 @@
+---
+title: "Docling Reader URL"
+description: "Process documents from URLs with Docling Reader."
+---
+```python
+from agno.agent import Agent
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.docling_reader import DoclingReader
+from agno.vectordb.pgvector import PgVector
+
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+# Create a knowledge base with docling reader
+knowledge = Knowledge(
+    vector_db=PgVector(
+        table_name="docling_documents",
+        db_url=db_url,
+    )
+)
+
+# Process document from URL
+knowledge.insert(
+    path="https://arxiv.org/pdf/2408.09869",
+    reader=DoclingReader(),
+)
+
+# Create an agent with the knowledge base
+agent = Agent(
+    knowledge=knowledge,
+    search_knowledge=True,
+)
+
+# Query the knowledge base
+agent.print_response(
+    "What is the arxiv research paper about?",
+    markdown=True,
+)
+```
+
+## Run the Example
+```bash
+# Clone and setup repo
+git clone https://github.com/agno-agi/agno.git
+cd agno/cookbook/07_knowledge/05_integrations/readers
+
+# Create and activate virtual environment
+./scripts/demo_setup.sh
+source .venvs/demo/bin/activate
+
+# Optional: Run PgVector (needs docker)
+./cookbook/scripts/run_pgvector.sh
+
+python docling_reader_url.py
+```

--- a/examples/knowledge/readers/docling-reader-url.mdx
+++ b/examples/knowledge/readers/docling-reader-url.mdx
@@ -32,7 +32,7 @@ agent = Agent(
 
 # Query the knowledge base
 agent.print_response(
-    "What is the arxiv research paper about?",
+    "What is the arXiv research paper about?",
     markdown=True,
 )
 ```

--- a/examples/knowledge/readers/docling-reader.mdx
+++ b/examples/knowledge/readers/docling-reader.mdx
@@ -1,0 +1,54 @@
+---
+title: "Docling Reader"
+description: "Process documents with Docling Reader."
+---
+```python
+from agno.agent import Agent
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.docling_reader import DoclingReader
+from agno.vectordb.pgvector import PgVector
+
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+# Create a knowledge base with docling reader
+knowledge = Knowledge(
+    vector_db=PgVector(
+        table_name="docling_documents",
+        db_url=db_url,
+    )
+)
+
+# Add documents using DoclingReader
+knowledge.insert(
+    path="cookbook/07_knowledge/testing_resources/cv_1.pdf",
+    reader=DoclingReader(),
+)
+
+# Create an agent with the knowledge base
+agent = Agent(
+    knowledge=knowledge,
+    search_knowledge=True,
+)
+
+# Query the knowledge base
+agent.print_response(
+    "Summarize the candidate's experience",
+    markdown=True,
+)
+```
+
+## Run the Example
+```bash
+# Clone and setup repo
+git clone https://github.com/agno-agi/agno.git
+cd agno/cookbook/07_knowledge/05_integrations/readers
+
+# Create and activate virtual environment
+./scripts/demo_setup.sh
+source .venvs/demo/bin/activate
+
+# Optional: Run PgVector (needs docker)
+./cookbook/scripts/run_pgvector.sh
+
+python docling_reader.py
+```

--- a/examples/knowledge/readers/overview.mdx
+++ b/examples/knowledge/readers/overview.mdx
@@ -13,7 +13,7 @@ description: "Readers transform raw data into structured, searchable knowledge f
 | [Doc Kb Async](/examples/knowledge/readers/doc-kb-async) | Run Doc Kb Async. |
 | [Docling Reader](/examples/knowledge/readers/docling-reader) | Run Docling Reader. |
 | [Docling Reader Async](/examples/knowledge/readers/docling-reader-async) | Run Docling Reader Async. |
-| [Docling Reader Multiple Format](/examples/knowledge/readers/docling-reader-multiple-format) | Run Docling Reader Multiple Formats. |
+| [Docling Multiple Formats](/examples/knowledge/readers/docling-multi-formats) | Run Docling Reader Multiple Formats. |
 | [Docling Reader URL](/examples/knowledge/readers/docling-reader-url) | Run Docling Reader URL. |
 | [Excel Reader](/examples/knowledge/readers/excel-reader) | Run Excel Reader. |
 | [Excel Legacy Xls](/examples/knowledge/readers/excel-legacy-xls) | Run Excel Legacy Xls. |

--- a/examples/knowledge/readers/overview.mdx
+++ b/examples/knowledge/readers/overview.mdx
@@ -11,6 +11,10 @@ description: "Readers transform raw data into structured, searchable knowledge f
 | [Csv Reader Async](/examples/knowledge/readers/csv-reader-async) | Run Csv Reader Async. |
 | [Csv Reader Url Async](/examples/knowledge/readers/csv-reader-url-async) | Run Csv Reader Url Async. |
 | [Doc Kb Async](/examples/knowledge/readers/doc-kb-async) | Run Doc Kb Async. |
+| [Docling Reader](/examples/knowledge/readers/docling-reader) | Run Docling Reader. |
+| [Docling Reader Async](/examples/knowledge/readers/docling-reader-async) | Run Docling Reader Async. |
+| [Docling Reader Multiple Format](/examples/knowledge/readers/docling-reader-multiple-format) | Run Docling Reader Multiple Formats. |
+| [Docling Reader URL](/examples/knowledge/readers/docling-reader-url) | Run Docling Reader URL. |
 | [Excel Reader](/examples/knowledge/readers/excel-reader) | Run Excel Reader. |
 | [Excel Legacy Xls](/examples/knowledge/readers/excel-legacy-xls) | Run Excel Legacy Xls. |
 | [Firecrawl Reader](/examples/knowledge/readers/firecrawl-reader) | Run Firecrawl Reader. |

--- a/knowledge/concepts/readers/docling-reader.mdx
+++ b/knowledge/concepts/readers/docling-reader.mdx
@@ -54,6 +54,11 @@ agent.print_response(
     # For audio/video processing
     uv pip install -U openai-whisper
     ```
+
+    **Install ffmpeg** (required for audio/video processing):
+    - **macOS**: `brew install ffmpeg`
+    - **Ubuntu**: `sudo apt-get install ffmpeg`
+    - **Windows**: Download from https://ffmpeg.org/download.html
   </Step>
 
   <Step title="Set environment variables">

--- a/knowledge/concepts/readers/docling-reader.mdx
+++ b/knowledge/concepts/readers/docling-reader.mdx
@@ -6,7 +6,7 @@ The **Docling Reader** processes multiple document formats using IBM's [Docling 
 
 ## Code
 
-```python examples/basics/knowledge/concepts/readers/overview/docling_reader_sync.py
+```python 
 from agno.agent import Agent
 from agno.knowledge.knowledge import Knowledge
 from agno.knowledge.reader.docling_reader import DoclingReader

--- a/knowledge/concepts/readers/docling-reader.mdx
+++ b/knowledge/concepts/readers/docling-reader.mdx
@@ -2,7 +2,7 @@
 title: Docling Reader
 ---
 
-The **Docling Reader** processes multiple document formats using IBM's Docling library. It handles PDFs, documents, presentations, spreadsheets, images, audio, video and markup files.
+The **Docling Reader** processes multiple document formats using IBM's [Docling library](https://github.com/docling-project/docling). It handles PDFs, documents, presentations, spreadsheets, images, audio, video and markup files.
 
 ## Code
 
@@ -84,7 +84,4 @@ agent.print_response(
 
 ## Params
 
-| Parameter | Type | Default | Description |
-| --- | --- | --- | --- |
-| `output_format` | `str` | `"markdown"` | Export format ("markdown", "text", "json", "yaml", "html", "html_split_page", "doctags", "vtt") |
-| `converter` | `Optional[DocumentConverter]` | `None` | Custom Docling converter configuration |
+<Snippet file="docling-reader-reference.mdx" />

--- a/knowledge/concepts/readers/docling-reader.mdx
+++ b/knowledge/concepts/readers/docling-reader.mdx
@@ -1,0 +1,85 @@
+---
+title: Docling Reader
+---
+
+The **Docling Reader** processes multiple document formats using IBM's Docling library. It handles PDFs, documents, presentations, spreadsheets, images, audio, video and markup files.
+
+## Code
+
+```python examples/basics/knowledge/concepts/readers/overview/docling_reader_sync.py
+from agno.agent import Agent
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.docling_reader import DoclingReader
+from agno.vectordb.pgvector import PgVector
+
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+# Create a knowledge base with docling reader
+knowledge = Knowledge(
+    vector_db=PgVector(
+        table_name="docling_documents",
+        db_url=db_url,
+    )
+)
+
+# Add documents using DoclingReader
+knowledge.insert(
+    path="documents/report.pdf",
+    reader=DoclingReader(),
+)
+
+# Create an agent with the knowledge base
+agent = Agent(
+    knowledge=knowledge,
+    search_knowledge=True,
+)
+
+# Query the knowledge base
+agent.print_response(
+    "Summarize the key findings from the report",
+    markdown=True,
+)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install dependencies">
+    ```bash
+    # Base dependencies
+    uv pip install -U docling sqlalchemy psycopg pgvector agno openai
+
+    # For audio/video processing
+    uv pip install -U openai-whisper
+    ```
+  </Step>
+
+  <Step title="Set environment variables">
+    ```bash
+    export OPENAI_API_KEY=xxx
+    ```
+  </Step>
+
+  <Snippet file="run-pgvector-step.mdx" />
+
+  <Step title="Run Agent">
+    <CodeGroup>
+    ```bash Mac
+    python examples/basics/knowledge/concepts/readers/overview/docling_reader_sync.py
+    ```
+
+    ```bash Windows
+    python examples/basics/knowledge/concepts/readers/overview/docling_reader_sync.py
+    ```
+    </CodeGroup>
+  </Step>
+</Steps>
+
+## Params
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `output_format` | `str` | `"markdown"` | Export format ("markdown", "text", "json", "yaml", "html", "html_split_page", "doctags" or "vtt") |
+| `converter` | `Optional[DocumentConverter]` | `None` | Custom Docling converter configuration |

--- a/knowledge/concepts/readers/docling-reader.mdx
+++ b/knowledge/concepts/readers/docling-reader.mdx
@@ -86,5 +86,5 @@ agent.print_response(
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| `output_format` | `str` | `"markdown"` | Export format ("markdown", "text", "json", "yaml", "html", "html_split_page", "doctags" or "vtt") |
+| `output_format` | `str` | `"markdown"` | Export format ("markdown", "text", "json", "yaml", "html", "html_split_page", "doctags", "vtt") |
 | `converter` | `Optional[DocumentConverter]` | `None` | Custom Docling converter configuration |

--- a/knowledge/concepts/readers/overview.mdx
+++ b/knowledge/concepts/readers/overview.mdx
@@ -35,6 +35,7 @@ Document(
 | Reader | Description |
 |--------|-------------|
 | `PDFReader` | Extract text from PDF files |
+| `DoclingReader` | Process multiple formats via Docling |
 | `TextReader` | Plain text files |
 | `MarkdownReader` | Markdown files |
 | `CSVReader` | CSV files (rows become documents) |


### PR DESCRIPTION
## Description

This PR adds documentation for [Docling](https://github.com/docling-project/docling) Reader integration following PR agno-agi/agno#6981. This adds the new `DoclingReader` class that enables processing of multiple document formats including PDFs, documents, presentations, spreadsheets, images, audio, video, etc. using the Docling library.

##  Key Changes:
  - Created conceptual documentation page `knowledge/concepts/readers/docling-reader.mdx`
  - Added 4 example pages demonstrating different use cases: 
     - `examples/knowledge/readers/docling-reader.mdx`
     - `examples/knowledge/readers/docling-reader-async.mdx`
     - `examples/knowledge/readers/docling-reader-multiple-format.mdx`
     - `examples/knowledge/readers/docling-reader-url.mdx`
  - Updated navigation in `docs.json` to include all new pages
  - Added Docling Reader to the supported readers table in overview page
  - Documented additional dependencies and system requirements wherever applicable.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related PRs 

<!-- Link any related issues or PRs -->

- Related SDK PR: https://github.com/agno-agi/agno/pull/6981

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
