### PR TITLE
docs(tools): add PerplexitySearch toolkit documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1920,6 +1920,7 @@
                           "tools/toolkits/search/hackernews",
                           "tools/toolkits/search/linkup",
                           "tools/toolkits/search/parallel",
+                          "tools/toolkits/search/perplexitysearch",
                           "tools/toolkits/search/pubmed",
                           "tools/toolkits/search/searxng",
                           "tools/toolkits/search/seltz",

--- a/docs.json
+++ b/docs.json
@@ -1920,7 +1920,7 @@
                           "tools/toolkits/search/hackernews",
                           "tools/toolkits/search/linkup",
                           "tools/toolkits/search/parallel",
-                          "tools/toolkits/search/perplexitysearch",
+                          "tools/toolkits/search/perplexity",
                           "tools/toolkits/search/pubmed",
                           "tools/toolkits/search/searxng",
                           "tools/toolkits/search/seltz",

--- a/tools/toolkits/overview.mdx
+++ b/tools/toolkits/overview.mdx
@@ -64,7 +64,7 @@ The following **Toolkits** are available to use
     title="Perplexity"
     icon="magnifying-glass"
     iconType="duotone"
-    href="/tools/toolkits/search/perplexitysearch"
+    href="/tools/toolkits/search/perplexity"
   >
     Tools to search the web using Perplexity.
   </Card>

--- a/tools/toolkits/overview.mdx
+++ b/tools/toolkits/overview.mdx
@@ -61,6 +61,14 @@ The following **Toolkits** are available to use
     Tools to read Hacker News articles.
   </Card>
   <Card
+    title="Perplexity"
+    icon="magnifying-glass"
+    iconType="duotone"
+    href="/tools/toolkits/search/perplexitysearch"
+  >
+    Tools to search the web using Perplexity.
+  </Card>
+  <Card
     title="Pubmed"
     icon="file-medical"
     iconType="duotone"

--- a/tools/toolkits/search/perplexity.mdx
+++ b/tools/toolkits/search/perplexity.mdx
@@ -1,12 +1,13 @@
 ---
 title: Perplexity
+description: "Search the web with filtering, recency, and domain restrictions using Perplexity Search API."
 ---
 
-**PerplexitySearch** enables an Agent to search the web using the Perplexity Search API.
+**PerplexitySearch** enables an Agent to search the web using the Perplexity Search API and return ranked results with titles, URLs, snippets, and publication dates.
 
 ## Prerequisites
 
-The following example requires the `httpx` library and an API key from [Perplexity](https://www.perplexity.ai/).
+The following example requires the `httpx` library and an API key from [Perplexity](https://console.perplexity.ai/).
 
 ```shell
 uv pip install -U httpx
@@ -16,17 +17,41 @@ uv pip install -U httpx
 export PERPLEXITY_API_KEY=***
 ```
 
-## Example
+## Examples
 
-The following agent will search the web for "latest developments in AI" and print the response.
+Basic search:
 
-```python cookbook/91_tools/perplexity_tools.py
+```python
 from agno.agent import Agent
 from agno.tools.perplexity import PerplexitySearch
 
 agent = Agent(tools=[PerplexitySearch()], markdown=True)
-agent.print_response("Search for 'latest developments in AI'")
+agent.print_response("What are the latest developments in AI?")
 ```
+
+Search with filters (news from the past week, specific domains):
+
+```python
+agent_filtered = Agent(
+    tools=[
+        PerplexitySearch(
+            max_results=10,
+            search_recency_filter="week",
+            search_domain_filter=["cnbc.com", "reuters.com", "bloomberg.com"],
+        )
+    ],
+    markdown=True,
+)
+agent_filtered.print_response("Latest AI industry developments")
+```
+
+## When to Use
+
+Use PerplexitySearch when you need:
+- Current, ranked web search results with publication dates
+- Filtering by recency (past day, week, month, or year)
+- Restriction to specific domains or languages
+- Integration with agents that need up-to-date information
 
 ## Toolkit Params
 
@@ -49,4 +74,6 @@ agent.print_response("Search for 'latest developments in AI'")
 
 ## Developer Resources
 
-- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/perplexity.py)
+- View [Example](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/perplexity_tools.py)
+- [PerplexitySearch source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/perplexity.py)
+- [Perplexity API docs](https://docs.perplexity.ai/)

--- a/tools/toolkits/search/perplexitysearch.mdx
+++ b/tools/toolkits/search/perplexitysearch.mdx
@@ -1,0 +1,52 @@
+---
+title: Perplexity
+---
+
+**PerplexitySearch** enables an Agent to search the web using the Perplexity Search API.
+
+## Prerequisites
+
+The following example requires the `httpx` library and an API key from [Perplexity](https://www.perplexity.ai/).
+
+```shell
+uv pip install -U httpx
+```
+
+```shell
+export PERPLEXITY_API_KEY=***
+```
+
+## Example
+
+The following agent will search the web for "latest developments in AI" and print the response.
+
+```python cookbook/91_tools/perplexity_tools.py
+from agno.agent import Agent
+from agno.tools.perplexity import PerplexitySearch
+
+agent = Agent(tools=[PerplexitySearch()], markdown=True)
+agent.print_response("Search for 'latest developments in AI'")
+```
+
+## Toolkit Params
+
+| Parameter                | Type                    | Default  | Description                                                                          |
+| ------------------------ | ----------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `api_key`                | `Optional[str]`         | `None`   | Perplexity API key. If not provided, uses PERPLEXITY_API_KEY environment variable.   |
+| `max_results`            | `int`                   | `5`      | Maximum number of results to return per query.                                       |
+| `max_tokens_per_page`    | `int`                   | `2048`   | Maximum content length per result in tokens.                                         |
+| `search_recency_filter`  | `Optional[str]`         | `None`   | Filter results by recency: `day`, `week`, `month`, or `year`.                        |
+| `search_domain_filter`   | `Optional[List[str]]`   | `None`   | List of domains to restrict search results to.                                       |
+| `search_language_filter` | `Optional[List[str]]`   | `None`   | List of ISO language codes to filter results by language.                             |
+| `show_results`           | `bool`                  | `False`  | Log search results for debugging.                                                    |
+
+## Toolkit Functions
+
+| Function  | Description                                                                                                                                                     |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `search`  | Search the web using the Perplexity Search API. Takes a `query` (str) and optional `max_results` (int). Returns a JSON array of results with url, title, snippet, and date. |
+| `asearch` | Async variant of `search`. Uses `httpx.AsyncClient` for non-blocking requests.                                                                                  |
+
+## Developer Resources
+
+- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/perplexity.py)


### PR DESCRIPTION
## Description

Add documentation page for the PerplexitySearch toolkit as requested in https://github.com/agno-agi/agno/pull/6951#issuecomment-4118622640

- Create `tools/toolkits/search/perplexity.mdx`
- Register page in docs.json Search nav group
- Add Card to `tools/toolkits/overview.mdx` Search CardGroup

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes: N/A
- Related SDK PR: https://github.com/agno-agi/agno/pull/6951

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)

<img width="750" height="1852" alt="CleanShot 2026-03-24 at 15 17 20@2x" src="https://github.com/user-attachments/assets/52bee9c2-d15e-49c3-9ba5-315e9b85cfcc" />