### PR TITLE
Add GeminiInteractions (Interactions API) docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1188,6 +1188,18 @@
                                   "models/providers/native/google/usage/video-input-file-upload",
                                   "models/providers/native/google/usage/video-input-local-file-upload"
                                 ]
+                              },
+                              "models/providers/native/google/gemini-interactions",
+                              {
+                                "group": "Interactions Usage",
+                                "pages": [
+                                  "models/providers/native/google/usage/interactions-basic",
+                                  "models/providers/native/google/usage/interactions-tool-use",
+                                  "models/providers/native/google/usage/interactions-multi-turn",
+                                  "models/providers/native/google/usage/interactions-thinking",
+                                  "models/providers/native/google/usage/interactions-search",
+                                  "models/providers/native/google/usage/interactions-structured-output"
+                                ]
                               }
                             ]
                           },
@@ -2956,6 +2968,18 @@
                               "models/providers/native/google/usage/video-input-bytes-content",
                               "models/providers/native/google/usage/video-input-file-upload",
                               "models/providers/native/google/usage/video-input-local-file-upload"
+                            ]
+                          },
+                          "models/providers/native/google/gemini-interactions",
+                          {
+                            "group": "Interactions Usage",
+                            "pages": [
+                              "models/providers/native/google/usage/interactions-basic",
+                              "models/providers/native/google/usage/interactions-tool-use",
+                              "models/providers/native/google/usage/interactions-multi-turn",
+                              "models/providers/native/google/usage/interactions-thinking",
+                              "models/providers/native/google/usage/interactions-search",
+                              "models/providers/native/google/usage/interactions-structured-output"
                             ]
                           }
                         ]

--- a/models/compatibility.mdx
+++ b/models/compatibility.mdx
@@ -55,6 +55,7 @@ Vercel V0 doesn't support native structured output, but does support `use_json_m
 | DeepSeek              |             |             |                 |             |             |
 | Fireworks             |             |             |                 |             |             |
 | Gemini                |     ✅      |     ✅      |                 |     ✅      |     ✅      |
+| GeminiInteractions    |     ✅      |     ✅      |                 |     ✅      |     ✅      |
 | Groq                  |     ✅      |             |                 |             |             |
 | HuggingFace           |     ✅      |             |                 |             |             |
 | IBM WatsonX           |     ✅      |             |                 |             |             |

