### PR TITLE
docs: add offline mode support for Qdrant hybrid search

### DIFF
--- a/_snippets/vectordb_qdrant_params.mdx
+++ b/_snippets/vectordb_qdrant_params.mdx
@@ -14,3 +14,4 @@
 | `timeout`     | `Optional[float]` | `None`             | Timeout for Qdrant operations                |
 | `host`        | `Optional[str]`   | `None`             | Host address for the Qdrant server           |
 | `path`        | `Optional[str]`   | `None`             | Path to the Qdrant database                  |
+| `fastembed_kwargs` | `Optional[dict]` | `None` | Additional kwargs passed to `SparseTextEmbedding`.   |

--- a/knowledge/vector-stores/qdrant/usage/qdrant-db-hybrid-search.mdx
+++ b/knowledge/vector-stores/qdrant/usage/qdrant-db-hybrid-search.mdx
@@ -48,6 +48,23 @@ if __name__ == "__main__":
     typer.run(qdrantdb_agent)
 ```
 
+<Note>
+To use hybrid search without internet access, 
+pre-cache the model and pass `fastembed_kwargs={"local_files_only": True, "cache_dir": "/path/to/local/model/cache"}` 
+to load models from the cache and disable downloads:
+
+  ```python
+  Qdrant(
+      collection="my_collection",
+      search_type=SearchType.hybrid,
+      fastembed_kwargs={
+          "local_files_only": True,
+          "cache_dir": "/path/to/cached/models",
+      },
+  )
+```
+</Note>
+
 ## Usage
 
 <Steps>


### PR DESCRIPTION
## Description

Following up on https://github.com/agno-agi/agno/pull/7181 which showcases offline mode support for Qdrant hybrid search via `fastembed_kwargs`, this PR updates the documentation to make the feature more discoverable.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

PR: https://github.com/agno-agi/agno/pull/7181

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
