### PR TITLE
docs: add custom prompt support to Agentic Chunking documentation

### DIFF
--- a/_snippets/chunking-agentic.mdx
+++ b/_snippets/chunking-agentic.mdx
@@ -2,4 +2,4 @@
 | --------- | ---- | ------- | ----------- |
 | `model` | `Model` | `OpenAIChat` | The model to use for chunking. |
 | `max_chunk_size` | `int` | `5000` | The maximum size of each chunk. |
-| `custom_prompt` | `str` | `None` | Allows personalised instructions to determine chunk breakpoints. |
+| `custom_prompt` | `str` | `None` | Allows personalized instructions to determine chunk breakpoints. |

--- a/_snippets/chunking-agentic.mdx
+++ b/_snippets/chunking-agentic.mdx
@@ -2,3 +2,4 @@
 | --------- | ---- | ------- | ----------- |
 | `model` | `Model` | `OpenAIChat` | The model to use for chunking. |
 | `max_chunk_size` | `int` | `5000` | The maximum size of each chunk. |
+| `custom_prompt` | `str` | `None` | Allows personalised instructions to determine chunk breakpoints. |

--- a/examples/knowledge/chunking/agentic-chunking-custom-prompt.mdx
+++ b/examples/knowledge/chunking/agentic-chunking-custom-prompt.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agentic Chunking with Custom Prompt"
-description: "Use custom prompts to determine personalised chunk breakpoints."
+description: "Use custom prompts to determine personalized chunk breakpoints."
 ---
 ```python
 from agno.agent import Agent

--- a/examples/knowledge/chunking/agentic-chunking-custom-prompt.mdx
+++ b/examples/knowledge/chunking/agentic-chunking-custom-prompt.mdx
@@ -1,0 +1,55 @@
+---
+title: "Agentic Chunking with Custom Prompt"
+description: "Use custom prompts to determine personalised chunk breakpoints."
+---
+```python
+from agno.agent import Agent
+from agno.knowledge.chunking.agentic import AgenticChunking
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.pdf_reader import PDFReader
+from agno.vectordb.pgvector import PgVector
+
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+knowledge = Knowledge(
+    vector_db=PgVector(table_name="recipes_custom_agentic_chunking", db_url=db_url),
+)
+
+knowledge.insert(
+    url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf",
+    reader=PDFReader(
+        name="Custom Agentic Chunking Reader",
+        chunking_strategy=AgenticChunking(
+            custom_prompt="""
+            Split this recipe document at natural recipe boundaries.
+            Keep each complete recipe (ingredients and instructions) in one chunk.
+            Break between different recipes, not within a single recipe.
+            """,
+            max_chunk_size=3000,
+        ),
+    ),
+)
+
+agent = Agent(
+    knowledge=knowledge,
+    search_knowledge=True,
+)
+
+agent.print_response("How to make Thai curry?", markdown=True)
+```
+
+## Run the Example
+```bash
+# Clone and setup repo
+git clone https://github.com/agno-agi/agno.git
+cd agno/cookbook/07_knowledge/chunking
+
+# Create and activate virtual environment
+./scripts/demo_setup.sh
+source .venvs/demo/bin/activate
+
+# Optional: Run PgVector (needs docker)
+./cookbook/scripts/run_pgvector.sh
+
+python agentic_chunking_custom_prompt.py
+```

--- a/examples/knowledge/chunking/overview.mdx
+++ b/examples/knowledge/chunking/overview.mdx
@@ -7,7 +7,7 @@ description: "Chunking breaks down large documents into manageable pieces for ef
 |---------|-------------|
 | [Custom Strategy Example](/examples/knowledge/chunking/custom-strategy-example) | Run Custom Strategy Example. |
 | [Agentic Chunking](/examples/knowledge/chunking/agentic-chunking) | Run Agentic Chunking. |
-| [Agentic Chunking with Custom Prompt](/examples/knowledge/chunking/agentic-chunking-custom-prompt) | Use custom prompts to personalise chunk breakpoints. |
+| [Agentic Chunking with Custom Prompt](/examples/knowledge/chunking/agentic-chunking-custom-prompt) | Use custom prompts to personalize chunk breakpoints. |
 | [Csv Row Chunking](/examples/knowledge/chunking/csv-row-chunking) | Run Csv Row Chunking. |
 | [Document Chunking](/examples/knowledge/chunking/document-chunking) | Run Document Chunking. |
 | [Fixed Size Chunking](/examples/knowledge/chunking/fixed-size-chunking) | Run Fixed Size Chunking. |

--- a/examples/knowledge/chunking/overview.mdx
+++ b/examples/knowledge/chunking/overview.mdx
@@ -7,6 +7,7 @@ description: "Chunking breaks down large documents into manageable pieces for ef
 |---------|-------------|
 | [Custom Strategy Example](/examples/knowledge/chunking/custom-strategy-example) | Run Custom Strategy Example. |
 | [Agentic Chunking](/examples/knowledge/chunking/agentic-chunking) | Run Agentic Chunking. |
+| [Agentic Chunking with Custom Prompt](/examples/knowledge/chunking/agentic-chunking-custom-prompt) | Use custom prompts to personalise chunk breakpoints. |
 | [Csv Row Chunking](/examples/knowledge/chunking/csv-row-chunking) | Run Csv Row Chunking. |
 | [Document Chunking](/examples/knowledge/chunking/document-chunking) | Run Document Chunking. |
 | [Fixed Size Chunking](/examples/knowledge/chunking/fixed-size-chunking) | Run Fixed Size Chunking. |

--- a/knowledge/concepts/chunking/agentic-chunking.mdx
+++ b/knowledge/concepts/chunking/agentic-chunking.mdx
@@ -66,7 +66,7 @@ AgenticChunking(
 ```
 
 <Info>
-Custom prompts override default chunking behavior and are prioritised over default instructions.
+Custom prompts override default chunking behavior and are prioritized over default instructions.
 </Info>
 
 <Tip>

--- a/knowledge/concepts/chunking/agentic-chunking.mdx
+++ b/knowledge/concepts/chunking/agentic-chunking.mdx
@@ -56,6 +56,28 @@ Agentic chunking is an intelligent method of splitting documents into smaller ch
 
 </Steps>
 
+## Custom Prompts
+
+```python
+AgenticChunking(
+    custom_prompt="Split at major section boundaries. Keep complete clauses together.",
+    max_chunk_size=3000,
+)
+```
+
+<Info>
+Custom prompts override default chunking behavior and are prioritised over default instructions.
+</Info>
+
+<Tip>
+**Best Practices:**
+- Always set `max_chunk_size` when using `custom_prompt`.
+- Focus `custom_prompt` on chunking logic only.
+- The default instructions automatically handle the output format constraints.
+</Tip>
+
+See [Agentic Chunking with Custom Prompt](/examples/knowledge/chunking/agentic-chunking-custom-prompt) for a complete example.
+
 ## Agentic Chunking Params
 
 <Snippet file="chunking-agentic.mdx" />


### PR DESCRIPTION
## Description

Add documentation for the `custom_prompt` introduced in PR https://github.com/agno-agi/agno/pull/7085, which allows users to customise how the LLM determines chunk breakpoints with a complete example.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes: https://github.com/agno-agi/agno/issues/3402
- Related SDK PR: https://github.com/agno-agi/agno/pull/7085

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
