### PR TITLE
docs: add fallback models page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -950,6 +950,7 @@
                   "models/model-as-string",
                   "models/compatibility",
                   "models/cache-response",
+                  "models/fallback-models",
                   {
                     "group": "Model Providers",
                     "pages": [

--- a/models/fallback-models.mdx
+++ b/models/fallback-models.mdx
@@ -1,11 +1,11 @@
 ---
 title: Fallback Models
 sidebarTitle: Fallback Models
-description: Automatic model failover when a provider errors out. No external proxy needed.
+description: Automatic model failover when a provider fails. No external proxy needed.
 keywords: [fallback models, model failover, resilience, rate limits, context window, error handling]
 ---
 
-When the primary model fails (rate limits, outages, context window limits), fallback models are tried in order until one succeeds. Works with any model provider Agno supports.
+When the primary model fails (rate limits, outages, context window limits), fallback models are tried in order until one succeeds.
 
 ```python
 from agno.agent import Agent
@@ -48,7 +48,7 @@ team = Team(
 
 ## Error-Specific Fallbacks
 
-Use `FallbackConfig` to route different error types to different models:
+`FallbackConfig` routes different error types to different models:
 
 ```python
 from agno.agent import Agent
@@ -86,9 +86,9 @@ agent = Agent(
 
 If a specific list is empty, the general `models` list is used as a catch-all.
 
-## How Retry and Fallback Interact
+## Retry vs. Fallback
 
-Retry and fallback are separate layers. Retry happens inside each model. Fallback happens after the retry loop is exhausted.
+Retry and fallback are separate layers. Retry happens inside each model. Fallback triggers after the retry loop is exhausted.
 
 ```
 call_model_with_fallback(model, fallback_config)
@@ -99,7 +99,7 @@ call_model_with_fallback(model, fallback_config)
        └─ fallback.response()     ← each fallback gets its own retries
 ```
 
-Each model instance controls its own retry behavior:
+Each model controls its own retry behavior:
 
 ```python
 agent = Agent(
@@ -110,21 +110,21 @@ agent = Agent(
 )
 ```
 
-The primary model retries 3 times with backoff. Only after all 3 retries fail does the fallback kick in, which then gets 2 retries of its own.
+The primary model retries 3 times with backoff. Only after all 3 fail does the fallback kick in with 2 retries of its own.
 
 ## Parameters
 
-These parameters are available on both `Agent` and `Team`:
+Available on both `Agent` and `Team`:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `fallback_models` | `List[Model \| str]` | Models tried in order on any failure. Shorthand for `FallbackConfig(models=...)`. |
-| `fallback_config` | `FallbackConfig` | Advanced configuration with error-specific routing. Takes precedence over `fallback_models` if both are provided. |
+| `fallback_config` | `FallbackConfig` | Error-specific routing. Takes precedence over `fallback_models` if both are set. |
 
 ### FallbackConfig
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `models` | `List[Model \| str]` | General fallback models for any error type. |
-| `rate_limit_models` | `List[Model \| str]` | Fallback models for rate-limit (429) errors. |
-| `context_window_models` | `List[Model \| str]` | Fallback models for context-window-exceeded errors. |
+| `models` | `List[Model \| str]` | General fallback for any error type. |
+| `rate_limit_models` | `List[Model \| str]` | Fallback for rate-limit (429) errors. |
+| `context_window_models` | `List[Model \| str]` | Fallback for context-window-exceeded errors. |

--- a/models/fallback-models.mdx
+++ b/models/fallback-models.mdx
@@ -20,6 +20,17 @@ agent = Agent(
 
 If `gpt-5.2` fails after exhausting its own retries, Claude is tried automatically.
 
+[Model strings](/models/model-as-string) work too:
+
+```python
+from agno.agent import Agent
+
+agent = Agent(
+    model="openai:gpt-5-mini",
+    fallback_models=["anthropic:claude-sonnet-4-5"],
+)
+```
+
 ## Usage with Teams
 
 ```python

--- a/models/fallback-models.mdx
+++ b/models/fallback-models.mdx
@@ -1,11 +1,11 @@
 ---
 title: Fallback Models
 sidebarTitle: Fallback Models
-description: Automatic model failover when a provider fails. No external proxy needed.
+description: Try backup models automatically when the primary model hits rate limits, outages, or context window limits.
 keywords: [fallback models, model failover, resilience, rate limits, context window, error handling]
 ---
 
-When the primary model fails (rate limits, outages, context window limits), fallback models are tried in order until one succeeds.
+Pass `fallback_models` to any Agent or Team. If the primary model fails after exhausting its retries, each fallback is tried in order until one succeeds.
 
 ```python
 from agno.agent import Agent

--- a/models/fallback-models.mdx
+++ b/models/fallback-models.mdx
@@ -13,12 +13,12 @@ from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIChat
 
 agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
-    fallback_models=[Claude(id="claude-sonnet-4-20250514")],
+    model=OpenAIChat(id="gpt-5.2"),
+    fallback_models=[Claude(id="claude-sonnet-4-6")],
 )
 ```
 
-If `gpt-4o` fails after exhausting its own retries, Claude is tried automatically.
+If `gpt-5.2` fails after exhausting its own retries, Claude is tried automatically.
 
 ## Usage with Teams
 
@@ -29,8 +29,8 @@ from agno.models.openai import OpenAIChat
 from agno.team import Team
 
 team = Team(
-    model=OpenAIChat(id="gpt-4o"),
-    fallback_models=[Claude(id="claude-sonnet-4-20250514")],
+    model=OpenAIChat(id="gpt-5.2"),
+    fallback_models=[Claude(id="claude-sonnet-4-6")],
     members=[researcher, writer],
 )
 ```
@@ -46,20 +46,20 @@ from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIChat
 
 agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
+    model=OpenAIChat(id="gpt-5.2"),
     fallback_config=FallbackConfig(
         # On rate-limit (429) errors
         rate_limit_models=[
-            OpenAIChat(id="gpt-4o-mini"),
-            Claude(id="claude-sonnet-4-20250514"),
+            OpenAIChat(id="gpt-5.2-mini"),
+            Claude(id="claude-sonnet-4-6"),
         ],
         # On context-window-exceeded errors
         context_window_models=[
-            Claude(id="claude-sonnet-4-20250514"),
+            Claude(id="claude-sonnet-4-6"),
         ],
         # On any other error
         models=[
-            Claude(id="claude-sonnet-4-20250514"),
+            Claude(id="claude-sonnet-4-6"),
         ],
     ),
 )
@@ -92,9 +92,9 @@ Each model instance controls its own retry behavior:
 
 ```python
 agent = Agent(
-    model=OpenAIChat(id="gpt-4o", retries=3, exponential_backoff=True),
+    model=OpenAIChat(id="gpt-5.2", retries=3, exponential_backoff=True),
     fallback_models=[
-        Claude(id="claude-sonnet-4-20250514", retries=2),
+        Claude(id="claude-sonnet-4-6", retries=2),
     ],
 )
 ```

--- a/models/fallback-models.mdx
+++ b/models/fallback-models.mdx
@@ -1,7 +1,7 @@
 ---
 title: Fallback Models
 sidebarTitle: Fallback Models
-description: Try backup models automatically when the primary model hits rate limits, outages, or context window limits.
+description: Automatically switch to backup models when the primary model hits rate limits, outages, or context window limits.
 keywords: [fallback models, model failover, resilience, rate limits, context window, error handling]
 ---
 
@@ -13,12 +13,12 @@ from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIChat
 
 agent = Agent(
-    model=OpenAIChat(id="gpt-5.2"),
-    fallback_models=[Claude(id="claude-sonnet-4-6")],
+    model=OpenAIChat(id="gpt-4o"),
+    fallback_models=[Claude(id="claude-sonnet-4-20250514")],
 )
 ```
 
-If `gpt-5.2` fails after exhausting its own retries, Claude is tried automatically.
+If `gpt-4o` fails after exhausting its own retries, Claude is tried automatically.
 
 [Model strings](/models/model-as-string) work too:
 
@@ -26,12 +26,14 @@ If `gpt-5.2` fails after exhausting its own retries, Claude is tried automatical
 from agno.agent import Agent
 
 agent = Agent(
-    model="openai:gpt-5-mini",
-    fallback_models=["anthropic:claude-sonnet-4-5"],
+    model="openai:gpt-4o",
+    fallback_models=["anthropic:claude-sonnet-4-20250514"],
 )
 ```
 
 ## Usage with Teams
+
+Fallback models apply to the team leader's model calls. Member agents keep their own models and are not affected by the leader's fallback config.
 
 ```python
 from agno.agent import Agent
@@ -39,78 +41,127 @@ from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIChat
 from agno.team import Team
 
+researcher = Agent(
+    name="Researcher",
+    role="You research topics and provide detailed findings.",
+    model=OpenAIChat(id="gpt-4o-mini"),
+)
+
+writer = Agent(
+    name="Writer",
+    role="You write clear, concise summaries from research findings.",
+    model=OpenAIChat(id="gpt-4o-mini"),
+)
+
 team = Team(
-    model=OpenAIChat(id="gpt-5.2"),
-    fallback_models=[Claude(id="claude-sonnet-4-6")],
+    name="Research Team",
+    model=OpenAIChat(id="gpt-4o"),
+    fallback_models=[Claude(id="claude-sonnet-4-20250514")],
     members=[researcher, writer],
+    markdown=True,
 )
 ```
 
 ## Error-Specific Fallbacks
 
-`FallbackConfig` routes different error types to different models:
+`FallbackConfig` lets you route different error types to different fallback models. Instead of a flat list, you specify which models to try for rate limits, context window overflows, and general errors separately.
 
 ```python
 from agno.agent import Agent
-from agno.fallback import FallbackConfig
+from agno.models.fallback import FallbackConfig
 from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIChat
 
 agent = Agent(
-    model=OpenAIChat(id="gpt-5.2"),
+    model=OpenAIChat(id="gpt-4o"),
     fallback_config=FallbackConfig(
-        # On rate-limit (429) errors
-        rate_limit_models=[
-            OpenAIChat(id="gpt-5.2-mini"),
-            Claude(id="claude-sonnet-4-6"),
+        # On rate-limit (429/529) errors
+        on_rate_limit=[
+            OpenAIChat(id="gpt-4o-mini"),
+            Claude(id="claude-sonnet-4-20250514"),
         ],
         # On context-window-exceeded errors
-        context_window_models=[
-            Claude(id="claude-sonnet-4-6"),
+        on_context_overflow=[
+            Claude(id="claude-sonnet-4-20250514"),
         ],
-        # On any other error
-        models=[
-            Claude(id="claude-sonnet-4-6"),
+        # General fallback for any other retryable error
+        on_error=[
+            Claude(id="claude-sonnet-4-20250514"),
         ],
     ),
 )
 ```
 
-### Error routing priority
+### Error routing
+
+When the primary model fails, the error is classified and routed to the matching fallback list:
 
 | Error Type | Fallback List | Example |
 |------------|---------------|---------|
-| Rate limit (429) | `rate_limit_models` | Provider throttling |
-| Context window exceeded | `context_window_models` | Input too long for model |
-| Any other error | `models` | Outages, auth errors |
+| Rate limit (429/529) | `on_rate_limit` | Provider throttling, Anthropic overloaded |
+| Context window exceeded | `on_context_overflow` | Input too long for model's context window |
+| Other retryable errors | `on_error` | Server errors (5xx), network failures |
 
-If a specific list is empty, the general `models` list is used as a catch-all.
+If a specific list (like `on_rate_limit`) is empty, `on_error` is used as a catch-all.
+
+Non-retryable client errors like 400, 401, 403, 404, and 422 are **not** caught by fallback. These indicate configuration problems (bad API key, invalid request) that need to be fixed rather than masked by switching models.
+
+## Fallback Callback
+
+Use the `callback` parameter to get notified whenever a fallback model is activated. This is useful for logging, metrics, or alerting.
+
+```python
+from agno.agent import Agent
+from agno.models.fallback import FallbackConfig
+from agno.models.anthropic import Claude
+from agno.models.openai import OpenAIChat
+
+
+def on_fallback(primary_model_id: str, fallback_model_id: str, error: Exception) -> None:
+    print(f"[fallback] {primary_model_id} -> {fallback_model_id} (reason: {error})")
+
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    fallback_config=FallbackConfig(
+        on_error=[Claude(id="claude-sonnet-4-20250514")],
+        callback=on_fallback,
+    ),
+)
+```
+
+The callback fires after the fallback model succeeds. For streaming calls, it fires after the full stream completes.
 
 ## Retry vs. Fallback
 
-Retry and fallback are separate layers. Retry happens inside each model. Fallback triggers after the retry loop is exhausted.
+Retry and fallback are separate layers. Retry happens inside each model. Fallback only triggers after the primary model's retry loop is fully exhausted.
 
 ```
-call_model_with_fallback(model, fallback_config)
-  └─ primary_model.response()
-       └─ _invoke_with_retry()    ← retries N times (per model config)
-  └─ on failure → select fallback list based on error type
-  └─ try each fallback in order
-       └─ fallback.response()     ← each fallback gets its own retries
+Primary model
+  └── _invoke_with_retry()        # retries N times (per model config)
+On failure
+  └── classify error type
+  └── select matching fallback list
+  └── try each fallback in order
+        └── fallback._invoke_with_retry()   # each fallback retries independently
 ```
 
 Each model controls its own retry behavior:
 
 ```python
 agent = Agent(
-    model=OpenAIChat(id="gpt-5.2", retries=3, exponential_backoff=True),
+    model=OpenAIChat(id="gpt-4o", retries=3, exponential_backoff=True),
     fallback_models=[
-        Claude(id="claude-sonnet-4-6", retries=2),
+        Claude(id="claude-sonnet-4-20250514", retries=2),
     ],
 )
 ```
 
-The primary model retries 3 times with backoff. Only after all 3 fail does the fallback kick in with 2 retries of its own.
+The primary model retries 3 times with exponential backoff. Only after all 3 attempts fail does the fallback kick in, and it gets 2 retries of its own.
+
+## Streaming
+
+Fallback works with streaming responses. If the primary model fails mid-stream, the fallback model takes over and the response content is reset so the consumer receives a clean response from the fallback model only.
 
 ## Parameters
 
@@ -118,13 +169,21 @@ Available on both `Agent` and `Team`:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `fallback_models` | `List[Model \| str]` | Models tried in order on any failure. Shorthand for `FallbackConfig(models=...)`. |
+| `fallback_models` | `List[Model \| str]` | Models tried in order on any failure. Shorthand for `FallbackConfig(on_error=...)`. |
 | `fallback_config` | `FallbackConfig` | Error-specific routing. Takes precedence over `fallback_models` if both are set. |
 
 ### FallbackConfig
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `models` | `List[Model \| str]` | General fallback for any error type. |
-| `rate_limit_models` | `List[Model \| str]` | Fallback for rate-limit (429) errors. |
-| `context_window_models` | `List[Model \| str]` | Fallback for context-window-exceeded errors. |
+| `on_error` | `List[Model \| str]` | General fallback for any retryable error. |
+| `on_rate_limit` | `List[Model \| str]` | Fallback for rate-limit (429/529) errors. Falls back to `on_error` if empty. |
+| `on_context_overflow` | `List[Model \| str]` | Fallback for context-window-exceeded errors. Falls back to `on_error` if empty. |
+| `callback` | `Callable[[str, str, Exception], None]` | Called when a fallback model is activated. Receives `(primary_model_id, fallback_model_id, error)`. |
+
+## Developer Resources
+
+- [Basic fallback example](https://github.com/agno-agi/agno/blob/main/cookbook/02_agents/17_fallback_models/01_basic_fallback.py)
+- [Error-specific fallbacks example](https://github.com/agno-agi/agno/blob/main/cookbook/02_agents/17_fallback_models/02_error_specific_fallbacks.py)
+- [Fallback callback example](https://github.com/agno-agi/agno/blob/main/cookbook/02_agents/17_fallback_models/04_fallback_callback.py)
+- [Team fallback example](https://github.com/agno-agi/agno/blob/main/cookbook/03_teams/17_fallback_models/01_basic_fallback.py)

--- a/models/fallback-models.mdx
+++ b/models/fallback-models.mdx
@@ -1,0 +1,119 @@
+---
+title: Fallback Models
+sidebarTitle: Fallback Models
+description: Automatic model failover when a provider errors out. No external proxy needed.
+keywords: [fallback models, model failover, resilience, rate limits, context window, error handling]
+---
+
+When the primary model fails (rate limits, outages, context window limits), fallback models are tried in order until one succeeds. Works with any model provider Agno supports.
+
+```python
+from agno.agent import Agent
+from agno.models.anthropic import Claude
+from agno.models.openai import OpenAIChat
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    fallback_models=[Claude(id="claude-sonnet-4-20250514")],
+)
+```
+
+If `gpt-4o` fails after exhausting its own retries, Claude is tried automatically.
+
+## Usage with Teams
+
+```python
+from agno.agent import Agent
+from agno.models.anthropic import Claude
+from agno.models.openai import OpenAIChat
+from agno.team import Team
+
+team = Team(
+    model=OpenAIChat(id="gpt-4o"),
+    fallback_models=[Claude(id="claude-sonnet-4-20250514")],
+    members=[researcher, writer],
+)
+```
+
+## Error-Specific Fallbacks
+
+Use `FallbackConfig` to route different error types to different models:
+
+```python
+from agno.agent import Agent
+from agno.fallback import FallbackConfig
+from agno.models.anthropic import Claude
+from agno.models.openai import OpenAIChat
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    fallback_config=FallbackConfig(
+        # On rate-limit (429) errors
+        rate_limit_models=[
+            OpenAIChat(id="gpt-4o-mini"),
+            Claude(id="claude-sonnet-4-20250514"),
+        ],
+        # On context-window-exceeded errors
+        context_window_models=[
+            Claude(id="claude-sonnet-4-20250514"),
+        ],
+        # On any other error
+        models=[
+            Claude(id="claude-sonnet-4-20250514"),
+        ],
+    ),
+)
+```
+
+### Error routing priority
+
+| Error Type | Fallback List | Example |
+|------------|---------------|---------|
+| Rate limit (429) | `rate_limit_models` | Provider throttling |
+| Context window exceeded | `context_window_models` | Input too long for model |
+| Any other error | `models` | Outages, auth errors |
+
+If a specific list is empty, the general `models` list is used as a catch-all.
+
+## How Retry and Fallback Interact
+
+Retry and fallback are separate layers. Retry happens inside each model. Fallback happens after the retry loop is exhausted.
+
+```
+call_model_with_fallback(model, fallback_config)
+  └─ primary_model.response()
+       └─ _invoke_with_retry()    ← retries N times (per model config)
+  └─ on failure → select fallback list based on error type
+  └─ try each fallback in order
+       └─ fallback.response()     ← each fallback gets its own retries
+```
+
+Each model instance controls its own retry behavior:
+
+```python
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o", retries=3, exponential_backoff=True),
+    fallback_models=[
+        Claude(id="claude-sonnet-4-20250514", retries=2),
+    ],
+)
+```
+
+The primary model retries 3 times with backoff. Only after all 3 retries fail does the fallback kick in, which then gets 2 retries of its own.
+
+## Parameters
+
+These parameters are available on both `Agent` and `Team`:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `fallback_models` | `List[Model \| str]` | Models tried in order on any failure. Shorthand for `FallbackConfig(models=...)`. |
+| `fallback_config` | `FallbackConfig` | Advanced configuration with error-specific routing. Takes precedence over `fallback_models` if both are provided. |
+
+### FallbackConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `models` | `List[Model \| str]` | General fallback models for any error type. |
+| `rate_limit_models` | `List[Model \| str]` | Fallback models for rate-limit (429) errors. |
+| `context_window_models` | `List[Model \| str]` | Fallback models for context-window-exceeded errors. |

--- a/models/overview.mdx
+++ b/models/overview.mdx
@@ -59,6 +59,6 @@ You can also configure `retries`, `delay_between_retries`, and `exponential_back
     Cache the response from the model provider to avoid duplicate API calls.
   </Card>
   <Card title="Fallback Models" icon="rotate" href="/models/fallback-models">
-    Try backup models automatically when the primary model fails.
+    Switch to backup models automatically on rate limits, outages, or context window errors.
   </Card>
 </CardGroup>

--- a/models/overview.mdx
+++ b/models/overview.mdx
@@ -59,6 +59,6 @@ You can also configure `retries`, `delay_between_retries`, and `exponential_back
     Cache the response from the model provider to avoid duplicate API calls.
   </Card>
   <Card title="Fallback Models" icon="rotate" href="/models/fallback-models">
-    Automatic model failover when a provider errors out.
+    Try backup models automatically when the primary model fails.
   </Card>
 </CardGroup>

--- a/models/overview.mdx
+++ b/models/overview.mdx
@@ -58,4 +58,7 @@ You can also configure `retries`, `delay_between_retries`, and `exponential_back
   <Card title="Cache Response" icon="database" href="/models/cache-response">
     Cache the response from the model provider to avoid duplicate API calls.
   </Card>
+  <Card title="Fallback Models" icon="rotate" href="/models/fallback-models">
+    Automatic model failover when a provider errors out.
+  </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Add new `models/fallback-models.mdx` page documenting the fallback models feature from agno-agi/agno#7080
- Covers basic usage (`fallback_models`), error-specific routing (`FallbackConfig`), retry/fallback interaction, and parameter reference
- Add page to sidebar navigation in `docs.json` and link card in models overview

## Test plan
- [ ] Verify page renders correctly with `mintlify dev`
- [ ] Check all internal links resolve
- [ ] Confirm sidebar navigation shows the new page under Models

🤖 Generated with [Claude Code](https://claude.com/claude-code)