### PR TITLE
docs: add Respan observability integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4102,6 +4102,7 @@
                   "observability/maxim",
                   "observability/mlflow",
                   "observability/openlit",
+                  "observability/respan",
                   "observability/traceloop",
                   "observability/weave"
                 ]

--- a/observability/overview.mdx
+++ b/observability/overview.mdx
@@ -19,6 +19,6 @@ Agno offers first-class support for OpenTelemetry, the industry standard for dis
 - **Custom Tracing**: Extend or customize tracing as needed.
 
 <Note>
-OpenTelemetry-compatible backends including Arize Phoenix, Langfuse, Langsmith, Langtrace, Logfire, Maxim, MLflow, OpenLIT, Traceloop, and Weave are supported by Agno out of the box.
+OpenTelemetry-compatible backends including Arize Phoenix, Langfuse, Langsmith, Langtrace, Logfire, Maxim, MLflow, OpenLIT, Respan, Traceloop, and Weave are supported by Agno out of the box.
 </Note>
 

--- a/observability/respan.mdx
+++ b/observability/respan.mdx
@@ -1,0 +1,67 @@
+---
+title: Respan
+description: Integrate Agno with Respan to trace agent workflows and monitor performance.
+---
+
+## Integrating Agno with Respan
+
+[Respan](https://respan.ai) is an observability platform for tracing and monitoring AI agents. The `respan-exporter-agno` package captures Agno's OpenInference trace data and sends it to Respan.
+
+## Prerequisites
+
+1. **Install Dependencies**
+
+   ```bash
+   uv pip install agno openinference-instrumentation-agno respan-exporter-agno
+   ```
+
+2. **Setup Respan Account**
+
+   - Create an account at [platform.respan.ai](https://platform.respan.ai).
+   - Generate an API key on the [API keys page](https://platform.respan.ai/platform/api/api-keys).
+
+3. **Set Environment Variables**
+
+   ```bash
+   export RESPAN_API_KEY=<your-api-key>
+   ```
+
+## Sending Traces to Respan
+
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from respan_exporter_agno import RespanAgnoInstrumentor
+
+# Initialize Respan instrumentation
+RespanAgnoInstrumentor.instrument()
+
+# Create and configure the agent
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="You are a helpful assistant.",
+)
+
+# Use the agent
+agent.print_response("Tell me a joke about AI")
+```
+
+View your traces on the [Traces page](https://platform.respan.ai/platform/traces) in the Respan dashboard.
+
+## Configuration
+
+`RespanAgnoInstrumentor.instrument()` accepts the following parameters:
+
+| Parameter             | Type          | Default                  | Description                  |
+| --------------------- | ------------- | ------------------------ | ---------------------------- |
+| `api_key`             | `str`         | `RESPAN_API_KEY` env var | Respan API key.              |
+| `endpoint`            | `str \| None` | `None`                   | Custom ingest endpoint URL.  |
+| `base_url`            | `str \| None` | `None`                   | API base URL.                |
+| `environment`         | `str \| None` | `None`                   | Environment label.           |
+| `customer_identifier` | `str \| None` | `None`                   | Default customer identifier. |
+
+## Notes
+
+- **Environment Variables**: Set `RESPAN_API_KEY` to avoid passing `api_key` directly in code.
+- **Initialization Order**: Call `RespanAgnoInstrumentor.instrument()` before creating any agents.
+- **Respan Docs**: See the [Respan Agno integration guide](https://respan.ai/docs/integrations/tracing/agno) for additional details.

--- a/observability/respan.mdx
+++ b/observability/respan.mdx
@@ -55,10 +55,10 @@ View your traces on the [Traces page](https://platform.respan.ai/platform/traces
 | Parameter             | Type          | Default                  | Description                  |
 | --------------------- | ------------- | ------------------------ | ---------------------------- |
 | `api_key`             | `str`         | `RESPAN_API_KEY` env var | Respan API key.              |
-| `endpoint`            | `str \| None` | `None`                   | Custom ingest endpoint URL.  |
-| `base_url`            | `str \| None` | `None`                   | API base URL.                |
-| `environment`         | `str \| None` | `None`                   | Environment label.           |
-| `customer_identifier` | `str \| None` | `None`                   | Default customer identifier. |
+| `endpoint`            | `str | None`  | `None`                   | Custom ingest endpoint URL.  |
+| `base_url`            | `str | None`  | `None`                   | API base URL.                |
+| `environment`         | `str | None`  | `None`                   | Environment label.           |
+| `customer_identifier` | `str | None`  | `None`                   | Default customer identifier. |
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Add `observability/respan.mdx` integration page with setup, code example, and configuration table
- Add Respan to the sidebar navigation in `docs.json`
- Add Respan to the supported backends list in `observability/overview.mdx`

## Test plan
- [x] Verify `mintlify dev` renders the new page correctly
- [x] Check navigation links work
- [x] Confirm no broken links with `mintlify broken-links`

🤖 Generated with [Claude Code](https://claude.com/claude-code)