### PR TITLE
docs: add `batch_size` param to ChromaDB configuration

### DIFF
--- a/_snippets/vectordb_chromadb_params.mdx
+++ b/_snippets/vectordb_chromadb_params.mdx
@@ -5,3 +5,4 @@
 | `distance`          | `Distance` | cosine           | The distance metric to use.                          |
 | `path`              | `str`      | "tmp/chromadb"   | The path where ChromaDB data will be stored.         |
 | `persistent_client` | `bool`     | False            | Whether to use a persistent ChromaDB client.         |
+| `batch_size`        | `int`      | None             | Maximum number of documents per batch operation. Auto-detected from ChromaDB's server limit if not set, falls back to `100` if auto-detect fails. |

--- a/knowledge/vector-stores/chroma/overview.mdx
+++ b/knowledge/vector-stores/chroma/overview.mdx
@@ -111,7 +111,9 @@ vector_db = ChromaDb(
 <Note>
 ChromaDB has a batch size limit due to SQLite constraints. 
 When inserting documents that exceed this limit, Agno automatically splits them into smaller batches.
-The batch size is auto-detected from ChromaDB's server configuration. Set `batch_size` to override the auto-detected value.
+The batch size is auto-detected from ChromaDB's server configuration. 
+
+You can also set `batch_size` to override the auto-detected value.
 </Note>
 
 ## ChromaDb Params

--- a/knowledge/vector-stores/chroma/overview.mdx
+++ b/knowledge/vector-stores/chroma/overview.mdx
@@ -108,6 +108,12 @@ vector_db = ChromaDb(
   </div>
 </Card>
 
+<Note>
+ChromaDB has a batch size limit due to SQLite constraints. 
+When inserting documents that exceed this limit, Agno automatically splits them into smaller batches.
+The batch size is auto-detected from ChromaDB's server configuration. Set `batch_size` to override the auto-detected value.
+</Note>
+
 ## ChromaDb Params
 
 <Snippet file="vectordb_chromadb_params.mdx" />


### PR DESCRIPTION
## Description

Add `batch_size` parameter to ChromaDB params table, introduced in https://github.com/agno-agi/agno/pull/7148.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Related SDK PR: https://github.com/agno-agi/agno/pull/7148

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)
