### PR TITLE
fix: correct cookbook broken links

### DIFF
--- a/agent-os/interfaces/ag-ui/introduction.mdx
+++ b/agent-os/interfaces/ag-ui/introduction.mdx
@@ -55,7 +55,7 @@ With Dojo running, open `http://localhost:3000` and select the Agno agent.
   </Step>
 </Steps>
 
-Additional examples are available in the [cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/06_agent_os/interfaces/agui/).
+Additional examples are available in the [cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/05_agent_os/interfaces/agui/).
 
 ## Custom Events
 


### PR DESCRIPTION
https://github.com/agno-agi/docs/issues/621

Path: /agent-os/interfaces/ag-ui/introduction

Additional examples are available in the [cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/06_agent_os/interfaces/agui/). link error the correct is:
https://github.com/agno-agi/agno/tree/main/cookbook/05_agent_os/interfaces/agui/

## Description

Describe key changes, mention related issues or motivation for the changes.

**Note:** Your PR title must follow conventional commit format (e.g., `docs: add auth guide`, `fix: correct broken links`, `style: update formatting`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

## Type of Change

- [X] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