--- a/models/providers/native/google/gemini-interactions.mdx
+++ b/models/providers/native/google/gemini-interactions.mdx
@@ -1,0 +1,257 @@
+---
+title: Gemini Interactions
+sidebarTitle: Interactions API
+description: Use Google's Interactions API for server-side conversation history, implicit caching, and background execution.
+---
+
+The Interactions API is an alternative to Gemini's `generateContent` endpoint. Instead of sending the full conversation history on every turn, it stores prior turns server-side and references them via `previous_interaction_id`. This reduces token costs and latency through implicit caching.
+
+See the [Interactions API documentation](https://ai.google.dev/gemini-api/docs/interactions) for more details.
+
+<Warning>
+The Interactions API is experimental and may change in future versions. You will see the following warning when using it:
+
+```
+UserWarning: Interactions usage is experimental and may change in future versions.
+```
+
+Requires `google-genai>=1.55.0`.
+</Warning>
+
+## Installation
+
+```bash
+uv pip install "google-genai>=1.55.0" agno
+```
+
+## Authentication
+
+`GeminiInteractions` uses the same authentication as the `Gemini` class. Set the `GOOGLE_API_KEY` environment variable or configure Vertex AI credentials.
+
+<CodeGroup>
+
+```bash Mac
+export GOOGLE_API_KEY=***
+```
+
+```bash Windows
+setx GOOGLE_API_KEY ***
+```
+
+</CodeGroup>
+
+For Vertex AI setup, see the [Vertex AI guide](/models/providers/native/google/usage/vertexai).
+
+## Example
+
+```python
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(id="gemini-2.5-flash"),
+    markdown=True,
+)
+
+agent.print_response("Share a 2 sentence horror story.")
+```
+
+<Note>View more examples [here](/models/providers/native/google/usage/interactions-basic).</Note>
+
+## How It Works
+
+1. On the first turn, the agent sends the user message and receives a response along with an `interaction_id`.
+2. On subsequent turns, only the new message is sent with `previous_interaction_id` referencing the prior turn.
+3. The server reconstructs the full context from stored history, applying implicit caching to reduce cost.
+
+This is transparent to the user. The `Agent` class handles `interaction_id` tracking automatically.
+
+## Capabilities
+
+<CardGroup cols={3}>
+  <Card title="Multi-turn" icon="messages" href="#multi-turn-conversations">
+    Server-side history management
+  </Card>
+  <Card title="Thinking" icon="brain" href="#thinking">
+    Reasoning with thinking levels
+  </Card>
+  <Card title="Google Search" icon="magnifying-glass" href="#google-search">
+    Built-in web search
+  </Card>
+  <Card title="Tool Use" icon="wrench" href="#tool-use">
+    Function calling
+  </Card>
+  <Card title="Structured Output" icon="brackets-curly" href="#structured-output">
+    Pydantic schema enforcement
+  </Card>
+  <Card title="Background Execution" icon="clock" href="#background-execution">
+    Long-running tasks
+  </Card>
+</CardGroup>
+
+## Multi-turn Conversations
+
+The key advantage of the Interactions API. Prior turns are stored server-side and referenced by ID, so only the new message is sent each turn.
+
+```python
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(id="gemini-2.5-flash"),
+    add_history_to_context=True,
+    markdown=True,
+)
+
+agent.print_response("My name is Alice and I love hiking in the mountains.")
+agent.print_response("What did I just tell you about myself?")
+agent.print_response("Suggest a hiking destination based on what you know about me.")
+```
+
+Read more about multi-turn conversations [here](/models/providers/native/google/usage/interactions-multi-turn).
+
+## Thinking
+
+Enable extended reasoning with the `thinking_level` parameter. Accepts `"low"` or `"high"`.
+
+```python
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        id="gemini-2.5-flash",
+        thinking_level="high",
+    ),
+    markdown=True,
+)
+
+agent.print_response("Explain why the sum of angles in a triangle is always 180 degrees.")
+```
+
+Read more about thinking [here](/models/providers/native/google/usage/interactions-thinking).
+
+## Google Search
+
+Enable built-in Google Search by setting `search=True`. No external tool needed.
+
+```python
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        id="gemini-2.5-flash",
+        search=True,
+    ),
+    markdown=True,
+)
+
+agent.print_response("What are the latest developments in quantum computing?")
+```
+
+Read more about Google Search [here](/models/providers/native/google/usage/interactions-search).
+
+## Tool Use
+
+Function calling works the same as with the `Gemini` class.
+
+```python
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+from agno.tools.websearch import WebSearchTools
+
+agent = Agent(
+    model=GeminiInteractions(id="gemini-2.5-flash"),
+    tools=[WebSearchTools()],
+    markdown=True,
+)
+
+agent.print_response("Whats happening in France?")
+```
+
+Read more about tool use [here](/models/providers/native/google/usage/interactions-tool-use).
+
+## Structured Output
+
+Use Pydantic models to enforce a JSON schema on the response.
+
+```python
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+from pydantic import BaseModel, Field
+
+class MovieReview(BaseModel):
+    title: str = Field(description="The movie title")
+    year: int = Field(description="Release year")
+    genre: str = Field(description="Primary genre")
+    rating: float = Field(description="Rating out of 10")
+    summary: str = Field(description="Brief review summary")
+
+agent = Agent(
+    model=GeminiInteractions(id="gemini-2.5-flash"),
+    output_schema=MovieReview,
+)
+
+response = agent.run("Write a review of The Matrix (1999)")
+```
+
+Read more about structured output [here](/models/providers/native/google/usage/interactions-structured-output).
+
+## Background Execution
+
+For long-running tasks like Deep Research, enable background execution. The API offloads the task and returns results when complete.
+
+```python
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        id="gemini-2.5-flash",
+        background=True,
+    ),
+    markdown=True,
+)
+
+agent.print_response("Research the history of quantum computing.")
+```
+
+## Interactions API vs generateContent
+
+| Feature | GeminiInteractions | Gemini |
+|---------|-------------------|--------|
+| Conversation history | Server-side, referenced by ID | Client-side, resent each turn |
+| Caching | Implicit on prior turns | Manual via context caching API |
+| Token cost on multi-turn | Lower (only new message sent) | Higher (full history resent) |
+| Background execution | Supported | Not supported |
+| Response format | Typed execution steps | Generic content parts |
+
+## Params
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `id` | `str` | `"gemini-3-flash-preview"` | The model identifier |
+| `name` | `str` | `"GeminiInteractions"` | The name of the model |
+| `provider` | `str` | `"Google"` | The provider of the model |
+| `api_key` | `Optional[str]` | `None` | Google API key (defaults to `GOOGLE_API_KEY` env var) |
+| `vertexai` | `bool` | `False` | Use Vertex AI instead of AI Studio |
+| `project_id` | `Optional[str]` | `None` | Google Cloud project ID for Vertex AI |
+| `location` | `Optional[str]` | `None` | Google Cloud region for Vertex AI |
+| `temperature` | `Optional[float]` | `None` | Controls randomness (0.0-2.0) |
+| `top_p` | `Optional[float]` | `None` | Nucleus sampling threshold |
+| `max_output_tokens` | `Optional[int]` | `None` | Maximum tokens in response |
+| `stop_sequences` | `Optional[list[str]]` | `None` | Sequences that stop generation |
+| `seed` | `Optional[int]` | `None` | Random seed for reproducibility |
+| `response_modalities` | `Optional[list[str]]` | `None` | Output types (e.g., `["text", "image"]`) |
+| `store` | `Optional[bool]` | `None` | Persist interactions server-side (default: True) |
+| `background` | `Optional[bool]` | `None` | Offload to background execution |
+| `thinking_level` | `Optional[str]` | `None` | Reasoning intensity: `"low"` or `"high"` |
+| `search` | `bool` | `False` | Enable built-in Google Search |
+| `url_context` | `bool` | `False` | Enable URL context extraction |
+| `code_execution` | `bool` | `False` | Enable code execution |
+| `service_tier` | `Optional[str]` | `None` | Inference tier: `"flex"`, `"standard"`, or `"priority"` |
+| `timeout` | `Optional[float]` | `None` | Request timeout in seconds |
+| `client_params` | `Optional[Dict[str, Any]]` | `None` | Additional client parameters |
+
+`GeminiInteractions` is a subclass of the [Model](/reference/models/model) class and has access to the same params.

--- a/models/providers/native/google/gemini-interactions.mdx
+++ b/models/providers/native/google/gemini-interactions.mdx
@@ -15,13 +15,13 @@ The Interactions API is experimental and may change in future versions. You will
 UserWarning: Interactions usage is experimental and may change in future versions.
 ```
 
-Requires `google-genai>=1.55.0`.
+Requires `google-genai>=2.0`.
 </Warning>
 
 ## Installation
 
 ```bash
-uv pip install "google-genai>=1.55.0" agno
+uv pip install "google-genai>=2.0" agno
 ```
 
 ## Authentication

--- a/models/providers/native/google/gemini-interactions.mdx
+++ b/models/providers/native/google/gemini-interactions.mdx
@@ -26,7 +26,7 @@ uv pip install "google-genai>=2.0" agno
 
 ## Authentication
 
-`GeminiInteractions` uses the same authentication as the `Gemini` class. Set the `GOOGLE_API_KEY` environment variable or configure Vertex AI credentials.
+Set the `GOOGLE_API_KEY` environment variable. You can get one [from Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key).
 
 <CodeGroup>
 
@@ -39,8 +39,6 @@ setx GOOGLE_API_KEY ***
 ```
 
 </CodeGroup>
-
-For Vertex AI setup, see the [Vertex AI guide](/models/providers/native/google/usage/vertexai).
 
 ## Example
 
@@ -235,9 +233,6 @@ agent.print_response("Research the history of quantum computing.")
 | `name` | `str` | `"GeminiInteractions"` | The name of the model |
 | `provider` | `str` | `"Google"` | The provider of the model |
 | `api_key` | `Optional[str]` | `None` | Google API key (defaults to `GOOGLE_API_KEY` env var) |
-| `vertexai` | `bool` | `False` | Use Vertex AI instead of AI Studio |
-| `project_id` | `Optional[str]` | `None` | Google Cloud project ID for Vertex AI |
-| `location` | `Optional[str]` | `None` | Google Cloud region for Vertex AI |
 | `temperature` | `Optional[float]` | `None` | Controls randomness (0.0-2.0) |
 | `top_p` | `Optional[float]` | `None` | Nucleus sampling threshold |
 | `max_output_tokens` | `Optional[int]` | `None` | Maximum tokens in response |

--- a/models/providers/native/google/gemini-interactions.mdx
+++ b/models/providers/native/google/gemini-interactions.mdx
@@ -49,7 +49,7 @@ from agno.agent import Agent
 from agno.models.google import GeminiInteractions
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-2.5-flash"),
+    model=GeminiInteractions(id="gemini-3-flash-preview"),
     markdown=True,
 )
 
