### PR TITLE
docs: add followup suggestions usage pages

### DIFF
--- a/agents/usage/agent-with-followup-suggestions.mdx
+++ b/agents/usage/agent-with-followup-suggestions.mdx
@@ -1,0 +1,120 @@
+---
+title: Agent with Followup Suggestions
+sidebarTitle: Followup Suggestions
+description: "Generate actionable followup prompts after every agent response."
+---
+
+Set `followups=True` to automatically generate followup prompt suggestions after each response. The agent makes a second model call to produce short, action-oriented prompts based on the conversation.
+
+<Steps>
+
+  <Step title="Create a Python file">
+    ```python followup_suggestions.py
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIResponses
+
+    agent = Agent(
+        model=OpenAIResponses(id="gpt-4o"),
+        followups=True,
+        num_followups=3,
+    )
+
+    response = agent.run("What is quantum computing?")
+
+    print(response.content)
+    print("\nFollowup suggestions:")
+    for i, suggestion in enumerate(response.followups, 1):
+        print(f"  {i}. {suggestion}")
+    ```
+  </Step>
+
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U agno openai
+    ```
+  </Step>
+
+  <Step title="Export your OpenAI API key">
+    <CodeGroup>
+    ```bash Mac/Linux
+    export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    ```bash Windows
+    $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python followup_suggestions.py
+    ```
+  </Step>
+
+</Steps>
+
+## Options
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `followups` | `bool` | `False` | Enable followup suggestion generation |
+| `num_followups` | `int` | `3` | Number of suggestions to generate (minimum 1) |
+| `followup_model` | `Model` | Agent's model | Separate model for generating followups. Use a smaller model to reduce cost. |
+
+## Streaming
+
+Followup suggestions are available via events when streaming. The `FollowupsCompleted` event carries the suggestions after the main response finishes.
+
+```python followup_suggestions_streaming.py
+import asyncio
+
+from agno.agent import Agent, RunEvent
+from agno.models.openai import OpenAIResponses
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-4o"),
+    followups=True,
+    num_followups=3,
+)
+
+
+async def main():
+    async for event in agent.arun(
+        "What is quantum computing?",
+        stream=True,
+        stream_events=True,
+    ):
+        if event.event == RunEvent.run_content and event.content:
+            print(event.content, end="", flush=True)
+
+        if event.event == RunEvent.followups_completed:
+            print("\n\nFollowup suggestions:")
+            for i, suggestion in enumerate(event.followups, 1):
+                print(f"  {i}. {suggestion}")
+
+
+asyncio.run(main())
+```
+
+## Using a separate model
+
+Use `followup_model` to offload followup generation to a cheaper model.
+
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-4o"),
+    followups=True,
+    num_followups=3,
+    followup_model=OpenAIResponses(id="gpt-4o-mini"),
+)
+```
+
+## Developer Resources
+
+- [Agent reference](/reference/agents/agent)
+- [RunOutput reference](/reference/agents/run-response)

--- a/docs.json
+++ b/docs.json
@@ -113,7 +113,8 @@
                       "agents/usage/agent-with-structured-output",
                       "agents/usage/agent-with-storage",
                       "agents/usage/agent-with-memory",
-                      "agents/usage/agent-with-knowledge"
+                      "agents/usage/agent-with-knowledge",
+                      "agents/usage/agent-with-followup-suggestions"
                     ]
                   }
                 ]
@@ -131,7 +132,8 @@
                     "pages": [
                       "teams/usage/basic-team",
                       "teams/usage/streaming",
-                      "teams/usage/respond-directly"
+                      "teams/usage/respond-directly",
+                      "teams/usage/team-with-followup-suggestions"
                     ]
                   }
                 ]

--- a/teams/usage/team-with-followup-suggestions.mdx
+++ b/teams/usage/team-with-followup-suggestions.mdx
@@ -1,0 +1,128 @@
+---
+title: Team with Followup Suggestions
+sidebarTitle: Followup Suggestions
+description: "Generate actionable followup prompts after every team response."
+---
+
+Set `followups=True` on a Team to automatically generate followup prompt suggestions after each response. Works the same way as [agent followups](/agents/usage/agent-with-followup-suggestions), with support for all team modes.
+
+<Steps>
+
+  <Step title="Create a Python file">
+    ```python team_followup_suggestions.py
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIResponses
+    from agno.team.team import Team
+    from agno.team.mode import TeamMode
+
+    researcher = Agent(
+        name="Researcher",
+        role="Research topics thoroughly",
+        model=OpenAIResponses(id="gpt-4o"),
+    )
+
+    team = Team(
+        name="Research Team",
+        model=OpenAIResponses(id="gpt-4o"),
+        mode=TeamMode.coordinate,
+        members=[researcher],
+        followups=True,
+        num_followups=3,
+    )
+
+    response = team.run("What are the latest advances in fusion energy?")
+
+    print(response.content)
+    print("\nFollowup suggestions:")
+    for i, suggestion in enumerate(response.followups, 1):
+        print(f"  {i}. {suggestion}")
+    ```
+  </Step>
+
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U agno openai
+    ```
+  </Step>
+
+  <Step title="Export your OpenAI API key">
+    <CodeGroup>
+    ```bash Mac/Linux
+    export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    ```bash Windows
+    $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run Team">
+    ```bash
+    python team_followup_suggestions.py
+    ```
+  </Step>
+
+</Steps>
+
+## Options
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `followups` | `bool` | `False` | Enable followup suggestion generation |
+| `num_followups` | `int` | `3` | Number of suggestions to generate (minimum 1) |
+| `followup_model` | `Model` | Team's model | Separate model for generating followups. Use a smaller model to reduce cost. |
+
+## Streaming
+
+Followup suggestions are available via events when streaming.
+
+```python team_followup_streaming.py
+import asyncio
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.team.team import Team
+from agno.team.mode import TeamMode
+from agno.team import TeamRunEvent
+
+researcher = Agent(
+    name="Researcher",
+    role="Research topics thoroughly",
+    model=OpenAIResponses(id="gpt-4o"),
+)
+
+team = Team(
+    name="Research Team",
+    model=OpenAIResponses(id="gpt-4o"),
+    mode=TeamMode.coordinate,
+    members=[researcher],
+    followups=True,
+    num_followups=3,
+)
+
+
+async def main():
+    async for event in team.arun(
+        "What are the latest advances in fusion energy?",
+        stream=True,
+        stream_events=True,
+    ):
+        if event.event == TeamRunEvent.run_content and event.content:
+            print(event.content, end="", flush=True)
+
+        if event.event == TeamRunEvent.followups_completed:
+            print("\n\nFollowup suggestions:")
+            for i, suggestion in enumerate(event.followups, 1):
+                print(f"  {i}. {suggestion}")
+
+
+asyncio.run(main())
+```
+
+## Developer Resources
+
+- [Agent followup suggestions](/agents/usage/agent-with-followup-suggestions)
+- [Team reference](/reference/teams/team)
+- [TeamRunOutput reference](/reference/teams/team-response)


### PR DESCRIPTION
## Summary

- Adds `agents/usage/agent-with-followup-suggestions.mdx` covering basic usage, options table, streaming events, and separate `followup_model`
- Adds `teams/usage/team-with-followup-suggestions.mdx` with the same structure for Teams
- Updates `docs.json` navigation for both sections

Companion docs for https://github.com/agno-agi/agno/pull/6672.

## Test plan

- [ ] `mintlify dev` renders both pages correctly
- [ ] Navigation shows new pages under Agents > Usage and Teams > Usage
- [ ] `mintlify broken-links` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)