### PR TITLE
docs: add SchedulerTools toolkit page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2076,6 +2076,7 @@
                           "tools/toolkits/others/replicate",
                           "tools/toolkits/others/resend",
                           "tools/toolkits/others/salesforce",
+                          "tools/toolkits/others/scheduler",
                           "tools/toolkits/others/spotify",
                           "tools/toolkits/others/shopify",
                           "tools/toolkits/others/todoist",

--- a/tools/toolkits/others/scheduler.mdx
+++ b/tools/toolkits/others/scheduler.mdx
@@ -3,7 +3,7 @@ title: Scheduler
 description: "Let agents create and manage recurring schedules through natural language."
 ---
 
-`SchedulerTools` wraps `ScheduleManager` so an agent can create, list, enable, disable, and delete cron-based schedules in response to prompts like _"Run a daily health check at 9am"_.
+`SchedulerTools` gives an agent natural-language control over the [AgentOS Scheduler](/agent-os/scheduler/overview). It wraps `ScheduleManager` so an agent can create, list, enable, disable, and delete cron-based schedules in response to prompts like _"Run a daily health check at 9am"_.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ Install the scheduler extras:
 uv pip install "agno[scheduler]"
 ```
 
-Requires a running AgentOS server with `scheduler=True` for scheduled tasks to execute.
+`SchedulerTools` persists schedules to the same database your AgentOS uses. For scheduled tasks to actually execute, run an AgentOS instance with `scheduler=True` pointed at that database. See the [Scheduler overview](/agent-os/scheduler/overview) for the AgentOS setup.
 
 ## Example
 

--- a/tools/toolkits/others/scheduler.mdx
+++ b/tools/toolkits/others/scheduler.mdx
@@ -1,0 +1,68 @@
+---
+title: Scheduler
+description: "Let agents create and manage recurring schedules through natural language."
+---
+
+`SchedulerTools` wraps `ScheduleManager` so an agent can create, list, enable, disable, and delete cron-based schedules in response to prompts like _"Run a daily health check at 9am"_.
+
+## Prerequisites
+
+Install the scheduler extras:
+
+```shell
+uv pip install "agno[scheduler]"
+```
+
+Requires a running AgentOS server with `scheduler=True` for scheduled tasks to execute.
+
+## Example
+
+```python cookbook/05_agent_os/scheduler/scheduler_tools_agent.py
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.scheduler import SchedulerTools
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[
+        SchedulerTools(
+            db=scheduler_db,
+            default_endpoint="/agents/my-agent/runs",
+        )
+    ],
+)
+
+agent.print_response("Run a health check every morning at 9am.")
+```
+
+Re-creating a schedule with the same name updates it instead of erroring (`if_exists="update"`).
+
+## Toolkit Params
+
+| Parameter          | Type                  | Default | Description                                       |
+| ------------------ | --------------------- | ------- | ------------------------------------------------- |
+| `db`               | `Any`                 | -       | Database adapter implementing scheduler methods   |
+| `default_endpoint` | `Optional[str]`       | `None`  | Default API endpoint to invoke on each run        |
+| `default_method`   | `str`                 | `"POST"`| HTTP method for scheduled requests                |
+| `default_timezone` | `str`                 | `"UTC"` | Timezone used for cron expressions                |
+| `default_payload`  | `Optional[Dict]`      | `None`  | Default request payload (e.g. `{"message": "..."}`) |
+
+## Toolkit Functions
+
+| Function            | Description                                       |
+| ------------------- | ------------------------------------------------- |
+| `create_schedule`   | Create a recurring schedule from a cron expression |
+| `list_schedules`    | List existing schedules                           |
+| `get_schedule`      | Fetch a schedule by ID                            |
+| `delete_schedule`   | Permanently remove a schedule                     |
+| `enable_schedule`   | Activate a disabled schedule                      |
+| `disable_schedule`  | Pause a schedule without deleting it              |
+| `get_schedule_runs` | Retrieve execution history for a schedule         |
+
+All functions have sync and async variants.
+
+## Developer Resources
+
+- [Tools source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/scheduler.py)
+- [Cookbook example](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/scheduler/scheduler_tools_agent.py)
+- [Scheduler overview](/agent-os/scheduler/overview)


### PR DESCRIPTION
## Summary
- Adds `tools/toolkits/others/scheduler.mdx` documenting `SchedulerTools` (params, functions, example) for [agno#7221](https://github.com/agno-agi/agno/pull/7221)
- Registers the new page in `docs.json` under the tools > others section

## Test plan
- [ ] `mintlify dev` renders the page
- [ ] `mintlify broken-links` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)