@@ -98,7 +98,7 @@ from agno.agent import Agent
 from agno.models.google import GeminiInteractions
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-2.5-flash"),
+    model=GeminiInteractions(id="gemini-3-flash-preview"),
     add_history_to_context=True,
     markdown=True,
 )
@@ -120,7 +120,7 @@ from agno.models.google import GeminiInteractions
 
 agent = Agent(
     model=GeminiInteractions(
-        id="gemini-2.5-flash",
+        id="gemini-3-flash-preview",
         thinking_level="high",
     ),
     markdown=True,
@@ -141,7 +141,7 @@ from agno.models.google import GeminiInteractions
 
 agent = Agent(
     model=GeminiInteractions(
-        id="gemini-2.5-flash",
+        id="gemini-3-flash-preview",
         search=True,
     ),
     markdown=True,
@@ -162,7 +162,7 @@ from agno.models.google import GeminiInteractions
 from agno.tools.websearch import WebSearchTools
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-2.5-flash"),
+    model=GeminiInteractions(id="gemini-3-flash-preview"),
     tools=[WebSearchTools()],
     markdown=True,
 )
@@ -189,7 +189,7 @@ class MovieReview(BaseModel):
     summary: str = Field(description="Brief review summary")
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-2.5-flash"),
+    model=GeminiInteractions(id="gemini-3-flash-preview"),
     output_schema=MovieReview,
 )
 
