### PR TITLE
docs: add Azure AI Foundry Claude provider

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1414,6 +1414,20 @@
                                 ]
                               },
                               {
+                                "group": "Azure AI Foundry Claude",
+                                "pages": [
+                                  "models/providers/cloud/azure-foundry-claude/overview",
+                                  {
+                                    "group": "Usage",
+                                    "pages": [
+                                      "models/providers/cloud/azure-foundry-claude/usage/basic",
+                                      "models/providers/cloud/azure-foundry-claude/usage/tool-use",
+                                      "models/providers/cloud/azure-foundry-claude/usage/thinking"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
                                 "group": "Azure OpenAI",
                                 "pages": [
                                   "models/providers/cloud/azure-openai/overview",

--- a/models/providers/cloud/azure-foundry-claude/overview.mdx
+++ b/models/providers/cloud/azure-foundry-claude/overview.mdx
@@ -1,0 +1,74 @@
+---
+title: Azure AI Foundry Claude
+description: Use Claude models through Azure AI Foundry with Agno agents.
+sidebarTitle: Claude
+---
+
+Use Claude models through Azure AI Foundry. This provides a native Claude integration optimized for Azure AI Foundry infrastructure.
+
+We recommend experimenting to find the best-suited model for your use-case. Here are some general recommendations:
+
+- `claude-sonnet-4-6` model is good for most use-cases.
+- `claude-opus-4-6` model is their best model.
+
+## Authentication
+
+Set your `ANTHROPIC_FOUNDRY_API_KEY` and `ANTHROPIC_FOUNDRY_RESOURCE` environment variables.
+
+<CodeGroup>
+
+```bash Mac
+export ANTHROPIC_FOUNDRY_API_KEY=***
+export ANTHROPIC_FOUNDRY_RESOURCE=***
+```
+
+```bash Windows
+setx ANTHROPIC_FOUNDRY_API_KEY ***
+setx ANTHROPIC_FOUNDRY_RESOURCE ***
+```
+
+</CodeGroup>
+
+Authenticate with an Azure AD token provider instead of an API key by passing `azure_ad_token_provider` to the `Claude` constructor.
+
+## Example
+
+Use `Claude` with your `Agent`:
+
+<CodeGroup>
+
+```python agent.py
+from agno.agent import Agent
+from agno.models.azure.claude import Claude
+
+agent = Agent(
+    model=Claude(id="claude-sonnet-4-6"),
+)
+
+# Print the response on the terminal
+agent.print_response("Share a 2 sentence dramatic story.")
+```
+
+</CodeGroup>
+
+You can also use the string syntax:
+
+```python
+agent = Agent(model="azure-foundry-claude:claude-sonnet-4-6")
+```
+
+<Note>View more examples [here](/models/providers/cloud/azure-foundry-claude/usage/basic). </Note>
+
+## Parameters
+
+| Parameter                  | Type       | Default              | Description                                           |
+| -------------------------- | ---------- | -------------------- | ----------------------------------------------------- |
+| `id`                       | `str`      | `"claude-sonnet-4-5"` | The specific Azure Foundry Claude model ID to use    |
+| `name`                     | `str`      | `"AzureFoundryClaude"` | The name identifier for the model                   |
+| `provider`                 | `str`      | `"AzureFoundry"`     | The provider of the model                             |
+| `resource`                 | `str`      | `None`               | The Azure resource name (or set `ANTHROPIC_FOUNDRY_RESOURCE`) |
+| `base_url`                 | `str`      | `None`               | The base URL (mutually exclusive with `resource`)     |
+| `azure_ad_token_provider`  | `Callable` | `None`               | Azure AD token provider for authentication            |
+| `max_retries`              | `int`      | `None`               | Maximum number of retries for failed requests         |
+
+`Claude` (Azure AI Foundry) extends the [Anthropic Claude](/models/providers/native/anthropic/overview) model with Azure AI Foundry integration and has access to most of the same parameters.

--- a/models/providers/cloud/azure-foundry-claude/overview.mdx
+++ b/models/providers/cloud/azure-foundry-claude/overview.mdx
@@ -6,11 +6,6 @@ sidebarTitle: Claude
 
 Use Claude models through Azure AI Foundry. This provides a native Claude integration optimized for Azure AI Foundry infrastructure.
 
-We recommend experimenting to find the best-suited model for your use-case. Here are some general recommendations:
-
-- `claude-sonnet-4-6` model is good for most use-cases.
-- `claude-opus-4-6` model is their best model.
-
 ## Authentication
 
 Set your `ANTHROPIC_FOUNDRY_API_KEY` and `ANTHROPIC_FOUNDRY_RESOURCE` environment variables.

--- a/models/providers/cloud/azure-foundry-claude/usage/basic.mdx
+++ b/models/providers/cloud/azure-foundry-claude/usage/basic.mdx
@@ -1,0 +1,49 @@
+---
+title: Basic Agent
+---
+
+## Code
+
+```python cookbook/90_models/azure/claude/basic.py
+from agno.agent import Agent, RunOutput  # noqa
+from agno.models.azure.claude import Claude
+
+agent = Agent(model=Claude(id="claude-sonnet-4-6"), markdown=True)
+
+# String syntax alternative:
+# agent = Agent(model="azure-foundry-claude:claude-sonnet-4-6", markdown=True)
+
+# Get the response in a variable
+# run: RunOutput = agent.run("Share a 2 sentence horror story")
+# print(run.content)
+
+# Print the response in the terminal
+agent.print_response("Share a 2 sentence horror story")
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+<Step title="Set your environment variables">
+  <CodeGroup>
+    ```bash Mac
+    export ANTHROPIC_FOUNDRY_API_KEY=xxx
+    export ANTHROPIC_FOUNDRY_RESOURCE=xxx
+    ```
+    ```bash Windows
+      setx ANTHROPIC_FOUNDRY_API_KEY xxx
+      setx ANTHROPIC_FOUNDRY_RESOURCE xxx
+    ```
+  </CodeGroup>
+</Step>
+
+<Step title="Install dependencies">```uv pip install -U anthropic agno ```</Step>
+
+<Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/azure/claude/basic.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/cloud/azure-foundry-claude/usage/thinking.mdx
+++ b/models/providers/cloud/azure-foundry-claude/usage/thinking.mdx
@@ -1,0 +1,48 @@
+---
+title: Extended Thinking
+---
+
+## Code
+
+```python cookbook/90_models/azure/claude/thinking.py
+from agno.agent import Agent
+from agno.models.azure.claude import Claude
+
+agent = Agent(
+    model=Claude(
+        id="claude-sonnet-4-6",
+        max_tokens=2048,
+        thinking={"type": "enabled", "budget_tokens": 1024},
+    ),
+    markdown=True,
+)
+
+agent.print_response("Share a very scary 2 sentence horror story")
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+<Step title="Set your environment variables">
+  <CodeGroup>
+    ```bash Mac
+    export ANTHROPIC_FOUNDRY_API_KEY=xxx
+    export ANTHROPIC_FOUNDRY_RESOURCE=xxx
+    ```
+    ```bash Windows
+      setx ANTHROPIC_FOUNDRY_API_KEY xxx
+      setx ANTHROPIC_FOUNDRY_RESOURCE xxx
+    ```
+  </CodeGroup>
+</Step>
+
+<Step title="Install dependencies">```uv pip install -U anthropic agno ```</Step>
+
+<Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/azure/claude/thinking.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/cloud/azure-foundry-claude/usage/tool-use.mdx
+++ b/models/providers/cloud/azure-foundry-claude/usage/tool-use.mdx
@@ -1,0 +1,45 @@
+---
+title: Agent with Tools
+---
+
+## Code
+
+```python cookbook/90_models/azure/claude/tool_use.py
+from agno.agent import Agent
+from agno.models.azure.claude import Claude
+from agno.tools.websearch import WebSearchTools
+
+agent = Agent(
+    model=Claude(id="claude-sonnet-4-6"),
+    tools=[WebSearchTools()],
+    markdown=True,
+)
+agent.print_response("Whats happening in France?")
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+<Step title="Set your environment variables">
+  <CodeGroup>
+    ```bash Mac
+    export ANTHROPIC_FOUNDRY_API_KEY=xxx
+    export ANTHROPIC_FOUNDRY_RESOURCE=xxx
+    ```
+    ```bash Windows
+      setx ANTHROPIC_FOUNDRY_API_KEY xxx
+      setx ANTHROPIC_FOUNDRY_RESOURCE xxx
+    ```
+  </CodeGroup>
+</Step>
+
+<Step title="Install dependencies">```uv pip install -U anthropic ddgs agno ```</Step>
+
+<Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/azure/claude/tool_use.py
+    ```
+  </Step>
+</Steps>


### PR DESCRIPTION
## Description

Adds documentation for the new `AzureFoundryClaude` model provider that enables running Claude models on Azure AI Foundry infrastructure.

- Overview page with authentication, example, string syntax, and parameters table
- Usage examples: basic agent, tool use, and extended thinking
- Navigation entry under the Azure group in the sidebar

## Type of Change

- [x] New content

## Related Issues/PRs (if applicable)

- Related SDK PR: agno-agi/agno#6816

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)