### PR TITLE
docs: async-mysql document's bug

### DIFF
--- a/database/providers/async-mysql/overview.mdx
+++ b/database/providers/async-mysql/overview.mdx
@@ -10,13 +10,13 @@ Agno supports using [MySQL](https://www.mysql.com/) asynchronously, with the `As
 
 ```python async_mysql_for_agent.py
 from agno.agent import Agent
-from agno.db.postgres import AsyncPostgresDb
+from agno.db.mysql import AsyncMySQLDb
 
 # Replace with your own connection string, and notice the `async_` prefix
-db_url = "postgresql+psycopg_async://ai:ai@localhost:5532/ai"
+db_url = "mysql+aiomysql://ai:ai@localhost:3306/ai"
 
 # Setup your Database
-db = AsyncPostgresDb(db_url=db_url)
+db = AsyncMySQLDb(db_url=db_url)
 
 # Setup your Agent with the Database
 agent = Agent(db=db)


### PR DESCRIPTION
## Description
This pull request updates the documentation example for using MySQL asynchronously with Agno. The main change is to replace the previous PostgreSQL example with a MySQL-specific one, ensuring users see the correct imports and connection string format.

* Updated the example in `database/providers/async-mysql/overview.mdx` to use `AsyncMySQLDb` and a MySQL connection string instead of `AsyncPostgresDb` and a PostgreSQL connection string.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

None

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)