### PR TITLE
docs: fix GCS overview page 500 error

### DIFF
--- a/database/providers/gcs/overview.mdx
+++ b/database/providers/gcs/overview.mdx
@@ -39,4 +39,6 @@ agent = Agent(db=db)
 
 ## Params
 
-<Snippet file="db-gcs-params.mdx" />- see full example [here](/database/providers/gcs/usage/gcs-for-agent)
+<Snippet file="db-gcs-params.mdx" />
+
+See the full example [here](/database/providers/gcs/usage/gcs-for-agent).


### PR DESCRIPTION
## Summary
- Fixed malformed `<Snippet />` usage on `database/providers/gcs/overview.mdx:42` that broke MDX parsing and caused the page to return 500. Trailing text `- see full example [here](...)` was glued to the same line as the self-closing tag with no final newline.
- Audited all other `<Snippet />` usages across active docs — no other occurrences of this pattern.

## Test plan
- [ ] Verify `/database/providers/gcs/overview` loads in Mintlify preview
- [ ] Confirm the params snippet renders and the "full example" link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)