### PR TITLE
fix: remove Pal references and align with current demo-os version

### DIFF
--- a/demo-os/knowledge.mdx
+++ b/demo-os/knowledge.mdx
@@ -1,9 +1,9 @@
 ---
 title: Knowledge
-description: "Hybrid search with embeddings, chunking, and metadata in Pal and Dash."
+description: "Hybrid search with embeddings, chunking, and metadata in the Dash team."
 ---
 
-`Knowledge` is the retrieval primitive: a vector index with an optional keyword index and optional reranker. Pal and Dash both use it heavily.
+`Knowledge` is the retrieval primitive: a vector index with an optional keyword index and optional reranker. Dash uses it heavily for grounding text-to-SQL.
 
 ```python
 from agno.knowledge import Knowledge
@@ -33,7 +33,7 @@ Three ways to put content in:
 dash_knowledge.add_content_from_path("knowledge/tables/")
 
 # From a URL
-pal_knowledge.add_content_from_url("https://example.com/article")
+dash_knowledge.add_content_from_url("https://example.com/article")
 
 # Programmatically
 dash_knowledge.add_content(
@@ -47,7 +47,6 @@ Demo OS loads via scripts:
 
 ```bash
 python -m agents.dash.scripts.load_knowledge
-python -m agents.pal.scripts.load_knowledge
 ```
 
 Re-run with `--recreate` to rebuild from scratch. Without it, content is upserted by primary key.
@@ -134,10 +133,9 @@ The vector DB returns the top-50, the reranker scores them, and the top-10 reach
 ## See it in action
 
 ```
-@Pal what do I know about transformers?
 @Dash what's the right way to count active subscriptions?
-@Pal which articles have I ingested about RAG?
 @Dash show me a query for MRR by plan
+@Dash which tables track customer lifecycle events?
 ```
 
 Source: [`agents/dash/`](https://github.com/agno-agi/demo-os/tree/main/agents/dash), [Knowledge docs](/knowledge/overview)

--- a/demo-os/learning.mdx
+++ b/demo-os/learning.mdx
@@ -1,13 +1,12 @@
 ---
 title: Learning
-description: "LearningMachine in Pal, Dash, Contacts, and Investment."
+description: "LearningMachine in Dash, Contacts, and Investment."
 ---
 
-A useful agent gets sharper the more you use it: generic patterns at first, your conventions after a few weeks of use, eventually anticipating what you need. That compounding behavior comes from `LearningMachine`. Four agents in the demo use it.
+A useful agent gets sharper the more you use it: generic patterns at first, your conventions after a few weeks of use, eventually anticipating what you need. That compounding behavior comes from `LearningMachine`. Three demos use it.
 
 | Agent | What it learns |
 |-------|----------------|
-| [Pal](https://github.com/agno-agi/demo-os/tree/main/agents/pal) | What you've ingested, how you write, who's in your network, recurring meetings |
 | [Dash](https://github.com/agno-agi/demo-os/tree/main/agents/dash) | Schema gotchas, validated query patterns, error fixes that worked |
 | [Contacts](https://github.com/agno-agi/demo-os/tree/main/agents/contacts) | People, relationships, events, your communication preferences |
 | [Investment](https://github.com/agno-agi/demo-os/tree/main/teams/investment) | Past investment decisions, framework refinements, pattern recognition |
@@ -91,8 +90,8 @@ This is what makes the Dash team self-improving. After a few weeks of use, the s
 |-------|-------------|
 | Contacts | *"Sarah Chen joined Acme as VP Engineering last month."* → entity gets created, relationship added |
 | Contacts | *"What do I know about the Acme team?"* → entity memory query, returns people + facts + events |
+| Contacts | *"I prefer concise responses."* → user profile updated; future responses get terser |
 | Dash | First time: *"why is churn high?"* → diagnoses, saves learning. Second time: same question, faster, references the saved pattern |
-| Pal | *"I prefer concise responses."* → user profile updated; future responses get terser |
 
 Source: [`agents/contacts/`](https://github.com/agno-agi/demo-os/tree/main/agents/contacts), [`agents/dash/`](https://github.com/agno-agi/demo-os/tree/main/agents/dash), [Learning docs](/learning/overview)
 

--- a/demo-os/learning.mdx
+++ b/demo-os/learning.mdx
@@ -3,7 +3,7 @@ title: Learning
 description: "LearningMachine in Dash, Contacts, and Investment."
 ---
 
-A useful agent gets sharper the more you use it: generic patterns at first, your conventions after a few weeks of use, eventually anticipating what you need. That compounding behavior comes from `LearningMachine`. Three demos use it.
+A useful agent gets sharper the more you use it: generic patterns at first, your conventions after a few weeks of use, eventually anticipating what you need. That compounding behavior comes from `LearningMachine`. Three agents in the demo use it.
 
 | Agent | What it learns |
 |-------|----------------|

--- a/demo-os/memory.mdx
+++ b/demo-os/memory.mdx
@@ -99,7 +99,6 @@ For most agents, `enable_agentic_memory=True` is enough: a single bucket of fact
 `LearningMachine` is right when the shape of memory matters:
 
 - A relationship graph (Contacts) needs entities and edges, not flat strings.
-- A long-running personal agent (Pal) needs to separate "what I know about you" from "what I know about your domain".
 - A self-improving SQL agent (Dash) needs to separate "validated queries" from "error patterns I've fixed".
 
 When in doubt, start with `enable_agentic_memory=True` and move to `LearningMachine` once flat memory feels too lossy.

--- a/demo-os/overview.mdx
+++ b/demo-os/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "A reference AgentOS with 14 agents, 4 teams, and 5 workflows in one FastAPI service."
+description: "A reference AgentOS with 14 agents, 3 teams, and 5 workflows in one FastAPI service."
 ---
 
 The [Demo OS](https://github.com/agno-agi/demo-os) is a single AgentOS application that exercises every feature in the [Runtime](/runtime/overview) section. Use it as a working reference when building your own.
@@ -18,7 +18,7 @@ Open [os.agno.com](https://os.agno.com) → **Add OS** → **Local** → `http:/
 | Type | Count | Examples |
 |------|-------|----------|
 | Agents | 14 | Helpdesk (HITL + guardrails), Approvals (compliance), Contacts (memory), Studio (multimodal), Reasoner (reasoning + fallback) |
