### PR TITLE
docs: align workbench example with README

### DIFF
--- a/first-agent.mdx
+++ b/first-agent.mdx
@@ -33,7 +33,7 @@ agent_os = AgentOS(agents=[workbench], tracing=True, db=SqliteDb(db_file="agno.d
 app = agent_os.get_app()
 ```
 
-`Workspace(".")` scopes the agent to the current directory. `read`, `list`, and `search` run freely; `write`, `edit`, `move`, `delete`, and `shell` require human approval.
+`Workspace(".")` scopes the agent to the current directory. `read`, `list`, and `search` run freely; `write`, `edit`, `delete`, and `shell` require human approval.
 
 ## 2. Run Your AgentOS
 
@@ -122,7 +122,7 @@ Use it to test, monitor, and manage your agents in real time.
 
 The agent reads your workspace and answers grounded in what it actually finds.
 
-Try a follow-up like "summarize the README" or "create a NOTES.md with three bullet takeaways". The second one will pause for your approval before the file is written, since `write_file` is a confirm-required tool by default.
+Try a follow-up like "summarize the README" or "create a NOTES.md with three bullet takeaways". The second one will pause for your approval before the file is written, since `write` is in the confirm list.
 
 Click Sessions or Traces in the sidebar to inspect stored conversations.
 

--- a/index.mdx
+++ b/index.mdx
@@ -21,24 +21,27 @@ Agno has a 3-layer architecture. Everything except the control plane is free and
 <CodeGroup>
 
 ```python Agno SDK
-from agno.os import AgentOS
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
 from agno.tools.workspace import Workspace
 
-agent = Agent(
-    name="Agno Agent",
+workbench = Agent(
+    name="Workbench",
     model="openai:gpt-5.4",
     tools=[Workspace(".",
         allowed=["read", "list", "search"],
         confirm=["write", "edit", "delete", "shell"],
     )],
+    enable_agentic_memory=True,
+    add_history_to_context=True,
+    num_history_runs=3,
 )
 
 agent_os = AgentOS(
-    agents=[agent],
+    agents=[workbench],
     tracing=True,
-    db=SqliteDb(db_file="tmp/agentos.db"),
+    db=SqliteDb(db_file="agno.db"),
 )
 app = agent_os.get_app()
 ```


### PR DESCRIPTION
## Summary

Tightens the workbench example so it reads identically across the README, [index.mdx](index.mdx), and [first-agent.mdx](first-agent.mdx). Fixes two stale references to the old Workspace tool API.

- **first-agent.mdx**: dropped `move` from the prose under the code example (the code example only lists `write/edit/delete/shell`, matching the README), and replaced `write_file` with `write` (the alias name in the new `allowed`/`confirm` model).
- **index.mdx Agno SDK tab**: renamed `Agno Agent` → `Workbench`, added `enable_agentic_memory` / `add_history_to_context` / `num_history_runs`, and switched the SQLite path to `agno.db` so the example matches the README and first-agent.mdx verbatim.

## What I checked but did not change

- README points to `/tutorials/starter/overview`. Already handled by existing redirects in `docs.json` to `/tutorials/agent-platform/overview`. No change needed.
- "20 lines of code" wording in `index.mdx` and `first-agent.mdx` is accurate. README's "30 lines" is the outlier; that lives in the agno repo and is out of scope here.

## Test plan
- [ ] `mint dev` and click through `/` and `/first-agent` to confirm the Agno SDK tab now shows the Workbench example
- [ ] `mint broken-links` clean
- [ ] `mint build` clean