### PR TITLE
docs: rewrite WhatsApp interface and toolkit documentation

### DIFF
--- a/agent-os/interfaces/whatsapp/introduction.mdx
+++ b/agent-os/interfaces/whatsapp/introduction.mdx
@@ -1,59 +1,104 @@
 ---
 title: WhatsApp
-description: Host agents as WhatsApp applications
+description: Host agents as WhatsApp applications.
 ---
 
-Use the WhatsApp interface to serve Agents or Teams via WhatsApp. It mounts webhook routes on a FastAPI app and sends responses back to WhatsApp users and threads.
+Use the WhatsApp interface to serve Agents, Teams, or Workflows on WhatsApp. It mounts webhook routes on a FastAPI app, processes incoming messages (text, images, video, audio, documents), and sends responses back to WhatsApp users.
 
-## Setup
+## Setup Steps
 
-Set up your WhatsApp Business API and configure the webhook URL to point to your AgentOS instance.
+### 1. Create a Meta App
 
-Required environment variables:
+1. Go to the [Meta Developer Portal](https://developers.facebook.com/) and create a developer account.
+2. Create a new app at the [Apps Dashboard](https://developers.facebook.com/apps/). Select **Business** as the app type. If you don't see it, choose **Other**, then **Business** on the next screen.
+3. In the app dashboard, find **WhatsApp** in the product list and click **Set up** to add it to your app.
 
-- `WHATSAPP_ACCESS_TOKEN`
-- `WHATSAPP_PHONE_NUMBER_ID`
-- `WHATSAPP_VERIFY_TOKEN`
-- Optional (production): `WHATSAPP_APP_SECRET` and `APP_ENV=production`
+### 2. Get Your Credentials
+
+1. In your app dashboard, go to **WhatsApp > API Setup**.
+2. Note your **Phone Number ID** — it's shown below the test phone number.
+3. Generate a **Temporary Access Token** from the same page. This token expires in ~24 hours and is only suitable for development.
+4. Add test recipient numbers under the **To** field to send messages during development.
 
 <Note>
-The user's phone number is automatically used as the `user_id` for runs. This ensures that sessions and memory are appropriately scoped to the user.
-
-The phone number is also used for the `session_id`, so a single WhatsApp conversation corresponds to a single session. This should be considered when managing session history.
+For production, create a **permanent access token** via a System User instead of using temporary tokens. Go to [Meta Business Manager](https://business.facebook.com/) > **Business Settings > System Users**, create an admin system user, assign your app and WhatsApp Business Account, then generate a token with `whatsapp_business_messaging` permission.
 </Note>
+
+5. Find your **App Secret** at **App Settings > Basic** in the developer dashboard. You'll need this for webhook signature validation in production.
+
+### 3. Set Environment Variables
+
+```shell
+export WHATSAPP_ACCESS_TOKEN=your_access_token
+export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
+export WHATSAPP_VERIFY_TOKEN=your_custom_verify_token    # Any string you choose
+```
+
+For production, also set your App Secret to enable webhook signature validation:
+
+```shell
+export WHATSAPP_APP_SECRET=your_app_secret
+```
+
+For local development without signature validation:
+
+```shell
+export WHATSAPP_SKIP_SIGNATURE_VALIDATION=true
+```
+
+### 4. Set Up a Webhook
+
+Meta requires webhook endpoints to use **HTTPS**. For local development, use a tunnel like [ngrok](https://ngrok.com/) which provides HTTPS automatically.
+
+1. Start your app locally (see example below).
+2. Expose it via ngrok: `ngrok http 8000`
+3. In the Meta app dashboard, go to **WhatsApp > Configuration**.
+4. Set the **Callback URL** to `https://<your-ngrok-url>/whatsapp/webhook`.
+5. Set the **Verify Token** to the same value as your `WHATSAPP_VERIFY_TOKEN` environment variable.
+6. Click **Verify and save**. Meta will send a GET request to your endpoint — it must be running.
+7. Under **Webhook fields**, subscribe to the **messages** field.
 
 ## Example Usage
 
 Create an agent, expose it with the `Whatsapp` interface, and serve via `AgentOS`:
 
-```python
+```python basic.py
 from agno.agent import Agent
-from agno.models.openai import OpenAIResponses
-from agno.os import AgentOS
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os.app import AgentOS
 from agno.os.interfaces.whatsapp import Whatsapp
 
-image_agent = Agent(
-    model=OpenAIResponses(id="gpt-5.2"), # Ensure OPENAI_API_KEY is set
-    tools=[OpenAITools(image_model="gpt-image-1")],
-    markdown=True,
+agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
+basic_agent = Agent(
+    name="Basic Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=agent_db,
     add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
+    instructions=[
+        "You are chatting on WhatsApp. Keep responses conversational and natural.",
+        "Structure your responses as separate short paragraphs separated by double newlines.",
+    ],
 )
 
 agent_os = AgentOS(
-    agents=[image_agent],
-    interfaces=[Whatsapp(agent=image_agent)],
+    agents=[basic_agent],
+    interfaces=[Whatsapp(agent=basic_agent)],
 )
 app = agent_os.get_app()
 
 if __name__ == "__main__":
-    agent_os.serve(app="basic:app", port=8000, reload=True)
+    agent_os.serve(app="basic:app", reload=True)
 ```
 
-See the [WhatsApp Examples](/agent-os/usage/interfaces/whatsapp/basic) for more usage patterns.
+A complete example is available at `cookbook/05_agent_os/interfaces/whatsapp/basic.py`.
 
 ## Core Components
 
-- `Whatsapp` (interface): Wraps an Agno `Agent` or `Team` for WhatsApp via FastAPI.
+- `Whatsapp` (interface): Wraps an Agno `Agent`, `Team`, or `Workflow` for WhatsApp integration via FastAPI.
 - `AgentOS.serve`: Serves the FastAPI app using Uvicorn.
 
 ## `Whatsapp` Interface
@@ -62,36 +107,133 @@ Main entry point for Agno WhatsApp applications.
 
 ### Initialization Parameters
 
-| Parameter | Type              | Default | Description            |
-| --------- | ----------------- | ------- | ---------------------- |
-| `agent`   | `Optional[Agent]` | `None`  | Agno `Agent` instance. |
-| `team`    | `Optional[Team]`  | `None`  | Agno `Team` instance.  |
+| Parameter                      | Type                                        | Default        | Description                                                                                     |
+| ------------------------------ | ------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------- |
+| `agent`                        | `Optional[Union[Agent, RemoteAgent]]`       | `None`         | Agno `Agent` instance.                                                                          |
+| `team`                         | `Optional[Union[Team, RemoteTeam]]`         | `None`         | Agno `Team` instance.                                                                           |
+| `workflow`                     | `Optional[Union[Workflow, RemoteWorkflow]]` | `None`         | Agno `Workflow` instance.                                                                       |
+| `prefix`                       | `str`                                       | `"/whatsapp"`  | Custom FastAPI route prefix. Useful when running [multiple instances](#multiple-instances).      |
+| `tags`                         | `Optional[List[str]]`                       | `None`         | FastAPI route tags for API documentation. Defaults to `["Whatsapp"]` if not provided.           |
+| `show_reasoning`               | `bool`                                      | `False`        | When `True`, sends the model's reasoning content as an italicized message before the response.  |
+| `send_user_number_to_context`  | `bool`                                      | `False`        | When `True`, injects the user's phone number and message ID into the agent's context via `dependencies`. |
+| `access_token`                 | `Optional[str]`                             | `None`         | WhatsApp Business API access token. Falls back to `WHATSAPP_ACCESS_TOKEN` env var.              |
+| `phone_number_id`              | `Optional[str]`                             | `None`         | WhatsApp Business phone number ID. Falls back to `WHATSAPP_PHONE_NUMBER_ID` env var.            |
+| `verify_token`                 | `Optional[str]`                             | `None`         | Webhook verification token. Falls back to `WHATSAPP_VERIFY_TOKEN` env var.                      |
+| `media_timeout`                | `int`                                       | `30`           | Timeout in seconds for media downloads from and uploads to Meta servers.                        |
+| `enable_encryption`            | `bool`                                      | `False`        | When `True`, encrypts user phone numbers before storing them as `user_id`. See [Encryption](#phone-number-encryption). |
+| `encryption_key`               | `Optional[str]`                             | `None`         | 32-byte hex key for phone encryption. Falls back to `WHATSAPP_ENCRYPTION_KEY` env var.          |
 
-Provide `agent` or `team`.
+Provide `agent`, `team`, or `workflow` — at least one is required.
 
 ### Key Method
 
-| Method       | Parameters               | Return Type | Description                                        |
-| ------------ | ------------------------ | ----------- | -------------------------------------------------- |
-| `get_router` | `use_async: bool = True` | `APIRouter` | Returns the FastAPI router and attaches endpoints. |
+| Method       | Parameters | Return Type | Description                                        |
+| ------------ | ---------- | ----------- | -------------------------------------------------- |
+| `get_router` | None       | `APIRouter` | Returns the FastAPI router and attaches endpoints. |
 
 ## Endpoints
 
-Mounted under the `/whatsapp` prefix:
+Mounted under the `/whatsapp` prefix (configurable via `prefix`):
 
 ### `GET /whatsapp/status`
 
-- Health/status of the interface.
+Returns `{"status": "available"}`. Use for health checks.
 
 ### `GET /whatsapp/webhook`
 
-- Verifies WhatsApp webhook (`hub.challenge`).
-- Returns `hub.challenge` on success; `403` on token mismatch; `500` if `WHATSAPP_VERIFY_TOKEN` missing.
+Handles WhatsApp webhook verification during setup. Meta sends a `hub.verify_token` challenge — the endpoint returns `hub.challenge` if the token matches, `403` if it doesn't, or `500` if `WHATSAPP_VERIFY_TOKEN` is not set.
 
 ### `POST /whatsapp/webhook`
 
-- Receives WhatsApp messages and events.
-- Validates signature (`X-Hub-Signature-256`); bypassed in development mode.
-- Processes text, image, video, audio, and document messages via the agent/team.
-- Sends replies (splits long messages; uploads and sends generated images).
-- Responses: `200 {"status": "processing"}` or `{"status": "ignored"}`, `403` invalid signature, `500` errors.
+Receives and processes incoming WhatsApp messages:
+
+1. Validates the `X-Hub-Signature-256` header against `WHATSAPP_APP_SECRET` (skipped when `WHATSAPP_SKIP_SIGNATURE_VALIDATION=true`).
+2. Extracts message content (text, image, video, audio, document, or interactive reply).
+3. Downloads any attached media from Meta servers and wraps them as Agno media objects (`Image`, `Video`, `Audio`, `File`).
+4. Runs the agent/team/workflow with the message and media.
+5. Sends the response back — text is auto-split at WhatsApp's 4096-char limit, and generated media (images, audio, video, documents) is uploaded back to Meta and sent.
+
+Responses: `200 {"status": "processing"}`, `200 {"status": "ignored"}` (non-WhatsApp events), `403` (invalid signature).
+
+## Session Management
+
+The user's phone number is used as both `user_id` and `session_id`, so each WhatsApp conversation maps to a single session.
+
+- **Session format**: `wa:<entity_id>:<user_id>`
+- **Reset**: Users can send `/new` to start a fresh session. The old session is preserved in the database — a new session ID is created with a random suffix.
+- **Database required**: Session reset (`/new`) only works when the agent/team/workflow has a `db` configured.
+
+<Note>
+If `enable_encryption` is set, the phone number is AES-256-GCM encrypted before being used as `user_id`, so raw phone numbers are never stored in the database.
+</Note>
+
+## Media Handling
+
+The WhatsApp interface supports bidirectional media:
+
+**Incoming** (user sends to agent):
+- Images, video, audio, and documents are downloaded from Meta servers and passed to the agent as Agno media objects.
+- If a media download fails, a notice is prepended to the text so the agent knows media was dropped.
+- Unsupported message types (stickers, contacts, etc.) receive a polite "not supported yet" reply.
+
+**Outgoing** (agent sends to user):
+- Images (JPEG, PNG), video, audio, and documents in the agent response are uploaded to Meta and sent.
+- Audio in unsupported formats (e.g., raw PCM from TTS) is auto-converted to WAV.
+- Long text responses are split into numbered batches (`[1/3]`, `[2/3]`, etc.).
+
+## Phone Number Encryption
+
+For privacy compliance, enable phone number encryption so raw numbers are never stored:
+
+```python
+Whatsapp(
+    agent=my_agent,
+    enable_encryption=True,
+    encryption_key="your_64_hex_char_key",  # or set WHATSAPP_ENCRYPTION_KEY env var
+)
+```
+
+The key must be exactly 32 bytes (64 hex characters). Phone numbers are encrypted with AES-256-GCM using a deterministic nonce derived from the number, ensuring the same phone always maps to the same `user_id`.
+
+## Multiple Instances
+
+Run multiple WhatsApp bots on one server by giving each a unique `prefix` and its own credentials:
+
+```python
+agent_os = AgentOS(
+    agents=[basic_agent, research_agent],
+    interfaces=[
+        Whatsapp(
+            agent=basic_agent,
+            prefix="/basic",
+            access_token=getenv("BASIC_WHATSAPP_ACCESS_TOKEN"),
+            phone_number_id=getenv("BASIC_WHATSAPP_PHONE_NUMBER_ID"),
+            verify_token=getenv("BASIC_WHATSAPP_VERIFY_TOKEN"),
+        ),
+        Whatsapp(
+            agent=research_agent,
+            prefix="/web-research",
+            access_token=getenv("RESEARCH_WHATSAPP_ACCESS_TOKEN"),
+            phone_number_id=getenv("RESEARCH_WHATSAPP_PHONE_NUMBER_ID"),
+            verify_token=getenv("RESEARCH_WHATSAPP_VERIFY_TOKEN"),
+        ),
+    ],
+)
+```
+
+Each bot needs its own Meta app and phone number. Set each app's webhook callback URL to its prefix (e.g., `https://myapp.com/basic/webhook`).
+
+## Testing the Integration
+
+1. Run the app locally: `python basic.py` (ensure ngrok is running).
+2. Open WhatsApp and send a message to your test phone number.
+3. Send `/new` to reset the session.
+4. Send an image or document to test media handling.
+
+## Troubleshooting
+
+- **No messages received**: Verify the webhook callback URL and that you subscribed to the `messages` field in Meta's dashboard.
+- **403 on webhook**: Check that `WHATSAPP_APP_SECRET` is set correctly, or set `WHATSAPP_SKIP_SIGNATURE_VALIDATION=true` for local development.
+- **Webhook verification fails**: Ensure `WHATSAPP_VERIFY_TOKEN` matches the value in Meta's dashboard.
+- **Media not sending**: Check `WHATSAPP_ACCESS_TOKEN` has the required permissions and hasn't expired. Temporary tokens expire after ~24 hours — use a [System User token](#get-your-credentials) for production.
+- **Bot not replying**: Review application logs. Common causes: missing env vars, expired access token, or agent errors.

--- a/agent-os/interfaces/whatsapp/introduction.mdx
+++ b/agent-os/interfaces/whatsapp/introduction.mdx
@@ -10,13 +10,13 @@ Use the WhatsApp interface to serve Agents, Teams, or Workflows on WhatsApp. It 
 ### 1. Create a Meta App
 
 1. Go to the [Meta Developer Portal](https://developers.facebook.com/) and create a developer account.
-2. Create a new app at the [Apps Dashboard](https://developers.facebook.com/apps/). Select **Business** as the app type. If you don't see it, choose **Other**, then **Business** on the next screen.
+2. Create a new app at the [Apps Dashboard](https://developers.facebook.com/apps/). Select **Business** as the app type. If you don't see it, choose **Other** and then **Business** on the next screen.
 3. In the app dashboard, find **WhatsApp** in the product list and click **Set up** to add it to your app.
 
 ### 2. Get Your Credentials
 
 1. In your app dashboard, go to **WhatsApp > API Setup**.
-2. Note your **Phone Number ID** — it's shown below the test phone number.
+2. Note your **Phone Number ID**, shown below the test phone number.
 3. Generate a **Temporary Access Token** from the same page. This token expires in ~24 hours and is only suitable for development.
 4. Add test recipient numbers under the **To** field to send messages during development.
 
@@ -55,7 +55,7 @@ Meta requires webhook endpoints to use **HTTPS**. For local development, use a t
 3. In the Meta app dashboard, go to **WhatsApp > Configuration**.
 4. Set the **Callback URL** to `https://<your-ngrok-url>/whatsapp/webhook`.
 5. Set the **Verify Token** to the same value as your `WHATSAPP_VERIFY_TOKEN` environment variable.
-6. Click **Verify and save**. Meta will send a GET request to your endpoint — it must be running.
+6. Click **Verify and save**. Meta will send a GET request to your endpoint, so it must be running.
 7. Under **Webhook fields**, subscribe to the **messages** field.
 
 ## Example Usage
@@ -123,7 +123,7 @@ Main entry point for Agno WhatsApp applications.
 | `enable_encryption`            | `bool`                                      | `False`        | When `True`, encrypts user phone numbers before storing them as `user_id`. See [Encryption](#phone-number-encryption). |
 | `encryption_key`               | `Optional[str]`                             | `None`         | 32-byte hex key for phone encryption. Falls back to `WHATSAPP_ENCRYPTION_KEY` env var.          |
 
-Provide `agent`, `team`, or `workflow` — at least one is required.
+Provide `agent`, `team`, or `workflow`. At least one is required.
 
 ### Key Method
 
@@ -141,7 +141,7 @@ Returns `{"status": "available"}`. Use for health checks.
 
 ### `GET /whatsapp/webhook`
 
-Handles WhatsApp webhook verification during setup. Meta sends a `hub.verify_token` challenge — the endpoint returns `hub.challenge` if the token matches, `403` if it doesn't, or `500` if `WHATSAPP_VERIFY_TOKEN` is not set.
+Handles WhatsApp webhook verification during setup. Meta sends a `hub.verify_token` challenge. The endpoint returns `hub.challenge` if the token matches, `403` if it doesn't, or `500` if `WHATSAPP_VERIFY_TOKEN` is not set.
 
 ### `POST /whatsapp/webhook`
 
@@ -151,7 +151,7 @@ Receives and processes incoming WhatsApp messages:
 2. Extracts message content (text, image, video, audio, document, or interactive reply).
 3. Downloads any attached media from Meta servers and wraps them as Agno media objects (`Image`, `Video`, `Audio`, `File`).
 4. Runs the agent/team/workflow with the message and media.
-5. Sends the response back — text is auto-split at WhatsApp's 4096-char limit, and generated media (images, audio, video, documents) is uploaded back to Meta and sent.
+5. Sends the response back. Text is auto-split at WhatsApp's 4096-char limit. Generated media (images, audio, video, documents) is uploaded back to Meta and sent.
 
 Responses: `200 {"status": "processing"}`, `200 {"status": "ignored"}` (non-WhatsApp events), `403` (invalid signature).
 
@@ -160,7 +160,7 @@ Responses: `200 {"status": "processing"}`, `200 {"status": "ignored"}` (non-What
 The user's phone number is used as both `user_id` and `session_id`, so each WhatsApp conversation maps to a single session.
 
 - **Session format**: `wa:<entity_id>:<user_id>`
-- **Reset**: Users can send `/new` to start a fresh session. The old session is preserved in the database — a new session ID is created with a random suffix.
+- **Reset**: Users can send `/new` to start a fresh session. The old session is preserved in the database. A new session ID is created with a random suffix.
 - **Database required**: Session reset (`/new`) only works when the agent/team/workflow has a `db` configured.
 
 <Note>
@@ -235,5 +235,5 @@ Each bot needs its own Meta app and phone number. Set each app's webhook callbac
 - **No messages received**: Verify the webhook callback URL and that you subscribed to the `messages` field in Meta's dashboard.
 - **403 on webhook**: Check that `WHATSAPP_APP_SECRET` is set correctly, or set `WHATSAPP_SKIP_SIGNATURE_VALIDATION=true` for local development.
 - **Webhook verification fails**: Ensure `WHATSAPP_VERIFY_TOKEN` matches the value in Meta's dashboard.
-- **Media not sending**: Check `WHATSAPP_ACCESS_TOKEN` has the required permissions and hasn't expired. Temporary tokens expire after ~24 hours — use a [System User token](#get-your-credentials) for production.
+- **Media not sending**: Check `WHATSAPP_ACCESS_TOKEN` has the required permissions and hasn't expired. Temporary tokens expire after ~24 hours. Use a [System User token](#get-your-credentials) for production.
 - **Bot not replying**: Review application logs. Common causes: missing env vars, expired access token, or agent errors.

--- a/agent-os/interfaces/whatsapp/introduction.mdx
+++ b/agent-os/interfaces/whatsapp/introduction.mdx
@@ -155,19 +155,9 @@ Users can send `/new` to start a fresh session. The old session is preserved in 
 
 ## Media
 
-The WhatsApp interface handles bidirectional media automatically.
+Users can send images, video, audio, and documents to the bot. Media is downloaded from Meta's servers and passed to the agent automatically. Agents can send media back in their responses.
 
-**Incoming** (user sends to agent):
-- Images, video, audio, and documents are downloaded from [Meta's servers](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media) and passed to the agent as Agno media objects.
-- If a download fails, a notice is prepended to the text so the agent knows media was dropped.
-- Unsupported types (stickers, contacts) receive a polite "not supported yet" reply.
-
-**Outgoing** (agent sends to user):
-- Images (JPEG, PNG), video, audio, and documents in the response are uploaded to Meta and sent.
-- Audio in unsupported formats (e.g., raw PCM from TTS) is auto-converted to WAV.
-- Long text responses are split into numbered batches at WhatsApp's 4096-char limit.
-
-See the [media agent example](/agent-os/usage/interfaces/whatsapp/agent-with-media) for a complete multimodal agent.
+See the [media agent example](/agent-os/usage/interfaces/whatsapp/agent-with-media) for a complete multimodal agent, and the [reference page](/agent-os/interfaces/whatsapp/reference) for supported message types.
 
 ## WhatsAppTools
 

--- a/agent-os/interfaces/whatsapp/introduction.mdx
+++ b/agent-os/interfaces/whatsapp/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: WhatsApp
 sidebarTitle: WhatsApp
-description: Deploy agents, teams, or workflows as WhatsApp bots via the WhatsApp Business API.
+description: Deploy agents, teams, or workflows as WhatsApp bots via the WhatsApp Interface using Agno.
 keywords: [whatsapp, bot, interface, media, team, workflow, interactive, encryption, webhook]
 ---
 

--- a/agent-os/interfaces/whatsapp/introduction.mdx
+++ b/agent-os/interfaces/whatsapp/introduction.mdx
@@ -5,58 +5,16 @@ description: Host agents as WhatsApp applications.
 
 Use the WhatsApp interface to serve Agents, Teams, or Workflows on WhatsApp. It mounts webhook routes on a FastAPI app, processes incoming messages (text, images, video, audio, documents), and sends responses back to WhatsApp users.
 
-## Setup Steps
+## Setup
 
-### 1. Create a Meta App
+Follow the [WhatsApp Bot setup guide](/deploy/interfaces/whatsapp/overview) for full step-by-step instructions.
 
-1. Go to the [Meta Developer Portal](https://developers.facebook.com/) and create a developer account.
-2. Create a new app at the [Apps Dashboard](https://developers.facebook.com/apps/). Select **Business** as the app type. If you don't see it, choose **Other** and then **Business** on the next screen.
-3. In the app dashboard, find **WhatsApp** in the product list and click **Set up** to add it to your app.
+Required configuration:
 
-### 2. Get Your Credentials
-
-1. In your app dashboard, go to **WhatsApp > API Setup**.
-2. Note your **Phone Number ID**, shown below the test phone number.
-3. Generate a **Temporary Access Token** from the same page. This token expires in ~24 hours and is only suitable for development.
-4. Add test recipient numbers under the **To** field to send messages during development.
-
-<Note>
-For production, create a **permanent access token** via a System User instead of using temporary tokens. Go to [Meta Business Manager](https://business.facebook.com/) > **Business Settings > System Users**, create an admin system user, assign your app and WhatsApp Business Account, then generate a token with `whatsapp_business_messaging` permission.
-</Note>
-
-5. Find your **App Secret** at **App Settings > Basic** in the developer dashboard. You'll need this for webhook signature validation in production.
-
-### 3. Set Environment Variables
-
-```shell
-export WHATSAPP_ACCESS_TOKEN=your_access_token
-export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
-export WHATSAPP_VERIFY_TOKEN=your_custom_verify_token    # Any string you choose
-```
-
-For production, also set your App Secret to enable webhook signature validation:
-
-```shell
-export WHATSAPP_APP_SECRET=your_app_secret
-```
-
-For local development without signature validation:
-
-```shell
-export WHATSAPP_SKIP_SIGNATURE_VALIDATION=true
-```
-
-### 4. Set Up a Webhook
-
-Meta requires webhook endpoints to use **HTTPS**. For local development, use a tunnel like [ngrok](https://ngrok.com/) which provides HTTPS automatically.
-
-1. Start your app locally (see example below).
-2. Expose it via ngrok: `ngrok http 8000`
-3. In the Meta app dashboard, go to **WhatsApp > Configuration**.
-4. Set the **Callback URL** to `https://<your-ngrok-url>/whatsapp/webhook`.
-5. Set the **Verify Token** to the same value as your `WHATSAPP_VERIFY_TOKEN` environment variable.
-6. Click **Verify and save**. Meta will send a GET request to your endpoint, so it must be running.
-7. Under **Webhook fields**, subscribe to the **messages** field.
+- `WHATSAPP_ACCESS_TOKEN` (from Meta App Dashboard > WhatsApp > API Setup)
+- `WHATSAPP_PHONE_NUMBER_ID` (from Meta App Dashboard > WhatsApp > API Setup)
+- `WHATSAPP_VERIFY_TOKEN` (any string you choose for webhook verification)
+- An [ngrok](https://ngrok.com/) tunnel (for local development) with the callback URL pointing to `/whatsapp/webhook`
 
 ## Example Usage
 
@@ -225,15 +183,8 @@ Each bot needs its own Meta app and phone number. Set each app's webhook callbac
 
 ## Testing the Integration
 
-1. Run the app locally: `python basic.py` (ensure ngrok is running).
-2. Open WhatsApp and send a message to your test phone number.
-3. Send `/new` to reset the session.
-4. Send an image or document to test media handling.
-
-## Troubleshooting
-
-- **No messages received**: Verify the webhook callback URL and that you subscribed to the `messages` field in Meta's dashboard.
-- **403 on webhook**: Check that `WHATSAPP_APP_SECRET` is set correctly, or set `WHATSAPP_SKIP_SIGNATURE_VALIDATION=true` for local development.
-- **Webhook verification fails**: Ensure `WHATSAPP_VERIFY_TOKEN` matches the value in Meta's dashboard.
-- **Media not sending**: Check `WHATSAPP_ACCESS_TOKEN` has the required permissions and hasn't expired. Temporary tokens expire after ~24 hours. Use a [System User token](#get-your-credentials) for production.
-- **Bot not replying**: Review application logs. Common causes: missing env vars, expired access token, or agent errors.
+1. Follow the [setup guide](/deploy/interfaces/whatsapp/overview) to configure your Meta App and webhook.
+2. Run the app locally: `python basic.py` (ensure ngrok is running).
+3. Open WhatsApp and send a message to your test phone number.
+4. Send `/new` to reset the session.
+5. Send an image or document to test media handling.

--- a/agent-os/interfaces/whatsapp/introduction.mdx
+++ b/agent-os/interfaces/whatsapp/introduction.mdx
@@ -1,25 +1,27 @@
 ---
 title: WhatsApp
-description: Host agents as WhatsApp applications.
+sidebarTitle: WhatsApp
+description: Deploy agents, teams, or workflows as WhatsApp bots via the WhatsApp Business API.
+keywords: [whatsapp, bot, interface, media, team, workflow, interactive, encryption, webhook]
 ---
 
-Use the WhatsApp interface to serve Agents, Teams, or Workflows on WhatsApp. It mounts webhook routes on a FastAPI app, processes incoming messages (text, images, video, audio, documents), and sends responses back to WhatsApp users.
+The WhatsApp interface lets you deploy agents, teams, or workflows as WhatsApp bots that handle text, images, video, audio, and documents.
 
 ## Setup
 
-Follow the [WhatsApp Bot setup guide](/deploy/interfaces/whatsapp/overview) for full step-by-step instructions.
+Follow the [WhatsApp deploy guide](/deploy/interfaces/whatsapp/overview) to create a Meta App, configure the WhatsApp Business API, and set up webhooks.
 
 Required configuration:
 
-- `WHATSAPP_ACCESS_TOKEN` (from Meta App Dashboard > WhatsApp > API Setup)
-- `WHATSAPP_PHONE_NUMBER_ID` (from Meta App Dashboard > WhatsApp > API Setup)
+- `WHATSAPP_ACCESS_TOKEN` (from [Meta App Dashboard](https://developers.facebook.com/apps/) > WhatsApp > API Setup)
+- `WHATSAPP_PHONE_NUMBER_ID` (from WhatsApp > API Setup)
 - `WHATSAPP_VERIFY_TOKEN` (any string you choose for webhook verification)
-- An [ngrok](https://ngrok.com/) tunnel (for local development) with the callback URL pointing to `/whatsapp/webhook`
+- Webhook URL set to `{prefix}/webhook` (use [ngrok](https://ngrok.com) for local development)
 
 ## Example Usage
 
-Create an agent, expose it with the `Whatsapp` interface, and serve via `AgentOS`:
-
+<Tabs>
+  <Tab title="Agent">
 ```python basic.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
@@ -28,6 +30,7 @@ from agno.os.app import AgentOS
 from agno.os.interfaces.whatsapp import Whatsapp
 
 agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
+
 basic_agent = Agent(
     name="Basic Agent",
     model=OpenAIChat(id="gpt-4o"),
@@ -36,10 +39,6 @@ basic_agent = Agent(
     num_history_runs=3,
     add_datetime_to_context=True,
     markdown=True,
-    instructions=[
-        "You are chatting on WhatsApp. Keep responses conversational and natural.",
-        "Structure your responses as separate short paragraphs separated by double newlines.",
-    ],
 )
 
 agent_os = AgentOS(
@@ -51,111 +50,148 @@ app = agent_os.get_app()
 if __name__ == "__main__":
     agent_os.serve(app="basic:app", reload=True)
 ```
+  </Tab>
+  <Tab title="Team">
+```python support_team.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.anthropic import Claude
+from agno.os.app import AgentOS
+from agno.os.interfaces.whatsapp import Whatsapp
+from agno.team import Team
+from agno.tools.websearch import WebSearchTools
 
-A complete example is available at `cookbook/05_agent_os/interfaces/whatsapp/basic.py`.
+model = Claude(id="claude-sonnet-4-6")
+team_db = SqliteDb(db_file="tmp/support_team.db")
 
-## Core Components
+researcher = Agent(
+    name="Researcher",
+    role="Find accurate, up-to-date information on the web",
+    model=model,
+    tools=[WebSearchTools()],
+)
 
-- `Whatsapp` (interface): Wraps an Agno `Agent`, `Team`, or `Workflow` for WhatsApp integration via FastAPI.
-- `AgentOS.serve`: Serves the FastAPI app using Uvicorn.
+writer = Agent(
+    name="Writer",
+    role="Turn research into clear, friendly WhatsApp replies",
+    model=model,
+)
 
-## `Whatsapp` Interface
+support_team = Team(
+    name="Support Team",
+    model=model,
+    members=[researcher, writer],
+    db=team_db,
+    add_history_to_context=True,
+    num_history_runs=3,
+    markdown=True,
+)
 
-Main entry point for Agno WhatsApp applications.
+agent_os = AgentOS(
+    teams=[support_team],
+    interfaces=[Whatsapp(team=support_team)],
+)
+app = agent_os.get_app()
 
-### Initialization Parameters
+if __name__ == "__main__":
+    agent_os.serve(app="support_team:app", reload=True)
+```
+  </Tab>
+  <Tab title="Workflow">
+```python multimodal_workflow.py
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.os.app import AgentOS
+from agno.os.interfaces.whatsapp import Whatsapp
+from agno.tools.websearch import WebSearchTools
+from agno.workflow import Parallel, Step, Workflow
 
-| Parameter                      | Type                                        | Default        | Description                                                                                     |
-| ------------------------------ | ------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------- |
-| `agent`                        | `Optional[Union[Agent, RemoteAgent]]`       | `None`         | Agno `Agent` instance.                                                                          |
-| `team`                         | `Optional[Union[Team, RemoteTeam]]`         | `None`         | Agno `Team` instance.                                                                           |
-| `workflow`                     | `Optional[Union[Workflow, RemoteWorkflow]]` | `None`         | Agno `Workflow` instance.                                                                       |
-| `prefix`                       | `str`                                       | `"/whatsapp"`  | Custom FastAPI route prefix. Useful when running [multiple instances](#multiple-instances).      |
-| `tags`                         | `Optional[List[str]]`                       | `None`         | FastAPI route tags for API documentation. Defaults to `["Whatsapp"]` if not provided.           |
-| `show_reasoning`               | `bool`                                      | `False`        | When `True`, sends the model's reasoning content as an italicized message before the response.  |
-| `send_user_number_to_context`  | `bool`                                      | `False`        | When `True`, injects the user's phone number and message ID into the agent's context via `dependencies`. |
-| `access_token`                 | `Optional[str]`                             | `None`         | WhatsApp Business API access token. Falls back to `WHATSAPP_ACCESS_TOKEN` env var.              |
-| `phone_number_id`              | `Optional[str]`                             | `None`         | WhatsApp Business phone number ID. Falls back to `WHATSAPP_PHONE_NUMBER_ID` env var.            |
-| `verify_token`                 | `Optional[str]`                             | `None`         | Webhook verification token. Falls back to `WHATSAPP_VERIFY_TOKEN` env var.                      |
-| `media_timeout`                | `int`                                       | `30`           | Timeout in seconds for media downloads from and uploads to Meta servers.                        |
-| `enable_encryption`            | `bool`                                      | `False`        | When `True`, encrypts user phone numbers before storing them as `user_id`. See [Encryption](#phone-number-encryption). |
-| `encryption_key`               | `Optional[str]`                             | `None`         | 32-byte hex key for phone encryption. Falls back to `WHATSAPP_ENCRYPTION_KEY` env var.          |
+analyst = Agent(
+    name="Visual Analyst",
+    model=OpenAIChat(id="gpt-4o"),
+)
 
-Provide `agent`, `team`, or `workflow`. At least one is required.
+researcher = Agent(
+    name="Web Researcher",
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[WebSearchTools()],
+)
 
-### Key Method
+creative_workflow = Workflow(
+    name="Creative Pipeline",
+    steps=[
+        Parallel(
+            Step(agent=analyst, name="Analyze"),
+            Step(agent=researcher, name="Research"),
+        ),
+    ],
+)
 
-| Method       | Parameters | Return Type | Description                                        |
-| ------------ | ---------- | ----------- | -------------------------------------------------- |
-| `get_router` | None       | `APIRouter` | Returns the FastAPI router and attaches endpoints. |
+agent_os = AgentOS(
+    workflows=[creative_workflow],
+    interfaces=[Whatsapp(workflow=creative_workflow)],
+)
+app = agent_os.get_app()
 
-## Endpoints
+if __name__ == "__main__":
+    agent_os.serve(app="multimodal_workflow:app", reload=True)
+```
+  </Tab>
+</Tabs>
 
-Mounted under the `/whatsapp` prefix (configurable via `prefix`):
+<Info>
+See [more examples](/agent-os/usage/interfaces/whatsapp/basic) including [media agents](/agent-os/usage/interfaces/whatsapp/agent-with-media), [image generation](/agent-os/usage/interfaces/whatsapp/image-generation-tools), [reasoning](/agent-os/usage/interfaces/whatsapp/reasoning-agent), and [multiple bots](/examples/agent-os/interfaces/whatsapp/multiple-instances).
+</Info>
 
-### `GET /whatsapp/status`
+## Sessions
 
-Returns `{"status": "available"}`. Use for health checks.
-
-### `GET /whatsapp/webhook`
-
-Handles WhatsApp webhook verification during setup. Meta sends a `hub.verify_token` challenge. The endpoint returns `hub.challenge` if the token matches, `403` if it doesn't, or `500` if `WHATSAPP_VERIFY_TOKEN` is not set.
-
-### `POST /whatsapp/webhook`
-
-Receives and processes incoming WhatsApp messages:
-
-1. Validates the `X-Hub-Signature-256` header against `WHATSAPP_APP_SECRET` (skipped when `WHATSAPP_SKIP_SIGNATURE_VALIDATION=true`).
-2. Extracts message content (text, image, video, audio, document, or interactive reply).
-3. Downloads any attached media from Meta servers and wraps them as Agno media objects (`Image`, `Video`, `Audio`, `File`).
-4. Runs the agent/team/workflow with the message and media.
-5. Sends the response back. Text is auto-split at WhatsApp's 4096-char limit. Generated media (images, audio, video, documents) is uploaded back to Meta and sent.
-
-Responses: `200 {"status": "processing"}`, `200 {"status": "ignored"}` (non-WhatsApp events), `403` (invalid signature).
-
-## Session Management
-
-The user's phone number is used as both `user_id` and `session_id`, so each WhatsApp conversation maps to a single session.
-
-- **Session format**: `wa:<entity_id>:<user_id>`
-- **Reset**: Users can send `/new` to start a fresh session. The old session is preserved in the database. A new session ID is created with a random suffix.
-- **Database required**: Session reset (`/new`) only works when the agent/team/workflow has a `db` configured.
+Each WhatsApp user gets a single session scoped to their phone number.
 
 <Note>
-If `enable_encryption` is set, the phone number is AES-256-GCM encrypted before being used as `user_id`, so raw phone numbers are never stored in the database.
+Session format: `wa:{entity_id}:{user_id}`. For example, an agent named "Basic Agent" talking to user +1234567890 produces `wa:Basic Agent:1234567890`.
 </Note>
 
-## Media Handling
+Users can send `/new` to start a fresh session. The old session is preserved in the database, and a new session ID is created with a random suffix. This requires a `db` on the agent, team, or workflow.
 
-The WhatsApp interface supports bidirectional media:
+## Media
+
+The WhatsApp interface handles bidirectional media automatically.
 
 **Incoming** (user sends to agent):
-- Images, video, audio, and documents are downloaded from Meta servers and passed to the agent as Agno media objects.
-- If a media download fails, a notice is prepended to the text so the agent knows media was dropped.
-- Unsupported message types (stickers, contacts, etc.) receive a polite "not supported yet" reply.
+- Images, video, audio, and documents are downloaded from [Meta's servers](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media) and passed to the agent as Agno media objects.
+- If a download fails, a notice is prepended to the text so the agent knows media was dropped.
+- Unsupported types (stickers, contacts) receive a polite "not supported yet" reply.
 
 **Outgoing** (agent sends to user):
-- Images (JPEG, PNG), video, audio, and documents in the agent response are uploaded to Meta and sent.
+- Images (JPEG, PNG), video, audio, and documents in the response are uploaded to Meta and sent.
 - Audio in unsupported formats (e.g., raw PCM from TTS) is auto-converted to WAV.
-- Long text responses are split into numbered batches (`[1/3]`, `[2/3]`, etc.).
+- Long text responses are split into numbered batches at WhatsApp's 4096-char limit.
 
-## Phone Number Encryption
+See the [media agent example](/agent-os/usage/interfaces/whatsapp/agent-with-media) for a complete multimodal agent.
 
-For privacy compliance, enable phone number encryption so raw numbers are never stored:
+## WhatsAppTools
+
+`WhatsAppTools` lets your agents send interactive messages: reply buttons, list menus, images, documents, locations, and reactions.
 
 ```python
-Whatsapp(
-    agent=my_agent,
-    enable_encryption=True,
-    encryption_key="your_64_hex_char_key",  # or set WHATSAPP_ENCRYPTION_KEY env var
+from agno.tools.whatsapp import WhatsAppTools
+
+agent = Agent(
+    tools=[WhatsAppTools(
+        enable_send_reply_buttons=True,
+        enable_send_list_message=True,
+        enable_send_location=True,
+    )],
 )
 ```
 
-The key must be exactly 32 bytes (64 hex characters). Phone numbers are encrypted with AES-256-GCM using a deterministic nonce derived from the number, ensuring the same phone always maps to the same `user_id`.
+See the [interactive concierge example](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/interfaces/whatsapp/interactive_concierge.py) for a full agent using all interactive features.
 
-## Multiple Instances
+For parameters and methods, see the [WhatsAppTools reference](/tools/toolkits/social/whatsapp).
 
-Run multiple WhatsApp bots on one server by giving each a unique `prefix` and its own credentials:
+## Multi-Instance
+
+Run multiple bots on the same server with different `prefix` values:
 
 ```python
 agent_os = AgentOS(
@@ -179,12 +215,93 @@ agent_os = AgentOS(
 )
 ```
 
-Each bot needs its own Meta app and phone number. Set each app's webhook callback URL to its prefix (e.g., `https://myapp.com/basic/webhook`).
+Each instance gets its own route prefix, session namespace, and Meta App credentials.
 
-## Testing the Integration
+<Tip>
+Each Meta App can only have one webhook callback URL, so multi-instance setups require separate Meta Apps (one per bot), each with its own phone number.
+</Tip>
 
-1. Follow the [setup guide](/deploy/interfaces/whatsapp/overview) to configure your Meta App and webhook.
-2. Run the app locally: `python basic.py` (ensure ngrok is running).
-3. Open WhatsApp and send a message to your test phone number.
-4. Send `/new` to reset the session.
-5. Send an image or document to test media handling.
+## Phone Number Encryption
+
+<Info>
+Enable with `enable_encryption=True` to encrypt phone numbers before storing them as `user_id`. Raw numbers are never written to the database.
+</Info>
+
+```python
+Whatsapp(agent=my_agent, enable_encryption=True)
+# Set WHATSAPP_ENCRYPTION_KEY env var (64 hex chars = 32 bytes)
+```
+
+Phone numbers are encrypted with AES-256-GCM using a deterministic nonce, so the same phone always maps to the same `user_id`. Requires the `cryptography` package.
+
+## Security
+
+Every incoming webhook is verified using HMAC-SHA256 signature validation:
+
+1. The `X-Hub-Signature-256` header is extracted
+2. A signature is computed: `HMAC-SHA256(app_secret, request_body)`
+3. The computed signature is compared using constant-time comparison (`hmac.compare_digest`)
+
+<Warning>
+If `WHATSAPP_APP_SECRET` is not set, the server returns a 500 error unless `WHATSAPP_SKIP_SIGNATURE_VALIDATION=true` is set. Always configure the App Secret for production. Find it at **App Settings > Basic** in your [Meta App Dashboard](https://developers.facebook.com/apps/).
+</Warning>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="No messages received">
+    **Cause:** Webhook not configured or not subscribed to the `messages` field.
+
+    **Fix:** In your [Meta App Dashboard](https://developers.facebook.com/apps/), go to **WhatsApp > Configuration** and verify the callback URL matches your tunnel URL (e.g., `https://your-tunnel.ngrok.io/whatsapp/webhook`). Click "Manage" and confirm you're subscribed to the `messages` field.
+  </Accordion>
+
+  <Accordion title="403 on webhook">
+    **Cause:** Invalid App Secret or missing signature validation config.
+
+    **Fix:** Verify `WHATSAPP_APP_SECRET` matches the value under **App Settings > Basic** in your [Meta App Dashboard](https://developers.facebook.com/apps/). For local development, set `WHATSAPP_SKIP_SIGNATURE_VALIDATION=true`.
+  </Accordion>
+
+  <Accordion title="Webhook verification fails">
+    **Cause:** Verify token mismatch or server not running.
+
+    **Fix:** Ensure `WHATSAPP_VERIFY_TOKEN` matches the value you entered in the Meta webhook configuration. Your server must be running when you click "Verify and save".
+  </Accordion>
+
+  <Accordion title="Media not sending">
+    **Cause:** Expired or insufficient access token.
+
+    **Fix:** Temporary tokens expire after ~24 hours. For production, create a permanent [System User token](https://developers.facebook.com/docs/whatsapp/business-management-api/get-started#system-user-access-tokens) via Meta Business Manager. Ensure the token has `whatsapp_business_messaging` permission.
+  </Accordion>
+
+  <Accordion title="Bot not replying">
+    **Cause:** Missing environment variables or agent errors.
+
+    **Fix:** Check application logs. Common causes: `WHATSAPP_ACCESS_TOKEN` not set, expired token, or an error in your agent's tools or model configuration.
+  </Accordion>
+
+  <Accordion title="SSL certificate errors">
+    **Cause:** macOS system Python missing root certificates.
+
+    **Fix:** Set the `SSL_CERT_FILE` environment variable:
+    ```bash
+    export SSL_CERT_FILE=$(python3 -c "import certifi; print(certifi.where())")
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Developer Resources
+
+<CardGroup cols={2}>
+  <Card title="Interface Reference" icon="book" href="/agent-os/interfaces/whatsapp/reference">
+    All parameters, endpoints, and session handling details.
+  </Card>
+  <Card title="Deploy Guide" icon="rocket" href="/deploy/interfaces/whatsapp/overview">
+    Create a Meta App, configure webhooks, and deploy step by step.
+  </Card>
+  <Card title="WhatsAppTools Reference" icon="wrench" href="/tools/toolkits/social/whatsapp">
+    Toolkit parameters and methods for interactive messages, media, and locations.
+  </Card>
+  <Card title="Usage Examples" icon="code" href="/agent-os/usage/interfaces/whatsapp/basic">
+    Agents, teams, media, image generation, reasoning, and more.
+  </Card>
+</CardGroup>

--- a/agent-os/interfaces/whatsapp/reference.mdx
+++ b/agent-os/interfaces/whatsapp/reference.mdx
@@ -72,6 +72,19 @@ Receives all [WhatsApp webhook events](https://developers.facebook.com/docs/what
 | `/new` command | Creates a new session. Old session is preserved. Requires a `db` on the agent/team/workflow. |
 | Unsupported types | Stickers, contacts, and other types receive a "not supported yet" reply. |
 
+### Outgoing Media
+
+Agent responses containing media are automatically uploaded to [Meta's media API](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media) and sent to the user.
+
+| Format | Behavior |
+| --- | --- |
+| Images (JPEG, PNG) | Uploaded and sent. Other formats (GIF, WebP, HEIC) are skipped. |
+| Video | Uploaded and sent as `video/mp4`. |
+| Audio (AAC, MP4, MPEG, OGG, WAV) | Uploaded and sent directly. |
+| Audio (raw PCM, e.g., from TTS) | Auto-converted to WAV before upload. |
+| Documents | Uploaded with detected MIME type and filename. |
+| Long text (>4096 chars) | Split into numbered batches: `[1/3]`, `[2/3]`, `[3/3]`. |
+
 ## Developer Resources
 
 <CardGroup cols={2}>

--- a/agent-os/interfaces/whatsapp/reference.mdx
+++ b/agent-os/interfaces/whatsapp/reference.mdx
@@ -1,0 +1,84 @@
+---
+title: WhatsApp Reference
+sidebarTitle: Reference
+description: Interface parameters, endpoints, and webhook handling for the WhatsApp interface.
+keywords: [whatsapp, reference, parameters, endpoints, webhook, api]
+---
+
+## Interface Parameters
+
+Pass one of `agent`, `team`, or `workflow` to the `Whatsapp` constructor.
+
+```python
+from agno.os.interfaces.whatsapp import Whatsapp
+
+Whatsapp(agent=my_agent, prefix="/whatsapp")
+```
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `agent` | `Optional[Union[Agent, RemoteAgent]]` | `None` | Agno `Agent` instance. |
+| `team` | `Optional[Union[Team, RemoteTeam]]` | `None` | Agno `Team` instance. |
+| `workflow` | `Optional[Union[Workflow, RemoteWorkflow]]` | `None` | Agno `Workflow` instance. |
+| `prefix` | `str` | `"/whatsapp"` | URL prefix for WhatsApp endpoints (e.g., `/whatsapp` means webhooks arrive at `/whatsapp/webhook`). |
+| `tags` | `Optional[List[str]]` | `None` | FastAPI route tags for API documentation. Defaults to `["Whatsapp"]`. |
+| `show_reasoning` | `bool` | `False` | When `True`, sends the model's reasoning content as an italicized message before the main response. |
+| `send_user_number_to_context` | `bool` | `False` | When `True`, injects the user's phone number and incoming message ID into the agent's context via `dependencies`. |
+| `access_token` | `Optional[str]` | `None` | WhatsApp Business API access token. Falls back to `WHATSAPP_ACCESS_TOKEN` environment variable. |
+| `phone_number_id` | `Optional[str]` | `None` | WhatsApp Business phone number ID. Falls back to `WHATSAPP_PHONE_NUMBER_ID` environment variable. |
+| `verify_token` | `Optional[str]` | `None` | Webhook verification token. Falls back to `WHATSAPP_VERIFY_TOKEN` environment variable. |
+| `media_timeout` | `int` | `30` | Timeout in seconds for media downloads from and uploads to [Meta's media API](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media). |
+| `enable_encryption` | `bool` | `False` | When `True`, encrypts user phone numbers with AES-256-GCM before storing them as `user_id`. Requires `WHATSAPP_ENCRYPTION_KEY` or the `encryption_key` parameter. |
+| `encryption_key` | `Optional[str]` | `None` | 32-byte hex key (64 characters) for phone number encryption. Falls back to `WHATSAPP_ENCRYPTION_KEY` environment variable. |
+
+## Endpoints
+
+Available at the `/whatsapp` prefix (customizable with `prefix`).
+
+### `GET {prefix}/status`
+
+Returns `{"status": "available"}`. Use for health checks.
+
+### `GET {prefix}/webhook`
+
+Handles [WhatsApp webhook verification](https://developers.facebook.com/docs/graph-api/webhooks/getting-started#verification-requests) during setup.
+
+| Status | Description |
+| --- | --- |
+| **200** | Verification successful. Returns the `hub.challenge` value. |
+| **400** | Missing `hub.challenge` parameter. |
+| **403** | `hub.verify_token` does not match `WHATSAPP_VERIFY_TOKEN`. |
+| **500** | `WHATSAPP_VERIFY_TOKEN` is not set. |
+
+### `POST {prefix}/webhook`
+
+Receives all [WhatsApp webhook events](https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components). Processing happens in the background so Meta gets a response within their timeout window.
+
+| Status | Description |
+| --- | --- |
+| **200** `{"status": "processing"}` | Messages received and queued for background processing. |
+| **200** `{"status": "ignored"}` | Non-WhatsApp event (e.g., `object` is not `whatsapp_business_account`). |
+| **403** | Invalid `X-Hub-Signature-256` signature. |
+| **500** | `WHATSAPP_APP_SECRET` not set and `WHATSAPP_SKIP_SIGNATURE_VALIDATION` not enabled. |
+
+### Built-in Message Handling
+
+| Message Type | Behavior |
+| --- | --- |
+| Text | Passed directly to the agent as the input message. |
+| Image, video, audio, document | Downloaded from [Meta's media API](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media) and passed as Agno media objects (`Image`, `Video`, `Audio`, `File`). |
+| Interactive (button reply) | The selected button's `title` is extracted and passed as text input. |
+| Interactive (list reply) | The selected row's `title` and `description` are extracted and passed as text input. |
+| `/new` command | Creates a new session. Old session is preserved. Requires a `db` on the agent/team/workflow. |
+| Unsupported types | Stickers, contacts, and other types receive a "not supported yet" reply. |
+
+## Developer Resources
+
+<CardGroup cols={2}>
+  <Card title="WhatsApp Guide" icon="book" href="/agent-os/interfaces/whatsapp/introduction">
+    Setup, code examples, media handling, and troubleshooting.
+  </Card>
+  <Card title="WhatsAppTools Reference" icon="wrench" href="/tools/toolkits/social/whatsapp">
+    Toolkit parameters and methods for interactive messages, media, and locations.
+  </Card>
+</CardGroup>

--- a/agent-os/usage/interfaces/whatsapp/agent-with-media.mdx
+++ b/agent-os/usage/interfaces/whatsapp/agent-with-media.mdx
@@ -5,7 +5,7 @@ description: "WhatsApp agent that analyzes images, videos, and audio using multi
 
 ## Code
 
-```python cookbook/os/interfaces/whatsapp/agent_with_media.py
+```python cookbook/05_agent_os/interfaces/whatsapp/agent_with_media.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.google import Gemini
@@ -15,7 +15,7 @@ from agno.os.interfaces.whatsapp import Whatsapp
 agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 media_agent = Agent(
     name="Media Agent",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-3-flash-preview"),
     db=agent_db,
     add_history_to_context=True,
     num_history_runs=3,
@@ -40,33 +40,33 @@ if __name__ == "__main__":
 
   <Step title="Set Environment Variables">
     ```bash
-    export WHATSAPP_ACCESS_TOKEN=your_whatsapp_access_token
+    export WHATSAPP_ACCESS_TOKEN=your_access_token
     export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
-    export WHATSAPP_WEBHOOK_URL=your_webhook_url
     export WHATSAPP_VERIFY_TOKEN=your_verify_token
+    export WHATSAPP_SKIP_SIGNATURE_VALIDATION=true  # For local dev
     export GOOGLE_API_KEY=your_google_api_key
-    export APP_ENV=development
     ```
+
+    See the [WhatsApp Bot setup guide](/deploy/interfaces/whatsapp/overview) for how to get these values from the [Meta Developer Dashboard](https://developers.facebook.com/apps/).
   </Step>
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U agno
+    uv pip install -U agno google-generativeai
     ```
   </Step>
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/whatsapp/agent_with_media.py
+    python cookbook/05_agent_os/interfaces/whatsapp/agent_with_media.py
     ```
   </Step>
 </Steps>
 
 ## Key Features
 
-- **Multimodal AI**: Gemini 2.0 Flash for image, video, and audio processing
+- **Multimodal AI**: Gemini Flash for image, video, and audio processing
 - **Image Analysis**: Object recognition, scene understanding, text extraction
 - **Video Processing**: Content analysis and summarization
 - **Audio Support**: Voice message transcription and response
 - **Context Integration**: Combines media analysis with conversation history
-

--- a/agent-os/usage/interfaces/whatsapp/agent-with-user-memory.mdx
+++ b/agent-os/usage/interfaces/whatsapp/agent-with-user-memory.mdx
@@ -24,12 +24,12 @@ memory_manager = MemoryManager(
                     Collect Information about the users likes and dislikes,
                     Collect information about what the user is doing with their life right now
                 """,
-    model=Gemini(id="gemini-flash-latest"),
+    model=Gemini(id="gemini-2.5-flash"),
 )
 
 personal_agent = Agent(
     name="Basic Agent",
-    model=Gemini(id="gemini-flash-latest"),
+    model=Gemini(id="gemini-2.5-flash"),
     tools=[HackerNewsTools()],
     add_history_to_context=True,
     num_history_runs=3,

--- a/agent-os/usage/interfaces/whatsapp/agent-with-user-memory.mdx
+++ b/agent-os/usage/interfaces/whatsapp/agent-with-user-memory.mdx
@@ -5,7 +5,7 @@ description: "Personalized WhatsApp agent that remembers user information and pr
 
 ## Code
 
-```python cookbook/os/interfaces/whatsapp/agent_with_user_memory.py
+```python cookbook/05_agent_os/interfaces/whatsapp/agent_with_user_memory.py
 from textwrap import dedent
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
@@ -24,12 +24,12 @@ memory_manager = MemoryManager(
                     Collect Information about the users likes and dislikes,
                     Collect information about what the user is doing with their life right now
                 """,
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
 )
 
 personal_agent = Agent(
     name="Basic Agent",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[HackerNewsTools()],
     add_history_to_context=True,
     num_history_runs=3,
@@ -43,7 +43,6 @@ personal_agent = Agent(
         First introduce yourself and ask for their name then, ask about themeselves, their hobbies, what they like to do and what they like to talk about.
         Use the HackerNews tools to find latest information about things in the conversations
                         """),
-    debug_mode=True,
 )
 
 agent_os = AgentOS(
@@ -63,23 +62,25 @@ if __name__ == "__main__":
 
   <Step title="Set Environment Variables">
     ```bash
-    export WHATSAPP_ACCESS_TOKEN=your_whatsapp_access_token
+    export WHATSAPP_ACCESS_TOKEN=your_access_token
     export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
-    export WHATSAPP_WEBHOOK_URL=your_webhook_url
     export WHATSAPP_VERIFY_TOKEN=your_verify_token
-    export APP_ENV=development
+    export WHATSAPP_SKIP_SIGNATURE_VALIDATION=true  # For local dev
+    export GOOGLE_API_KEY=your_google_api_key
     ```
+
+    See the [WhatsApp Bot setup guide](/deploy/interfaces/whatsapp/overview) for how to get these values from the [Meta Developer Dashboard](https://developers.facebook.com/apps/).
   </Step>
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U agno
+    uv pip install -U agno google-generativeai
     ```
   </Step>
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/whatsapp/agent_with_user_memory.py
+    python cookbook/05_agent_os/interfaces/whatsapp/agent_with_user_memory.py
     ```
   </Step>
 </Steps>
@@ -91,4 +92,3 @@ if __name__ == "__main__":
 - **Personalized Responses**: Uses stored memories for contextualized replies
 - **Friendly AI**: Acts as personal AI friend with engaging conversation
 - **Gemini Powered**: Fast, intelligent responses with multimodal capabilities
-

--- a/agent-os/usage/interfaces/whatsapp/basic.mdx
+++ b/agent-os/usage/interfaces/whatsapp/basic.mdx
@@ -5,22 +5,26 @@ description: "Create a basic AI agent that integrates with WhatsApp Business API
 
 ## Code
 
-```python cookbook/os/interfaces/whatsapp/basic.py
+```python cookbook/05_agent_os/interfaces/whatsapp/basic.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
-from agno.models.openai import OpenAIResponses
-from agno.os import AgentOS
+from agno.models.openai import OpenAIChat
+from agno.os.app import AgentOS
 from agno.os.interfaces.whatsapp import Whatsapp
 
 agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 basic_agent = Agent(
     name="Basic Agent",
-    model=OpenAIResponses(id="gpt-5.2"),
+    model=OpenAIChat(id="gpt-4o"),
     db=agent_db,
     add_history_to_context=True,
     num_history_runs=3,
     add_datetime_to_context=True,
     markdown=True,
+    instructions=[
+        "You are chatting on WhatsApp. Keep responses conversational and natural.",
+        "Structure your responses as separate short paragraphs separated by double newlines.",
+    ],
 )
 
 agent_os = AgentOS(
@@ -40,33 +44,33 @@ if __name__ == "__main__":
 
   <Step title="Set Environment Variables">
     ```bash
-    export WHATSAPP_ACCESS_TOKEN=your_whatsapp_access_token
+    export WHATSAPP_ACCESS_TOKEN=your_access_token
     export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
-    export WHATSAPP_WEBHOOK_URL=your_webhook_url
     export WHATSAPP_VERIFY_TOKEN=your_verify_token
+    export WHATSAPP_SKIP_SIGNATURE_VALIDATION=true  # For local dev
     export OPENAI_API_KEY=your_openai_api_key
-    export APP_ENV=development
     ```
+
+    See the [WhatsApp Bot setup guide](/deploy/interfaces/whatsapp/overview) for how to get these values from the [Meta Developer Dashboard](https://developers.facebook.com/apps/).
   </Step>
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U agno
+    uv pip install -U agno openai
     ```
   </Step>
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/whatsapp/basic.py
+    python cookbook/05_agent_os/interfaces/whatsapp/basic.py
     ```
   </Step>
 </Steps>
 
 ## Key Features
 
-- **WhatsApp Integration**: Responds to messages automatically  
+- **WhatsApp Integration**: Responds to messages via the WhatsApp Business API
 - **Conversation History**: Maintains context with last 3 interactions
 - **Persistent Memory**: SQLite database for session storage
-- **DateTime Context**: Time-aware responses
+- **Session Reset**: Users can send `/new` to start a fresh conversation
 - **Markdown Support**: Rich text formatting in messages
-

--- a/agent-os/usage/interfaces/whatsapp/image-generation-model.mdx
+++ b/agent-os/usage/interfaces/whatsapp/image-generation-model.mdx
@@ -5,7 +5,7 @@ description: "WhatsApp agent that generates images using Gemini's built-in capab
 
 ## Code
 
-```python cookbook/os/interfaces/whatsapp/image_generation_model.py
+```python cookbook/05_agent_os/interfaces/whatsapp/image_generation_model.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.google import Gemini
@@ -17,10 +17,9 @@ image_agent = Agent(
     id="image_generation_model",
     db=agent_db,
     model=Gemini(
-        id="gemini-2.0-flash-exp-image-generation",
+        id="models/gemini-2.5-flash-image",
         response_modalities=["Text", "Image"],
     ),
-    debug_mode=True,
 )
 
 agent_os = AgentOS(
@@ -40,33 +39,32 @@ if __name__ == "__main__":
 
   <Step title="Set Environment Variables">
     ```bash
-    export WHATSAPP_ACCESS_TOKEN=your_whatsapp_access_token
+    export WHATSAPP_ACCESS_TOKEN=your_access_token
     export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
-    export WHATSAPP_WEBHOOK_URL=your_webhook_url
     export WHATSAPP_VERIFY_TOKEN=your_verify_token
+    export WHATSAPP_SKIP_SIGNATURE_VALIDATION=true  # For local dev
     export GOOGLE_API_KEY=your_google_api_key
-    export APP_ENV=development
     ```
+
+    See the [WhatsApp Bot setup guide](/deploy/interfaces/whatsapp/overview) for how to get these values from the [Meta Developer Dashboard](https://developers.facebook.com/apps/).
   </Step>
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U agno
+    uv pip install -U agno google-generativeai
     ```
   </Step>
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/whatsapp/image_generation_model.py
+    python cookbook/05_agent_os/interfaces/whatsapp/image_generation_model.py
     ```
   </Step>
 </Steps>
 
 ## Key Features
 
-- **Direct Image Generation**: Gemini 2.0 Flash experimental image generation
+- **Direct Image Generation**: Gemini Flash with native image generation
 - **Text-to-Image**: Converts descriptions into visual content
 - **Multimodal Responses**: Generates both text and images
 - **WhatsApp Integration**: Sends images directly through WhatsApp
-- **Debug Mode**: Enhanced logging for troubleshooting
-

--- a/agent-os/usage/interfaces/whatsapp/image-generation-tools.mdx
+++ b/agent-os/usage/interfaces/whatsapp/image-generation-tools.mdx
@@ -17,7 +17,7 @@ agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 image_agent = Agent(
     id="image_generation_tools",
     db=agent_db,
-    model=OpenAIChat(id="gpt-4o"),
+    model=OpenAIChat(id="gpt-5.2-mini"),
     tools=[OpenAITools(image_model="gpt-image-1")],
     markdown=True,
     add_history_to_context=True,

--- a/agent-os/usage/interfaces/whatsapp/image-generation-tools.mdx
+++ b/agent-os/usage/interfaces/whatsapp/image-generation-tools.mdx
@@ -5,10 +5,10 @@ description: "WhatsApp agent that generates images using OpenAI's image generati
 
 ## Code
 
-```python cookbook/os/interfaces/whatsapp/image_generation_tools.py
+```python cookbook/05_agent_os/interfaces/whatsapp/image_generation_tools.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
-from agno.models.openai import OpenAIResponses
+from agno.models.openai import OpenAIChat
 from agno.os.app import AgentOS
 from agno.os.interfaces.whatsapp import Whatsapp
 from agno.tools.openai import OpenAITools
@@ -17,10 +17,9 @@ agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 image_agent = Agent(
     id="image_generation_tools",
     db=agent_db,
-    model=OpenAIResponses(id="gpt-5.2"),
+    model=OpenAIChat(id="gpt-4o"),
     tools=[OpenAITools(image_model="gpt-image-1")],
     markdown=True,
-    debug_mode=True,
     add_history_to_context=True,
 )
 
@@ -41,24 +40,25 @@ if __name__ == "__main__":
 
   <Step title="Set Environment Variables">
     ```bash
-    export WHATSAPP_ACCESS_TOKEN=your_whatsapp_access_token
+    export WHATSAPP_ACCESS_TOKEN=your_access_token
     export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
-    export WHATSAPP_WEBHOOK_URL=your_webhook_url
     export WHATSAPP_VERIFY_TOKEN=your_verify_token
+    export WHATSAPP_SKIP_SIGNATURE_VALIDATION=true  # For local dev
     export OPENAI_API_KEY=your_openai_api_key
-    export APP_ENV=development
     ```
+
+    See the [WhatsApp Bot setup guide](/deploy/interfaces/whatsapp/overview) for how to get these values from the [Meta Developer Dashboard](https://developers.facebook.com/apps/).
   </Step>
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U agno
+    uv pip install -U agno openai
     ```
   </Step>
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/whatsapp/image_generation_tools.py
+    python cookbook/05_agent_os/interfaces/whatsapp/image_generation_tools.py
     ```
   </Step>
 </Steps>
@@ -67,7 +67,6 @@ if __name__ == "__main__":
 
 - **Tool-based Generation**: OpenAI's GPT Image-1 model via external tools
 - **High-Quality Images**: Professional-grade image generation
-- **Conversational Interface**: Natural language interaction for image requests  
+- **Conversational Interface**: Natural language interaction for image requests
 - **History Context**: Remembers previous images and conversations
 - **GPT-4o Orchestration**: Intelligent conversation and tool management
-

--- a/agent-os/usage/interfaces/whatsapp/reasoning-agent.mdx
+++ b/agent-os/usage/interfaces/whatsapp/reasoning-agent.mdx
@@ -5,23 +5,23 @@ description: "WhatsApp agent with advanced reasoning and financial analysis capa
 
 ## Code
 
-```python cookbook/os/interfaces/whatsapp/reasoning_agent.py
+```python cookbook/05_agent_os/interfaces/whatsapp/reasoning_agent.py
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.anthropic.claude import Claude
 from agno.os.app import AgentOS
 from agno.os.interfaces.whatsapp import Whatsapp
-from agno.tools.thinking import ThinkingTools
+from agno.tools.reasoning import ReasoningTools
 from agno.tools.yfinance import YFinanceTools
 
 agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 
 reasoning_finance_agent = Agent(
     name="Reasoning Finance Agent",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=agent_db,
     tools=[
-        ThinkingTools(add_instructions=True),
+        ReasoningTools(add_instructions=True),
         YFinanceTools(
             stock_price=True,
             analyst_recommendations=True,
@@ -51,33 +51,33 @@ if __name__ == "__main__":
 
   <Step title="Set Environment Variables">
     ```bash
-    export WHATSAPP_ACCESS_TOKEN=your_whatsapp_access_token
+    export WHATSAPP_ACCESS_TOKEN=your_access_token
     export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
-    export WHATSAPP_WEBHOOK_URL=your_webhook_url
     export WHATSAPP_VERIFY_TOKEN=your_verify_token
+    export WHATSAPP_SKIP_SIGNATURE_VALIDATION=true  # For local dev
     export ANTHROPIC_API_KEY=your_anthropic_api_key
-    export APP_ENV=development
     ```
+
+    See the [WhatsApp Bot setup guide](/deploy/interfaces/whatsapp/overview) for how to get these values from the [Meta Developer Dashboard](https://developers.facebook.com/apps/).
   </Step>
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U agno yfinance
+    uv pip install -U agno anthropic yfinance
     ```
   </Step>
 
   <Step title="Run Example">
     ```bash
-    python cookbook/os/interfaces/whatsapp/reasoning_agent.py
+    python cookbook/05_agent_os/interfaces/whatsapp/reasoning_agent.py
     ```
   </Step>
 </Steps>
 
 ## Key Features
 
-- **Advanced Reasoning**: ThinkingTools for step-by-step financial analysis
+- **Advanced Reasoning**: ReasoningTools for step-by-step financial analysis
 - **Real-time Data**: Stock prices, analyst recommendations, company news
 - **Claude Powered**: Superior analytical and reasoning capabilities
 - **Structured Output**: Well-formatted tables and financial insights
-- **Market Intelligence**: Comprehensive company analysis and recommendations
-
+- **Show Reasoning**: Use `show_reasoning=True` on the Whatsapp interface to see the model's thought process

--- a/deploy/interfaces/whatsapp/overview.mdx
+++ b/deploy/interfaces/whatsapp/overview.mdx
@@ -5,25 +5,29 @@ description: "Deploy agents on WhatsApp Business for customer-facing interaction
 
 Agno and AgentOS make it easy to deploy your agents on WhatsApp with just 2 extra lines of code.
 
-This example creates a simple agent for answering questions and generating images:
+This example creates a simple agent for answering questions:
 
 ```python
 from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
-from agno.tools.openai import OpenAITools
-from agno.os import AgentOS
+from agno.os.app import AgentOS
 from agno.os.interfaces.whatsapp import Whatsapp
 
-image_agent = Agent(
-    model=OpenAIChat(id="gpt-5.2"), # Ensure OPENAI_API_KEY is set
-    tools=[OpenAITools(image_model="gpt-image-1")],
-    markdown=True,
+agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
+basic_agent = Agent(
+    name="Basic Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=agent_db,
     add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
 )
 
 agent_os = AgentOS(
-    agents=[image_agent],
-    interfaces=[Whatsapp(agent=image_agent)],
+    agents=[basic_agent],
+    interfaces=[Whatsapp(agent=basic_agent)],
 )
 app = agent_os.get_app()
 
@@ -32,7 +36,7 @@ if __name__ == "__main__":
 ```
 
 <Note>
-The user's phone number is automatically used as the `user_id` for runs. This ensures that sessions and memory are appropriately scoped to the user. The phone number is also used for the `session_id`, so a single WhatsApp conversation corresponds to a single session.
+The user's phone number is automatically used as the `user_id` and `session_id` for runs. Each WhatsApp conversation maps to a single session. Users can send `/new` to start a fresh session (requires a `db` on the agent).
 </Note>
 
 ## Setup and Configuration
@@ -41,51 +45,64 @@ The user's phone number is automatically used as the `user_id` for runs. This en
 
 <Step title="Prerequisites">
 Ensure you have the following:
-- A Meta Developer Account
-- A Meta Business Account
+- A [Meta Developer Account](https://developers.facebook.com/)
+- A Meta Business Account (created at [Meta Business Manager](https://business.facebook.com/))
 - A valid Facebook account
 - ngrok (for development)
-- Python 3.7+
+- Python 3.9+
 </Step>
 
 <Step title="Create a Meta App">
 1. Go to [Meta for Developers](https://developers.facebook.com/) and verify your account.
-2. Create a new app at [Meta Apps Dashboard](https://developers.facebook.com/apps/).
-3. Under "Use Case", select "Other".
-4. Choose "Business" as the app type.
+2. Create a new app at the [Apps Dashboard](https://developers.facebook.com/apps/).
+3. Under "Use Case", select **Other**.
+4. Choose **Business** as the app type.
 5. Provide:
     - App name
     - Contact email
 6. Click "Create App".
+7. In the app dashboard, find **WhatsApp** in the product list and click **Set up** to add it.
 </Step>
 
 <Step title="Set Up a Meta Business Account">
 1. Navigate to [Meta Business Manager](https://business.facebook.com/).
 2. Create a new business account or use an existing one.
-3. Verify your business by clicking on the email link.
-4. Go to your App page, navigate to "App settings / Basic", and click "Start Verification" under "Business Verification". Complete the verification process for production.
-5. Associate the app with your business account and click "Create App".
+3. Verify your business email.
+4. In your Meta App, go to **App Settings > Basic** and click "Start Verification" under Business Verification. Complete this for production access.
+5. Associate the app with your business account.
 </Step>
 
-<Step title="Setup WhatsApp Business API">
-1. Go to your app's WhatsApp Setup page.
-2. Click on "Start using the API" (API Setup).
-3. Generate an Access Token.
-4. Copy your Phone Number ID.
-5. Copy your WhatsApp Business Account ID.
-6. Add a "To" number that you will use for testing (this will likely be your personal number).
+<Step title="Configure WhatsApp Business API">
+1. In your app dashboard, go to **WhatsApp > API Setup**.
+2. Generate a **Temporary Access Token**. This token expires in ~24 hours and is suitable for development only.
+3. Copy your **Phone Number ID**, shown below the test phone number.
+4. Add a test recipient under the **To** field (your personal number for testing).
+
+For production, create a permanent token:
+1. Go to [Meta Business Manager](https://business.facebook.com/) > **Business Settings > System Users**.
+2. Click **Add** and create a new admin-level system user.
+3. Click on the system user, then **Assign Assets**.
+4. Assign your app with **Full control**.
+5. Assign your WhatsApp Business Account with **Full control**.
+6. Click **Generate Token** and select `whatsapp_business_messaging` and `whatsapp_business_management` permissions.
+7. Copy and store the token securely. This token does not expire unless revoked.
 </Step>
 
-<Step title="Setup Environment Variables">
-Create a `.env` file in your project root with the following content, replacing placeholder values with your actual credentials:
+<Step title="Set Up Environment Variables">
+Create a `.env` file or export these variables:
 ```bash
-WHATSAPP_ACCESS_TOKEN="your_whatsapp_access_token"
+WHATSAPP_ACCESS_TOKEN="your_access_token"
 WHATSAPP_PHONE_NUMBER_ID="your_phone_number_id"
-WHATSAPP_VERIFY_TOKEN="your_chosen_verify_token"  # A string you create
+WHATSAPP_VERIFY_TOKEN="your_chosen_verify_token"  # Any string you create
 ```
+
+Find these values in your Meta App:
+- **Access Token**: WhatsApp > API Setup (temporary) or System User token (permanent)
+- **Phone Number ID**: WhatsApp > API Setup, below the test phone number
+- **Verify Token**: A string you choose. Must match in both your app and Meta's webhook config.
 </Step>
 
-<Step title="Setup Webhook with ngrok">
+<Step title="Set Up Webhook with ngrok">
 1. Run ngrok to expose your local server, ensuring the port matches your app (7777):
    ```bash
    ngrok http 7777
@@ -93,31 +110,36 @@ WHATSAPP_VERIFY_TOKEN="your_chosen_verify_token"  # A string you create
    # ngrok http --domain=your-custom-domain.ngrok-free.app 7777
    ```
 2. Copy the `https://` URL provided by ngrok. This is your base ngrok URL.
-3. Construct your full webhook URL by appending `/whatsapp/webhook` to the ngrok URL (e.g., `https://<random-string>.ngrok-free.app/whatsapp/webhook`).
-4. In your Meta App's WhatsApp Setup page, navigate to the "Webhook" section and click "Edit".
-5. Configure the webhook:
-    - **Callback URL**: Enter your full ngrok webhook URL.
-    - **Verify Token**: Enter the same value you used for `WHATSAPP_VERIFY_TOKEN` in your `.env` file.
-6. Click "Verify and save". Your Agno application must be running locally for verification to succeed.
-7. After successful verification, click "Manage" next to Webhook fields. Subscribe to the `messages` field under `whatsapp_business_account`.
+3. In your Meta App, go to **WhatsApp > Configuration** and click "Edit" on the Webhook section.
+4. Configure the webhook:
+    - **Callback URL**: `https://<your-ngrok-url>/whatsapp/webhook`
+    - **Verify Token**: The same value as your `WHATSAPP_VERIFY_TOKEN`
+5. Click "Verify and save". Your Agno app must be running locally for verification to succeed.
+6. After verification, click "Manage" next to Webhook fields. Subscribe to the **messages** field under `whatsapp_business_account`.
 </Step>
 
-<Step title="Configure Application Environment">
-Set the `APP_ENV` environment variable:
-- For **Development Mode**:
-  ```bash
-  APP_ENV="development"
-  ```
-  (Webhook signature validation might be less strict or bypassed).
-- For **Production Mode**:
-  ```bash
-  APP_ENV="production"
-  ```
-  You will also need to set the `WHATSAPP_APP_SECRET` for webhook signature validation:
-  ```bash
-  WHATSAPP_APP_SECRET="your_meta_app_secret"
-  ```
-  This should be the "App Secret" found in your Meta App's "App settings > Basic" page.
+<Step title="Configure Signature Validation">
+For **development**, skip signature validation:
+```bash
+WHATSAPP_SKIP_SIGNATURE_VALIDATION="true"
+```
+
+For **production**, set your App Secret to enable webhook signature validation:
+```bash
+WHATSAPP_APP_SECRET="your_meta_app_secret"
+```
+Find the App Secret at **App Settings > Basic** in your Meta App dashboard.
+
+When `WHATSAPP_APP_SECRET` is set, every incoming webhook request is validated against the `X-Hub-Signature-256` header. Invalid requests receive a `403` response.
+</Step>
+
+<Step title="Test Your Bot">
+1. Start your app: `python whatsapp_bot.py`
+2. Ensure ngrok is running and the webhook is verified.
+3. Open WhatsApp and send a message to the test phone number.
+4. The bot should respond in the same chat.
+5. Send `/new` to start a fresh session (requires `db` on the agent).
+6. Send an image or document to test media handling.
 </Step>
 
 </Steps>
@@ -126,11 +148,20 @@ Set the `APP_ENV` environment variable:
 ngrok is used only for local development and testing. For production deployments, see the [deployment tutorials](/production/templates/overview).
 </Note>
 
+## Environment Variables Reference
+
+| Variable | Required | Description |
+| -------- | -------- | ----------- |
+| `WHATSAPP_ACCESS_TOKEN` | Yes | Bot access token from Meta App Dashboard or System User |
+| `WHATSAPP_PHONE_NUMBER_ID` | Yes | Phone number ID from WhatsApp > API Setup |
+| `WHATSAPP_VERIFY_TOKEN` | Yes | User-chosen string for webhook verification |
+| `WHATSAPP_APP_SECRET` | Production | App Secret from App Settings > Basic. Enables signature validation. |
+| `WHATSAPP_SKIP_SIGNATURE_VALIDATION` | Dev only | Set to `true` to bypass signature checks in development |
+| `WHATSAPP_ENCRYPTION_KEY` | Optional | 64 hex char (32-byte) key for AES-256-GCM phone number encryption |
+
 ## Developer Resources
 
-
 - [WhatsApp Interface](/agent-os/interfaces/whatsapp/introduction)
-- [WhatsApp Webhook API](/reference-api/schema/whatsapp/webhook)
+- [WhatsApp Cookbooks](https://github.com/agno-agi/agno/tree/main/cookbook/05_agent_os/interfaces/whatsapp)
 - [Deployment Templates](/production/templates/overview)
-- [Agent reference](/reference/agents/agent)
 - [Discord](https://agno.link/discord)

--- a/docs.json
+++ b/docs.json
@@ -4276,7 +4276,13 @@
                 "group": "Interfaces",
                 "pages": [
                   "agent-os/interfaces/overview",
-                  "agent-os/interfaces/whatsapp/introduction",
+                  {
+                    "group": "WhatsApp",
+                    "pages": [
+                      "agent-os/interfaces/whatsapp/introduction",
+                      "agent-os/interfaces/whatsapp/reference"
+                    ]
+                  },
                   "agent-os/interfaces/a2a/introduction",
                   "agent-os/interfaces/ag-ui/introduction",
                   {

--- a/examples/tools/whatsapp-tools.mdx
+++ b/examples/tools/whatsapp-tools.mdx
@@ -6,47 +6,33 @@ description: "Use WhatsApp with Agno agents."
 ## Prerequisites
 
 <AccordionGroup>
-  *(Click for details)*
-  <Accordion title="Set up WhatsApp developer account:">
-
-    1. Create Meta Developer Account
-      - Go to [Meta Developer Portal](https://developers.facebook.com/) and create a new account
-      - Create a new app at [Meta Apps Dashboard](https://developers.facebook.com/apps/)
-      - Enable WhatsApp integration for your app [here](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started)
-
-    2. Set Up WhatsApp Business API
-      You can get your WhatsApp Business Account ID from [Business Settings](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started)
+  <Accordion title="Set up a Meta Developer App">
+    1. Go to the [Meta Developer Portal](https://developers.facebook.com/) and create a developer account.
+    2. Create a new **Business** app at the [Apps Dashboard](https://developers.facebook.com/apps/).
+    3. Add the **WhatsApp** product to your app from the app dashboard.
+    4. In **WhatsApp > API Setup**, note your **Phone Number ID** and generate an **Access Token**.
   </Accordion>
   <Accordion title="Configure environment variables">
     ```bash
-      WHATSAPP_ACCESS_TOKEN=your_access_token          # Access Token
-      WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id    # Phone Number ID
-      WHATSAPP_RECIPIENT_WAID=your_recipient_waid      # Recipient WhatsApp ID (e.g. 1234567890)
-      WHATSAPP_VERSION=your_whatsapp_version           # WhatsApp API Version (e.g. v22.0)
+    export WHATSAPP_ACCESS_TOKEN=your_access_token
+    export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
+    export WHATSAPP_RECIPIENT_WAID=recipient_phone_number   # e.g. 1234567890
     ```
   </Accordion>
 </AccordionGroup>
 
-Note that for first-time outreach, you must use pre-approved message templates
-  [here](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-message-templates)
-- Test messages can only be sent to numbers that are registered in your test environment
+<Note>
+For first-time outreach to a user, you must use [pre-approved message templates](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-message-templates). Test messages can only be sent to numbers registered in your test environment.
+</Note>
 
-```python
-"""
+## Example
 
-The example below shows how to send a template message using Agno's WhatsApp tools.
-For more complex use cases, check out the WhatsApp Cloud API documentation:
-[here](https://developers.facebook.com/docs/whatsapp/cloud-api/overview)
-"""
+The following agent sends a template message via WhatsApp:
 
+```python cookbook/91_tools/whatsapp_tools.py
 from agno.agent import Agent
 from agno.models.google import Gemini
 from agno.tools.whatsapp import WhatsAppTools
-
-# ---------------------------------------------------------------------------
-# Create Agent
-# ---------------------------------------------------------------------------
-
 
 agent = Agent(
     name="whatsapp",
@@ -54,28 +40,16 @@ agent = Agent(
     tools=[WhatsAppTools()],
 )
 
-# Example: Send a template message
-# Note: Replace 'hello_world' with your actual template name
-
-# ---------------------------------------------------------------------------
-# Run Agent
-# ---------------------------------------------------------------------------
-if __name__ == "__main__":
-    agent.print_response(
-        "Send a template message using the 'hello_world' template in English to +1 123456789"
-    )
+agent.print_response(
+    "Send a template message using the 'hello_world' template in English to +1 1234567890"
+)
 ```
 
 ## Run the Example
+
 ```bash
-# Clone and setup repo
-git clone https://github.com/agno-agi/agno.git
-cd agno/cookbook/91_tools
-
-# Create and activate virtual environment
-./scripts/demo_setup.sh
-source .venvs/demo/bin/activate
-
+pip install agno google-generativeai
 python whatsapp_tools.py
 ```
-For details, see [WhatsApp cookbook](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/whatsapp_tools.py).
+
+For more examples, see the [WhatsApp cookbooks](https://github.com/agno-agi/agno/tree/main/cookbook/05_agent_os/interfaces/whatsapp).

--- a/tools/toolkits/social/whatsapp.mdx
+++ b/tools/toolkits/social/whatsapp.mdx
@@ -2,7 +2,7 @@
 title: WhatsApp
 ---
 
-**WhatsAppTools** enable an Agent to send messages via the WhatsApp Business API — text, templates, images, documents, locations, reactions, and interactive messages (reply buttons, list menus).
+**WhatsAppTools** enable an Agent to send messages via the WhatsApp Business API: text, templates, images, documents, locations, reactions, and interactive messages (reply buttons, list menus).
 
 ## Prerequisites
 
@@ -98,15 +98,15 @@ See `cookbook/05_agent_os/interfaces/whatsapp/interactive_concierge.py` for a fu
 
 The toolkit includes Pydantic models for structured interactive messages:
 
-**`ReplyButton`** — A quick-reply button for `send_reply_buttons`:
+**`ReplyButton`**: A quick-reply button for `send_reply_buttons`.
 - `id` (str): Unique button identifier (e.g., `"yes"`, `"no"`).
 - `title` (str): Button display text, max 20 characters.
 
-**`ListSection`** — A section for `send_list_message`, containing `ListRow` items:
+**`ListSection`**: A section for `send_list_message`, containing `ListRow` items.
 - `title` (str): Section heading.
 - `rows` (list of `ListRow`): Selectable rows.
 
-**`ListRow`** — A selectable row inside a `ListSection`:
+**`ListRow`**: A selectable row inside a `ListSection`.
 - `id` (str): Unique row identifier.
 - `title` (str): Row title text.
 - `description` (str, optional): Row description.
@@ -117,5 +117,5 @@ from agno.tools.whatsapp import ReplyButton, ListSection, ListRow
 
 ## Developer Resources
 
-- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/whatsapp.py)
-- View [WhatsApp Interface Cookbooks](https://github.com/agno-agi/agno/tree/main/cookbook/05_agent_os/interfaces/whatsapp)
+- [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/whatsapp.py)
+- [WhatsApp Interface Cookbooks](https://github.com/agno-agi/agno/tree/main/cookbook/05_agent_os/interfaces/whatsapp)

--- a/tools/toolkits/social/whatsapp.mdx
+++ b/tools/toolkits/social/whatsapp.mdx
@@ -2,81 +2,120 @@
 title: WhatsApp
 ---
 
-**WhatsAppTools** enable an Agent to interact with the WhatsApp Business API, allowing it to send text and template messages.
+**WhatsAppTools** enable an Agent to send messages via the WhatsApp Business API — text, templates, images, documents, locations, reactions, and interactive messages (reply buttons, list menus).
 
 ## Prerequisites
 
-This cookbook demonstrates how to use WhatsApp integration with Agno. Before running this example,
-you'''ll need to complete these setup steps:
+1. Create a Meta Developer Account at the [Meta Developer Portal](https://developers.facebook.com/).
+2. Create a new app at the [Apps Dashboard](https://developers.facebook.com/apps/) and add the **WhatsApp** product.
+3. Get your **Access Token** and **Phone Number ID** from **WhatsApp > API Setup**.
 
-1. Create Meta Developer Account
-   - Go to [Meta Developer Portal](https://developers.facebook.com/) and create a new account
-   - Create a new app at [Meta Apps Dashboard](https://developers.facebook.com/apps/)
-   - Enable WhatsApp integration for your app [here](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started)
+```shell
+export WHATSAPP_ACCESS_TOKEN=your_access_token
+export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
+```
 
-2. Set Up WhatsApp Business API
-   You can get your WhatsApp Business Account ID from [Business Settings](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started)
+For standalone use (outside the WhatsApp interface), also set a default recipient:
 
-3. Configure Environment
-   - Set these environment variables:
-     ```shell
-     export WHATSAPP_ACCESS_TOKEN=your_access_token          # Access Token
-     export WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id    # Phone Number ID
-     export WHATSAPP_RECIPIENT_WAID=your_recipient_waid      # Recipient WhatsApp ID (e.g. 1234567890)
-     export WHATSAPP_VERSION=your_whatsapp_version           # WhatsApp API Version (e.g. v22.0)
-     ```
+```shell
+export WHATSAPP_RECIPIENT_WAID=recipient_phone_number    # e.g. 1234567890
+```
 
-Important Notes:
-- For first-time outreach, you must use pre-approved message templates
-  [here](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-message-templates)
-- Test messages can only be sent to numbers that are registered in your test environment
-
-The example below shows how to send a template message using Agno'''s WhatsApp tools.
-For more complex use cases, check out the WhatsApp Cloud API documentation:
-[here](https://developers.facebook.com/docs/whatsapp/cloud-api/overview)
+<Note>
+For first-time outreach to a user, you must use [pre-approved message templates](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-message-templates). Test messages can only be sent to numbers registered in your test environment.
+</Note>
 
 ## Example
 
-The following agent will send a template message using WhatsApp:
+The following agent sends a template message using WhatsApp:
 
-```python cookbook/14_tools/whatsapp_tool.py
+```python cookbook/91_tools/whatsapp_tools.py
 from agno.agent import Agent
 from agno.models.google import Gemini
 from agno.tools.whatsapp import WhatsAppTools
 
 agent = Agent(
     name="whatsapp",
-    model=Gemini(id="gemini-2.0-flash"),
-    tools=[WhatsAppTools()]
+    model=Gemini(id="gemini-3-flash-preview"),
+    tools=[WhatsAppTools()],
 )
 
-# Example: Send a template message
-# Note: Replace '''hello_world''' with your actual template name
-# and +91 1234567890 with the recipient's WhatsApp ID
 agent.print_response(
-    "Send a template message using the '''hello_world''' template in English to +91 1234567890"
+    "Send a template message using the 'hello_world' template in English to +1 1234567890"
 )
 ```
 
+### Interactive Concierge Example
+
+Use interactive features like reply buttons, list messages, and location pins:
+
+```python
+from agno.tools.whatsapp import WhatsAppTools
+
+tools = WhatsAppTools(
+    enable_send_reply_buttons=True,
+    enable_send_list_message=True,
+    enable_send_location=True,
+    enable_send_reaction=True,
+    enable_send_image=True,
+)
+```
+
+See `cookbook/05_agent_os/interfaces/whatsapp/interactive_concierge.py` for a full example.
+
 ## Toolkit Params
 
-| Parameter         | Type          | Default   | Description                                                                                                |
-| ----------------- | ------------- | --------- | ---------------------------------------------------------------------------------------------------------- |
-| `access_token`    | `Optional[str]` | `None`    | WhatsApp Business API access token. If not provided, uses `WHATSAPP_ACCESS_TOKEN` environment variable.      |
-| `phone_number_id` | `Optional[str]` | `None`    | WhatsApp Business Account phone number ID. If not provided, uses `WHATSAPP_PHONE_NUMBER_ID` environment variable. |
-| `version`         | `str`         | `"v22.0"` | API version to use. If not provided, uses `WHATSAPP_VERSION` environment variable or defaults to "v22.0".     |
-| `recipient_waid`  | `Optional[str]` | `None`    | Default recipient WhatsApp ID (e.g., "1234567890"). If not provided, uses `WHATSAPP_RECIPIENT_WAID` environment variable. |
-| `async_mode`      | `bool`        | `False`   | Enable asynchronous methods for sending messages.                                                            |
+| Parameter                       | Type             | Default   | Description                                                                                         |
+| ------------------------------- | ---------------- | --------- | --------------------------------------------------------------------------------------------------- |
+| `access_token`                  | `Optional[str]`  | `None`    | WhatsApp Business API access token. Falls back to `WHATSAPP_ACCESS_TOKEN` env var.                  |
+| `phone_number_id`               | `Optional[str]`  | `None`    | WhatsApp Business phone number ID. Falls back to `WHATSAPP_PHONE_NUMBER_ID` env var.                |
+| `version`                       | `Optional[str]`  | `None`    | API version (e.g., `"v22.0"`). Falls back to `WHATSAPP_VERSION` env var, then defaults to `v22.0`. |
+| `recipient_waid`                | `Optional[str]`  | `None`    | Default recipient WhatsApp ID. Falls back to `WHATSAPP_RECIPIENT_WAID` env var.                     |
+| `enable_send_text_message`      | `bool`           | `True`    | Enable the `send_text_message` tool.                                                                |
+| `enable_send_template_message`  | `bool`           | `True`    | Enable the `send_template_message` tool.                                                            |
+| `enable_send_reply_buttons`     | `bool`           | `False`   | Enable the `send_reply_buttons` tool.                                                               |
+| `enable_send_list_message`      | `bool`           | `False`   | Enable the `send_list_message` tool.                                                                |
+| `enable_send_image`             | `bool`           | `False`   | Enable the `send_image` tool.                                                                       |
+| `enable_send_document`          | `bool`           | `False`   | Enable the `send_document` tool.                                                                    |
+| `enable_send_location`          | `bool`           | `False`   | Enable the `send_location` tool.                                                                    |
+| `enable_send_reaction`          | `bool`           | `False`   | Enable the `send_reaction` tool.                                                                    |
+| `all`                           | `bool`           | `False`   | Enable all tools when set to `True`.                                                                |
 
 ## Toolkit Functions
 
-| Function                        | Description                                                                                                                               |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `send_text_message_sync`        | Sends a text message to a WhatsApp user (synchronous). Parameters: `text` (str), `recipient` (Optional[str]), `preview_url` (bool), `recipient_type` (str). |
-| `send_template_message_sync`    | Sends a template message to a WhatsApp user (synchronous). Parameters: `recipient` (Optional[str]), `template_name` (str), `language_code` (str), `components` (Optional[List[Dict[str, Any]]]). |
-| `send_text_message_async`       | Sends a text message to a WhatsApp user (asynchronous). Parameters: `text` (str), `recipient` (Optional[str]), `preview_url` (bool), `recipient_type` (str). |
-| `send_template_message_async`   | Sends a template message to a WhatsApp user (asynchronous). Parameters: `recipient` (Optional[str]), `template_name` (str), `language_code` (str), `components` (Optional[List[Dict[str, Any]]]). |
+| Function                 | Description                                                                                                          |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `send_text_message`      | Send a text message. Params: `text`, `recipient` (optional), `preview_url` (bool).                                   |
+| `send_template_message`  | Send a pre-approved template. Params: `template_name`, `recipient` (optional), `language_code`, `components`.        |
+| `send_reply_buttons`     | Send an interactive reply-button message (max 3 buttons). Params: `body_text`, `buttons` (list of `ReplyButton`), `recipient`, `header`, `footer`. |
+| `send_list_message`      | Send an interactive list menu (max 10 sections, 10 rows total). Params: `body_text`, `button_text`, `sections` (list of `ListSection`), `recipient`, `header`, `footer`. |
+| `send_image`             | Send an image by URL or media ID. Params: `recipient`, `image_url`, `media_id`, `caption`.                           |
+| `send_document`          | Send a document by URL or media ID. Params: `recipient`, `document_url`, `media_id`, `filename`, `caption`.          |
+| `send_location`          | Send a location pin. Params: `latitude`, `longitude`, `name`, `address`, `recipient`.                                |
+| `send_reaction`          | React to a message with an emoji. Params: `message_id`, `emoji`, `recipient`.                                        |
+
+### Interactive Message Models
+
+The toolkit includes Pydantic models for structured interactive messages:
+
+**`ReplyButton`** — A quick-reply button for `send_reply_buttons`:
+- `id` (str): Unique button identifier (e.g., `"yes"`, `"no"`).
+- `title` (str): Button display text, max 20 characters.
+
+**`ListSection`** — A section for `send_list_message`, containing `ListRow` items:
+- `title` (str): Section heading.
+- `rows` (list of `ListRow`): Selectable rows.
+
+**`ListRow`** — A selectable row inside a `ListSection`:
+- `id` (str): Unique row identifier.
+- `title` (str): Row title text.
+- `description` (str, optional): Row description.
+
+```python
+from agno.tools.whatsapp import ReplyButton, ListSection, ListRow
+```
 
 ## Developer Resources
 
 - View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/whatsapp.py)
+- View [WhatsApp Interface Cookbooks](https://github.com/agno-agi/agno/tree/main/cookbook/05_agent_os/interfaces/whatsapp)


### PR DESCRIPTION
## Summary

Rewrites all three WhatsApp documentation pages to match the current codebase (WhatsApp V2 with media I/O, interactive tools, Team/Workflow support).

### Changes

**`agent-os/interfaces/whatsapp/introduction.mdx`** (main interface doc):
- Added step-by-step setup guide verified against Meta's official documentation (app creation, credentials, webhook config)
- Documented all 13 initialization parameters (previously only 2 were listed)
- Fixed `get_router()` signature — takes no parameters (docs incorrectly showed `use_async: bool = True`)
- Added sections: Session Management, Media Handling, Phone Number Encryption, Multiple Instances
- Added Troubleshooting section with common issues and fixes
- Updated example code to match actual cookbook (`OpenAIChat` not `OpenAIResponses`, correct imports)

**`tools/toolkits/social/whatsapp.mdx`** (toolkit reference):
- Replaced 4 fictional methods (`send_text_message_sync`, `send_text_message_async`, etc.) with the actual 8 methods
- Removed non-existent `async_mode` parameter
- Added all 10 enable/disable flags and `all` param
- Documented interactive message Pydantic models: `ReplyButton`, `ListSection`, `ListRow`
- Added interactive concierge usage example

**`examples/tools/whatsapp-tools.mdx`** (examples page):
- Updated setup instructions with accordion-based Meta app setup guide
- Fixed code example to use correct cookbook path (`cookbook/91_tools/whatsapp_tools.py`)
- Added link to WhatsApp interface cookbooks

## Type of Change

- [x] Documentation update

## Checklist

- [x] All init parameters match actual code in `libs/agno/agno/os/interfaces/whatsapp/whatsapp.py`
- [x] All toolkit methods match actual code in `libs/agno/agno/tools/whatsapp.py`
- [x] Example code matches actual cookbooks in `cookbook/05_agent_os/interfaces/whatsapp/`
- [x] Setup steps verified against Meta's official WhatsApp Business API documentation
- [x] Structure follows the Slack interface docs pattern (recently updated)