### PR TITLE
docs: add GitHub Copilot model provider documentation

### DIFF
--- a/cookbook/models/open-source/copilot.mdx
+++ b/cookbook/models/open-source/copilot.mdx
@@ -1,0 +1,124 @@
+---
+title: GitHub Copilot
+description: Use GPT-4.1, Claude, Gemini and other Copilot models via GitHub Copilot.
+---
+
+GitHub Copilot exposes an OpenAI-compatible chat API. The `CopilotChat` provider automatically exchanges your GitHub OAuth token for a short-lived Copilot session token, so you only need to provide `GITHUB_COPILOT_TOKEN` once.
+
+## Getting your token
+
+Run these three steps once to obtain a long-lived GitHub OAuth token via the device flow:
+
+**Step 1 — Request a device code:**
+
+<CodeGroup>
+
+```bash Mac / Linux
+curl -s -X POST https://github.com/login/device/code \
+  -H "accept: application/json" \
+  -H "content-type: application/json" \
+  -d '{"client_id":"Iv1.b507a08c87ecfe98","scope":"read:user"}'
+```
+
+```powershell Windows
+curl.exe -s -X POST https://github.com/login/device/code `
+  -H "accept: application/json" `
+  -H "content-type: application/json" `
+  -d '{"client_id":"Iv1.b507a08c87ecfe98","scope":"read:user"}'
+```
+
+</CodeGroup>
+
+**Step 2 — Visit [https://github.com/login/device](https://github.com/login/device) and enter the `user_code`.**
+
+**Step 3 — Poll for the token** (replace `<DEVICE_CODE>` with the value from Step 1):
+
+<CodeGroup>
+
+```bash Mac / Linux
+curl -s -X POST https://github.com/login/oauth/access_token \
+  -H "accept: application/json" \
+  -H "content-type: application/json" \
+  -d '{"client_id":"Iv1.b507a08c87ecfe98","device_code":"<DEVICE_CODE>","grant_type":"urn:ietf:params:oauth:grant-type:device_code"}'
+```
+
+```powershell Windows
+curl.exe -s -X POST https://github.com/login/oauth/access_token `
+  -H "accept: application/json" `
+  -H "content-type: application/json" `
+  -d '{"client_id":"Iv1.b507a08c87ecfe98","device_code":"<DEVICE_CODE>","grant_type":"urn:ietf:params:oauth:grant-type:device_code"}'
+```
+
+</CodeGroup>
+
+The `access_token` (`ghu_*`) in the response is your `GITHUB_COPILOT_TOKEN`.
+
+## Basic Agent
+
+```python
+from agno.agent import Agent
+from agno.models.copilot import CopilotChat
+
+agent = Agent(
+    model=CopilotChat(id="gpt-4.1"),
+    markdown=True,
+)
+
+agent.print_response("Explain the CAP theorem", stream=True)
+```
+
+## Tool Use
+
+```python
+from agno.agent import Agent
+from agno.models.copilot import CopilotChat
+from agno.tools.websearch import WebSearchTools
+
+agent = Agent(
+    model=CopilotChat(id="gpt-4.1"),
+    tools=[WebSearchTools()],
+    markdown=True,
+)
+
+agent.print_response("Whats happening in France?", stream=True)
+```
+
+## Structured Output
+
+```python
+from typing import List
+
+from agno.agent import Agent
+from agno.models.copilot import CopilotChat
+from pydantic import BaseModel, Field
+
+
+class MovieScript(BaseModel):
+    setting: str = Field(..., description="Provide a nice setting for a blockbuster movie.")
+    ending: str = Field(..., description="Ending of the movie. If not available, provide a happy ending.")
+    genre: str = Field(..., description="Genre of the movie. If not available, select action, thriller or romantic comedy.")
+    name: str = Field(..., description="Give a name to this movie")
+    characters: List[str] = Field(..., description="Name of characters for this movie.")
+    storyline: str = Field(..., description="3 sentence storyline for the movie. Make it exciting!")
+
+
+agent = Agent(
+    model=CopilotChat(id="gpt-4.1"),
+    output_schema=MovieScript,
+)
+
+agent.print_response("New York")
+```
+
+## Run Examples
+
+```bash
+export GITHUB_COPILOT_TOKEN=ghu_xxxxxxxxxxxxxxxxxxxx
+
+git clone https://github.com/agno-agi/agno.git
+cd agno/cookbook/90_models/copilot
+
+python basic.py
+python tool_use.py
+python structured_output.py
+```

--- a/docs.json
+++ b/docs.json
@@ -1533,6 +1533,21 @@
                             ]
                           },
                           {
+                            "group": "GitHub Copilot",
+                            "pages": [
+                              "models/providers/gateways/copilot/overview",
+                              {
+                                "group": "Usage",
+                                "pages": [
+                                  "models/providers/gateways/copilot/usage/basic",
+                                  "models/providers/gateways/copilot/usage/basic-stream",
+                                  "models/providers/gateways/copilot/usage/tool-use",
+                                  "models/providers/gateways/copilot/usage/structured-output"
+                                ]
+                              }
+                            ]
+                          },
+                          {
                             "group": "DeepInfra",
                             "pages": [
                               "models/providers/gateways/deepinfra/overview",

--- a/models/providers/gateways/copilot/overview.mdx
+++ b/models/providers/gateways/copilot/overview.mdx
@@ -1,0 +1,184 @@
+---
+title: GitHub Copilot
+sidebarTitle: Overview
+description: Use GitHub Copilot models (GPT-4.1, o4-mini, Claude Sonnet and more) with Agno agents.
+---
+
+GitHub Copilot exposes a chat completions API at `https://api.githubcopilot.com/` that is compatible with the OpenAI API spec.
+With Agno's `CopilotChat` provider you simply supply your GitHub OAuth token — the provider automatically exchanges it for a short-lived Copilot access token and refreshes it before every call.
+
+## Available Models
+
+GitHub Copilot exposes the models available to your Copilot subscription. The table below lists the currently known model IDs.
+
+**GPT (OpenAI)**
+
+| Model ID | Name |
+| --- | --- |
+| `gpt-4.1` | GPT-4.1 (default) |
+| `gpt-4.1-2025-04-14` | GPT-4.1 (dated snapshot) |
+| `gpt-41-copilot` | GPT-4.1 Copilot |
+| `gpt-4o` | GPT-4o |
+| `gpt-4o-2024-11-20` | GPT-4o (Nov 2024) |
+| `gpt-4o-mini` | GPT-4o mini |
+| `gpt-5.1` | GPT-5.1 |
+| `gpt-5.1-codex-max` | GPT-5.1 Codex Max |
+| `gpt-5.2` | GPT-5.2 |
+| `gpt-5.2-codex` | GPT-5.2 Codex |
+| `gpt-5.3-codex` | GPT-5.3 Codex |
+| `gpt-5.4` | GPT-5.4 |
+| `gpt-5.4-mini` | GPT-5.4 mini |
+| `gpt-5-mini` | GPT-5 mini |
+
+**Claude (Anthropic)**
+
+| Model ID | Name |
+| --- | --- |
+| `claude-sonnet-4` | Claude Sonnet 4 |
+| `claude-sonnet-4.5` | Claude Sonnet 4.5 |
+| `claude-sonnet-4.6` | Claude Sonnet 4.6 |
+| `claude-opus-4.5` | Claude Opus 4.5 |
+| `claude-opus-4.6` | Claude Opus 4.6 |
+| `claude-haiku-4.5` | Claude Haiku 4.5 |
+
+**Gemini (Google)**
+
+| Model ID | Name |
+| --- | --- |
+| `gemini-2.5-pro` | Gemini 2.5 Pro |
+| `gemini-3-pro-preview` | Gemini 3 Pro (Preview) |
+| `gemini-3-flash-preview` | Gemini 3 Flash (Preview) |
+| `gemini-3.1-pro-preview` | Gemini 3.1 Pro (Preview) |
+
+**Grok (xAI)**
+
+| Model ID | Name |
+| --- | --- |
+| `grok-code-fast-1` | Grok Code Fast 1 |
+
+<Note>Model availability depends on your Copilot subscription tier. We recommend experimenting to find the best model for your use-case.</Note>
+
+## Authentication
+
+The provider needs a **GitHub OAuth token** (`ghu_*`) with Copilot access. Set it as the `GITHUB_COPILOT_TOKEN` environment variable.
+
+### Getting your GitHub token
+
+Run these three steps once. The resulting token is long-lived until you revoke it.
+
+**Step 1 — Request a device code:**
+
+<CodeGroup>
+
+```bash Mac / Linux
+curl -s -X POST https://github.com/login/device/code \
+  -H "accept: application/json" \
+  -H "content-type: application/json" \
+  -d '{"client_id":"Iv1.b507a08c87ecfe98","scope":"read:user"}'
+```
+
+```powershell Windows
+curl.exe -s -X POST https://github.com/login/device/code `
+  -H "accept: application/json" `
+  -H "content-type: application/json" `
+  -d '{"client_id":"Iv1.b507a08c87ecfe98","scope":"read:user"}'
+```
+
+</CodeGroup>
+
+You will receive a response like:
+
+```json
+{
+  "device_code": "...",
+  "user_code": "XXXX-XXXX",
+  "verification_uri": "https://github.com/login/device"
+}
+```
+
+**Step 2 — Authorize in the browser:**
+
+Visit [https://github.com/login/device](https://github.com/login/device) and enter the `user_code` shown above.
+
+**Step 3 — Poll for the token** (replace `<DEVICE_CODE>` with the value from Step 1):
+
+<CodeGroup>
+
+```bash Mac / Linux
+curl -s -X POST https://github.com/login/oauth/access_token \
+  -H "accept: application/json" \
+  -H "content-type: application/json" \
+  -d '{"client_id":"Iv1.b507a08c87ecfe98","device_code":"<DEVICE_CODE>","grant_type":"urn:ietf:params:oauth:grant-type:device_code"}'
+```
+
+```powershell Windows
+curl.exe -s -X POST https://github.com/login/oauth/access_token `
+  -H "accept: application/json" `
+  -H "content-type: application/json" `
+  -d '{"client_id":"Iv1.b507a08c87ecfe98","device_code":"<DEVICE_CODE>","grant_type":"urn:ietf:params:oauth:grant-type:device_code"}'
+```
+
+</CodeGroup>
+
+The response contains your `access_token` (`ghu_*`). That is your `GITHUB_COPILOT_TOKEN`.
+
+### Set the environment variable
+
+<CodeGroup>
+
+```bash Mac / Linux
+export GITHUB_COPILOT_TOKEN=ghu_xxxxxxxxxxxxxxxxxxxx
+```
+
+```bash Windows
+setx GITHUB_COPILOT_TOKEN ghu_xxxxxxxxxxxxxxxxxxxx
+```
+
+</CodeGroup>
+
+## Example
+
+Use `CopilotChat` with your `Agent`:
+
+<CodeGroup>
+
+```python agent.py
+from agno.agent import Agent
+from agno.models.copilot import CopilotChat
+
+agent = Agent(
+    model=CopilotChat(id="gpt-4.1"),
+    markdown=True,
+)
+
+agent.print_response("Share a 2 sentence horror story.")
+```
+
+</CodeGroup>
+
+You can also use the string syntax:
+
+<CodeGroup>
+
+```python agent.py
+from agno.agent import Agent
+
+agent = Agent(model="copilot:gpt-4.1", markdown=True)
+agent.print_response("Share a 2 sentence horror story.")
+```
+
+</CodeGroup>
+
+<Note> View more examples [here](/models/providers/gateways/copilot/usage/basic). </Note>
+
+## Params
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `id` | `str` | `"gpt-4.1"` | The Copilot model ID to use |
+| `name` | `str` | `"CopilotChat"` | Display name for the model |
+| `provider` | `str` | `"Copilot"` | Provider identifier |
+| `github_token` | `Optional[str]` | `None` | GitHub OAuth token. Falls back to `GITHUB_COPILOT_TOKEN` env var |
+| `base_url` | `str` | `"https://api.githubcopilot.com/"` | Copilot API base URL |
+
+`CopilotChat` also supports all params of [OpenAI](/reference/models/openai).

--- a/models/providers/gateways/copilot/usage/basic-stream.mdx
+++ b/models/providers/gateways/copilot/usage/basic-stream.mdx
@@ -1,0 +1,50 @@
+---
+title: Streaming Agent
+---
+
+## Code
+
+```python cookbook/90_models/copilot/basic.py
+from typing import Iterator  # noqa
+from agno.agent import Agent, RunOutputEvent  # noqa
+from agno.models.copilot import CopilotChat
+
+agent = Agent(
+    model=CopilotChat(id="gpt-4.1"),
+    markdown=True,
+)
+
+# Get the response in a variable
+# run_response: Iterator[RunOutputEvent] = agent.run("Share a 2 sentence horror story", stream=True)
+# for chunk in run_response:
+#     print(chunk.content)
+
+# Print the response in the terminal
+agent.print_response("Share a 2 sentence horror story", stream=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your GitHub token">
+    ```bash
+    export GITHUB_COPILOT_TOKEN=ghu_xxxxxxxxxxxxxxxxxxxx
+    ```
+
+    See the [overview](/models/providers/gateways/copilot/overview#authentication) for how to obtain a token.
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U openai agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/copilot/basic.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/gateways/copilot/usage/basic.mdx
+++ b/models/providers/gateways/copilot/usage/basic.mdx
@@ -1,0 +1,48 @@
+---
+title: Basic Agent
+---
+
+## Code
+
+```python cookbook/90_models/copilot/basic.py
+from agno.agent import Agent, RunOutput  # noqa
+from agno.models.copilot import CopilotChat
+
+agent = Agent(
+    model=CopilotChat(id="gpt-4.1"),
+    markdown=True,
+)
+
+# Get the response in a variable
+# run: RunOutput = agent.run("Share a 2 sentence horror story")
+# print(run.content)
+
+# Print the response in the terminal
+agent.print_response("Share a 2 sentence horror story")
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your GitHub token">
+    ```bash
+    export GITHUB_COPILOT_TOKEN=ghu_xxxxxxxxxxxxxxxxxxxx
+    ```
+
+    See the [overview](/models/providers/gateways/copilot/overview#authentication) for how to obtain a token.
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U openai agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/copilot/basic.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/gateways/copilot/usage/structured-output.mdx
+++ b/models/providers/gateways/copilot/usage/structured-output.mdx
@@ -1,0 +1,71 @@
+---
+title: Agent with Structured Outputs
+---
+
+## Code
+
+```python cookbook/90_models/copilot/structured_output.py
+from typing import List
+
+from agno.agent import Agent, RunOutput  # noqa
+from agno.models.copilot import CopilotChat
+from pydantic import BaseModel, Field
+from rich.pretty import pprint  # noqa
+
+
+class MovieScript(BaseModel):
+    setting: str = Field(
+        ..., description="Provide a nice setting for a blockbuster movie."
+    )
+    ending: str = Field(
+        ...,
+        description="Ending of the movie. If not available, provide a happy ending.",
+    )
+    genre: str = Field(
+        ...,
+        description="Genre of the movie. If not available, select action, thriller or romantic comedy.",
+    )
+    name: str = Field(..., description="Give a name to this movie")
+    characters: List[str] = Field(..., description="Name of characters for this movie.")
+    storyline: str = Field(
+        ..., description="3 sentence storyline for the movie. Make it exciting!"
+    )
+
+
+agent = Agent(
+    model=CopilotChat(id="gpt-4.1"),
+    output_schema=MovieScript,
+)
+
+# Get the response in a variable
+# run_response: RunOutput = agent.run("New York")
+# pprint(run_response.content)
+
+agent.print_response("New York")
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your GitHub token">
+    ```bash
+    export GITHUB_COPILOT_TOKEN=ghu_xxxxxxxxxxxxxxxxxxxx
+    ```
+
+    See the [overview](/models/providers/gateways/copilot/overview#authentication) for how to obtain a token.
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U openai agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/copilot/structured_output.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/gateways/copilot/usage/tool-use.mdx
+++ b/models/providers/gateways/copilot/usage/tool-use.mdx
@@ -1,0 +1,45 @@
+---
+title: Agent with Tools
+---
+
+## Code
+
+```python cookbook/90_models/copilot/tool_use.py
+from agno.agent import Agent
+from agno.models.copilot import CopilotChat
+from agno.tools.websearch import WebSearchTools
+
+agent = Agent(
+    model=CopilotChat(id="gpt-4.1"),
+    tools=[WebSearchTools()],
+    markdown=True,
+)
+
+agent.print_response("Whats happening in France?")
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your GitHub token">
+    ```bash
+    export GITHUB_COPILOT_TOKEN=ghu_xxxxxxxxxxxxxxxxxxxx
+    ```
+
+    See the [overview](/models/providers/gateways/copilot/overview#authentication) for how to obtain a token.
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U openai duckduckgo-search agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/copilot/tool_use.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/model-index.mdx
+++ b/models/providers/model-index.mdx
@@ -234,6 +234,14 @@ Agno supports the following model providers organized by category:
     CometAPI model provider integration.
   </Card>
   <Card
+    title="GitHub Copilot"
+    icon="github"
+    iconType="duotone"
+    href="/models/providers/gateways/copilot/overview"
+  >
+    GitHub Copilot models (GPT-4.1, Claude, Gemini and more).
+  </Card>
+  <Card
     title="DeepInfra"
     icon="infinity"
     iconType="duotone"


### PR DESCRIPTION
## Description

Adds documentation for the new `CopilotChat` model provider, which allows using GitHub Copilot models (GPT-4.1, Claude, Gemini, Grok and more) with Agno agents.

The provider automatically exchanges a GitHub OAuth token for a short-lived Copilot access token — users only need to set `GITHUB_COPILOT_TOKEN` once.

## Type of Change

- [x] New content

## Related Issues/PRs (if applicable)

- Related SDK PR: agno-agi/agno#7136

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)