@@ -208,7 +208,7 @@ from agno.models.google import GeminiInteractions
 
 agent = Agent(
     model=GeminiInteractions(
-        id="gemini-2.5-flash",
+        id="gemini-3-flash-preview",
         background=True,
     ),
     markdown=True,

--- a/models/providers/native/google/usage/interactions-basic.mdx
+++ b/models/providers/native/google/usage/interactions-basic.mdx
@@ -1,0 +1,54 @@
+---
+title: Basic Agent (Interactions)
+---
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/basic.py
+import asyncio
+
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    # --- Sync ---
+    agent.print_response("Share a 2 sentence horror story")
+
+    # --- Sync + Streaming ---
+    agent.print_response("Share a 2 sentence horror story", stream=True)
+
+    # --- Async ---
+    asyncio.run(agent.aprint_response("Share a 2 sentence horror story"))
+
+    # --- Async + Streaming ---
+    asyncio.run(agent.aprint_response("Share a 2 sentence horror story", stream=True))
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=1.55.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/basic.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-basic.mdx
+++ b/models/providers/native/google/usage/interactions-basic.mdx
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U "google-genai>=1.55.0" agno
+    uv pip install -U "google-genai>=2.0" agno
     ```
   </Step>
 

--- a/models/providers/native/google/usage/interactions-multi-turn.mdx
+++ b/models/providers/native/google/usage/interactions-multi-turn.mdx
@@ -1,0 +1,54 @@
+---
+title: Multi-turn Conversation (Interactions)
+---
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/multi_turn.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    add_history_to_context=True,
+    db=SqliteDb(db_file="tmp/data.db"),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    # First turn - establishes the interaction
+    agent.print_response("My name is Alice and I love hiking in the mountains.")
+
+    # Second turn - references the previous interaction for context
+    agent.print_response("What did I just tell you about myself?")
+
+    # Third turn - continues the conversation chain
+    agent.print_response(
+        "Suggest a hiking destination based on what you know about me."
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=1.55.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/multi_turn.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-multi-turn.mdx
+++ b/models/providers/native/google/usage/interactions-multi-turn.mdx
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U "google-genai>=1.55.0" agno
+    uv pip install -U "google-genai>=2.0" agno
     ```
   </Step>
 

--- a/models/providers/native/google/usage/interactions-search.mdx
+++ b/models/providers/native/google/usage/interactions-search.mdx
@@ -1,0 +1,51 @@
+---
+title: Google Search (Interactions)
+---
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/search.py
+import asyncio
+
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        id="gemini-3-flash-preview",
+        search=True,
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response("What are the latest developments in quantum computing?")
+
+    asyncio.run(
+        agent.aprint_response("What are the top news stories today?", stream=True)
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=1.55.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/search.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-search.mdx
+++ b/models/providers/native/google/usage/interactions-search.mdx
@@ -39,7 +39,7 @@ if __name__ == "__main__":
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U "google-genai>=1.55.0" agno
+    uv pip install -U "google-genai>=2.0" agno
     ```
   </Step>
 

--- a/models/providers/native/google/usage/interactions-structured-output.mdx
+++ b/models/providers/native/google/usage/interactions-structured-output.mdx
@@ -1,0 +1,64 @@
+---
+title: Structured Output (Interactions)
+---
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/structured_output.py
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+from pydantic import BaseModel, Field
+
+
+class MovieReview(BaseModel):
+    title: str = Field(description="The movie title")
+    year: int = Field(description="Release year")
+    genre: str = Field(description="Primary genre")
+    rating: float = Field(description="Rating out of 10")
+    summary: str = Field(description="Brief review summary")
+
+
+agent = Agent(
+    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    output_schema=MovieReview,
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    response = agent.run("Write a review of The Matrix (1999)")
+
+    if response.content:
+        review = response.content
+        if isinstance(review, MovieReview):
+            print(f"Title: {review.title}")
+            print(f"Year: {review.year}")
+            print(f"Genre: {review.genre}")
+            print(f"Rating: {review.rating}/10")
+            print(f"Summary: {review.summary}")
+        else:
+            print(f"Raw response: {review}")
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=1.55.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/structured_output.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-structured-output.mdx
+++ b/models/providers/native/google/usage/interactions-structured-output.mdx
@@ -52,7 +52,7 @@ if __name__ == "__main__":
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U "google-genai>=1.55.0" agno
+    uv pip install -U "google-genai>=2.0" agno
     ```
   </Step>
 

--- a/models/providers/native/google/usage/interactions-thinking.mdx
+++ b/models/providers/native/google/usage/interactions-thinking.mdx
@@ -1,0 +1,56 @@
+---
+title: Thinking (Interactions)
+---
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/thinking.py
+import asyncio
+
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        id="gemini-3-flash-preview",
+        thinking_level="high",
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Solve: If a train travels at 60 mph for 2.5 hours, then at 80 mph for 1.5 hours, what is the total distance and average speed?"
+    )
+
+    asyncio.run(
+        agent.aprint_response(
+            "Explain why the sum of angles in a triangle is always 180 degrees.",
+            stream=True,
+        )
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=1.55.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/thinking.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-thinking.mdx
+++ b/models/providers/native/google/usage/interactions-thinking.mdx
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U "google-genai>=1.55.0" agno
+    uv pip install -U "google-genai>=2.0" agno
     ```
   </Step>
 

--- a/models/providers/native/google/usage/interactions-tool-use.mdx
+++ b/models/providers/native/google/usage/interactions-tool-use.mdx
@@ -1,0 +1,50 @@
+---
+title: Agent with Tools (Interactions)
+---
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/tool_use.py
+import asyncio
+
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+from agno.tools.websearch import WebSearchTools
+
+agent = Agent(
+    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    tools=[WebSearchTools()],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response("Whats happening in France?")
+
+    agent.print_response("Whats happening in France?", stream=True)
+
+    asyncio.run(agent.aprint_response("Whats happening in France?", stream=True))
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=1.55.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/tool_use.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-tool-use.mdx
+++ b/models/providers/native/google/usage/interactions-tool-use.mdx
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
   <Step title="Install dependencies">
     ```bash
-    uv pip install -U "google-genai>=1.55.0" agno
+    uv pip install -U "google-genai>=2.0" agno
     ```
   </Step>
 


### PR DESCRIPTION
## Summary

- Adds overview page for the new `GeminiInteractions` model class that uses Google's experimental Interactions API
- Adds 6 usage example pages: basic, tool use, multi-turn, thinking, search, structured output
- Updates `docs.json` navigation in both sidebar locations
- Includes experimental API warning with the `UserWarning` message users will see

Corresponding SDK PR: https://github.com/agno-agi/agno/pull/7926

## Test plan

- [ ] Verify `mint dev` renders the new pages correctly
- [ ] Confirm all internal links resolve
- [ ] Check navigation shows "Interactions API" under the Google group

🤖 Generated with [Claude Code](https://claude.com/claude-code)