-| Teams | 4 | Pal (RAG), Dash (text-to-SQL), Research (4 team modes), Investment (7-agent committee) |
+| Teams | 3 | Dash (text-to-SQL), Research (4 team modes), Investment (7-agent committee) |
 | Workflows | 5 | Morning Brief, AI Research, Content Pipeline, Repo Walkthrough, Support Triage |
 
 All running inside one FastAPI service, sharing one Postgres for sessions, memory, knowledge, traces, and schedules.
@@ -29,11 +29,11 @@ Each row points at the demo agent that exercises that capability.
 
 | Capability | Demo agent | Page |
 |------------|------------|------|
-| Hybrid search RAG | Pal, Dash | [RAG](/demo-os/rag) |
+| Hybrid search RAG | Dash | [RAG](/demo-os/rag) |
 | MCP tool / context provider | MCP agent | [MCP](/demo-os/mcp) |
 | Dependency injection | Injector | [Context Providers](/demo-os/context-providers) |
-| Persistent learning across sessions | Pal, Dash, Contacts, Investment | [Learning](/demo-os/learning) |
-| Knowledge base with chunking & reranking | Pal, Dash | [Knowledge](/demo-os/knowledge) |
+| Persistent learning across sessions | Dash, Contacts, Investment | [Learning](/demo-os/learning) |
+| Knowledge base with chunking & reranking | Dash | [Knowledge](/demo-os/knowledge) |
 | Entity memory + user profile + session context | Contacts | [Memory](/demo-os/memory) |
 | Session state with agentic updates | Taskboard | [Session State](/demo-os/session-state) |
 | HITL confirmation, user input, external execution | Helpdesk, Approvals, Feedback | [Human-in-the-Loop](/demo-os/human-in-the-loop) |

--- a/demo-os/rag.mdx
+++ b/demo-os/rag.mdx
@@ -1,43 +1,17 @@
 ---
 title: RAG
-description: "Hybrid search across structured and unstructured knowledge in Pal and Dash."
+description: "Hybrid search grounding text-to-SQL in the Dash team."
 ---
 
