### PR TITLE
fix: Add A2A task endpoints and deprecate generic API

### DIFF
--- a/agent-os/interfaces/a2a/introduction.mdx
+++ b/agent-os/interfaces/a2a/introduction.mdx
@@ -75,8 +75,14 @@ For each available agent, team and workflow, the following A2A-compatible endpoi
   See [API reference](/reference-api/schema/a2a/stream-message-agent) and [A2A protocol docs](https://a2a-protocol.org/v0.3.0/specification/#356-method-mapping-reference-table).
 
 - `/a2a/agents/{id}/v1/message:send`:
-  Runs the agen, returning the response in A2A format (non-streaming).
+  Runs the agent, returning the response in A2A format (non-streaming).
   See [A2A protocol docs](https://a2a-protocol.org/v0.3.0/specification/#356-method-mapping-reference-table).
+
+- `/a2a/agents/{id}/v1/tasks:get`:
+  Retrieves task status by ID. See [API reference](/reference-api/schema/a2a/get-agent-task).
+
+- `/a2a/agents/{id}/v1/tasks:cancel`:
+  Cancels a running task. See [API reference](/reference-api/schema/a2a/cancel-agent-task).
 
 
 ### Teams
@@ -89,6 +95,12 @@ For each available agent, team and workflow, the following A2A-compatible endpoi
 
 - `/a2a/teams/{id}/v1/message:send`:
   Runs the team, returning the response in A2A format (non-streaming). See [API reference](/reference-api/schema/a2a/run-message-agent).
+
+- `/a2a/teams/{id}/v1/tasks:get`:
+  Retrieves task status by ID. See [API reference](/reference-api/schema/a2a/get-team-task).
+
+- `/a2a/teams/{id}/v1/tasks:cancel`:
+  Cancels a running task. See [API reference](/reference-api/schema/a2a/cancel-team-task).
 
 ### Workflows
 

--- a/reference-api/schema/a2a/send-message.mdx
+++ b/reference-api/schema/a2a/send-message.mdx
@@ -1,3 +1,9 @@
 ---
 openapi: post /a2a/message/send
 ---
+
+<Warning>
+This generic endpoint is deprecated. Use the per-resource endpoints instead:
+`/a2a/agents/{id}/v1/message:send`, `/a2a/teams/{id}/v1/message:send`, or
+`/a2a/workflows/{id}/v1/message:send`.
+</Warning>

--- a/reference-api/schema/a2a/stream-message.mdx
+++ b/reference-api/schema/a2a/stream-message.mdx
@@ -1,3 +1,9 @@
 ---
 openapi: post /a2a/message/stream
 ---
+
+<Warning>
+This generic endpoint is deprecated. Use the per-resource endpoints instead:
+`/a2a/agents/{id}/v1/message:stream`, `/a2a/teams/{id}/v1/message:stream`, or
+`/a2a/workflows/{id}/v1/message:stream`.
+</Warning>

--- a/reference/clients/a2a-client.mdx
+++ b/reference/clients/a2a-client.mdx
@@ -86,6 +86,7 @@ print(f"Context ID: {result.context_id}")
 | `videos` | `Optional[List[Video]]` | `None` | Videos to include |
 | `files` | `Optional[List[File]]` | `None` | Files to include |
 | `metadata` | `Optional[Dict[str, Any]]` | `None` | Additional metadata |
+| `headers` | `Optional[Dict[str, str]]` | `None` | Extra HTTP headers to send with the request |
 
 **Returns:** `TaskResult`
 
@@ -129,6 +130,12 @@ if card:
     print(f"Capabilities: {card.capabilities}")
 ```
 
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `headers` | `Optional[Dict[str, str]]` | `None` | Extra HTTP headers to send with the request |
+
 **Returns:** `AgentCard` if available, `None` otherwise
 
 ---
@@ -143,6 +150,12 @@ if card:
     print(f"Description: {card.description}")
     print(f"Capabilities: {card.capabilities}")
 ```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `headers` | `Optional[Dict[str, str]]` | `None` | Extra HTTP headers to send with the request |
 
 **Returns:** `AgentCard` if available, `None` otherwise
 


### PR DESCRIPTION


## Description
Document new per-resource task endpoints and mark generic message endpoints as deprecated. Added /a2a/{agents,teams}/{id}/v1/tasks:get and /tasks:cancel references in the A2A introduction, added deprecation warnings to the generic /a2a/message/send and /a2a/message/stream reference pages, and updated the A2A client docs to include an optional `headers` parameter for requests and agent card retrieval.

**Note:** Your PR title must follow conventional commit format (e.g., `docs: add auth guide`, `fix: correct broken links`, `style: update formatting`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