-[Pal](https://github.com/agno-agi/demo-os/tree/main/agents/pal) and [Dash](https://github.com/agno-agi/demo-os/tree/main/agents/dash) both use retrieval to ground answers, with different content but the same underlying primitive.
+The [Dash team](https://github.com/agno-agi/demo-os/tree/main/agents/dash) uses retrieval to ground every SQL query in known patterns. Hallucinated SQL is the failure mode RAG prevents.
 
-| Agent | What it retrieves | Why retrieval |
-|-------|-------------------|---------------|
-| **Pal** | Wiki articles, meeting notes, voice guides, raw research dumps | The user's personal knowledge accumulates over time. Search beats stuffing it all in context. |
-| **Dash** | Table descriptions, validated SQL queries, business rules | The Analyst grounds every query in known patterns. Hallucinated SQL is the failure mode RAG prevents. |
-
-## Pal: knowledge that compounds
-
-Pal stores everything the user feeds it (URLs ingested, articles compiled, meetings) in a vector-indexed wiki. The Navigator agent searches it before answering:
-
-```python
-from agno.knowledge import Knowledge
-from agno.vector_db.pgvector import PgVector
-
-pal_knowledge = Knowledge(
-    vector_db=PgVector(
-        table_name="pal_knowledge",
-        db_url=DB_URL,
-        search_type="hybrid",  # semantic + keyword
-    ),
-)
-
-navigator = Agent(
-    knowledge=pal_knowledge,
-    add_knowledge_to_context=True,
-    search_knowledge=True,
-)
-```
-
-`search_type="hybrid"` runs both vector similarity and BM25 keyword search, then merges results. Catches both "what's the same idea worded differently?" (semantic) and "find the doc that mentions this exact term" (keyword).
+| What it retrieves | Why retrieval |
+|-------------------|---------------|
+| Table descriptions, validated SQL queries, business rules | The Analyst grounds every query in known patterns. Without retrieval, the model invents column names and misreads enum values. |
 
 ## Dash: SQL grounded in known patterns
 
-Dash holds three kinds of knowledge under one [`Knowledge`](https://github.com/agno-agi/demo-os/blob/main/agents/dash/knowledge/) instance:
+Dash holds three kinds of knowledge under one [`Knowledge`](https://github.com/agno-agi/demo-os/tree/main/agents/dash/knowledge) instance:
 
 | Knowledge | Purpose |
 |-----------|---------|
@@ -47,14 +21,32 @@ Dash holds three kinds of knowledge under one [`Knowledge`](https://github.com/a
 
 When a user asks "what's our MRR trend?", the Analyst retrieves matching table descriptions, similar past queries, and the MRR definition. The model writes SQL with all of that in context. Hallucination rate drops.
 
+```python
+from agno.knowledge import Knowledge
+from agno.vector_db.pgvector import PgVector
+
+dash_knowledge = Knowledge(
+    vector_db=PgVector(
+        table_name="dash_knowledge",
+        db_url=DB_URL,
+        search_type="hybrid",  # semantic + keyword
+    ),
+)
+
+analyst = Agent(
+    knowledge=dash_knowledge,
+    add_knowledge_to_context=True,
+    search_knowledge=True,
+)
+```
+
+`search_type="hybrid"` runs both vector similarity and BM25 keyword search, then merges results. Catches both "what's the same idea worded differently?" (semantic) and "find the doc that mentions this exact term" (keyword).
+
 ## Loading knowledge
 
 Knowledge content gets loaded once at boot or via a script:
 
 ```bash
-# Pal: voice guides, system docs
-python -m agents.pal.scripts.load_knowledge
-
 # Dash: table metadata, queries, business rules
 python -m agents.dash.scripts.load_knowledge
 ```
@@ -77,10 +69,9 @@ If `search_knowledge=True` is also set, the agent gets a `search_knowledge_base(
 
 | Try in chat | What happens |
 |-------------|--------------|
-| Pal: *"what do I know about RAG techniques?"* | Navigator searches the wiki, returns curated answer with citations. |
-| Pal: *"ingest https://example.com/article"* | Researcher fetches, saves to `raw/`, Compiler eventually folds into wiki. |
 | Dash: *"what's our MRR trend?"* | Analyst retrieves MRR definition + matching query, writes grounded SQL. |
 | Dash: *"why is churn so high?"* | Analyst retrieves churn definitions, finds matching query patterns, executes, interprets. |
+| Dash: *"show me revenue by plan"* | Analyst pulls table metadata for `subscriptions`, generates the aggregation. |
 
 ## When hybrid search isn't enough
 
@@ -90,9 +81,9 @@ For very large knowledge bases, add reranking. PgVector + a reranker (Cohere, BG
 from agno.vector_db.pgvector import PgVector
 from agno.rerank.cohere import CohereReranker
 
-pal_knowledge = Knowledge(
+dash_knowledge = Knowledge(
     vector_db=PgVector(
-        table_name="pal_knowledge",
+        table_name="dash_knowledge",
         db_url=DB_URL,
         search_type="hybrid",
         reranker=CohereReranker(model="rerank-3.5"),
@@ -102,7 +93,7 @@ pal_knowledge = Knowledge(
 
 Two-stage retrieval (hybrid then rerank) is the standard production setup. The hybrid stage casts a wide net (top-50), the reranker prunes to the best top-10.
 
-Source: [`agents/pal/`](https://github.com/agno-agi/demo-os/tree/main/agents/pal), [`agents/dash/`](https://github.com/agno-agi/demo-os/tree/main/agents/dash)
+Source: [`agents/dash/`](https://github.com/agno-agi/demo-os/tree/main/agents/dash)
 
 ## Next
 


### PR DESCRIPTION
## Description

 - Following up on https://github.com/agno-agi/docs/pull/623, the docs refer Pal in demo-os section but it was removed in the application. 
 - This PR brings the `/demo-os/` section back in sync with the actual application [demo-os](https://github.com/agno-agi/demo-os).

## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
