### PR TITLE
docs: add LLMs.txt reader page and allowed_hosts notes

### DIFF
--- a/_snippets/docling-reader-reference.mdx
+++ b/_snippets/docling-reader-reference.mdx
@@ -4,3 +4,4 @@
 | `converter` | `Optional[DocumentConverter]` | `None` | Custom Docling converter configuration |
 | `format_options` | `Optional[dict]` | `None` | Format options dictionary for DocumentConverter |
 | `chunking_strategy` | `Optional[ChunkingStrategy]` | `DocumentChunking()` | Strategy for chunking the document |
+| `allowed_hosts` | `Optional[List[str]]` | `None` | Hostnames the reader is allowed to fetch from. See [Restricting URL Fetches](/knowledge/concepts/readers/overview#restricting-url-fetches). |

--- a/_snippets/firecrawl-reader-reference.mdx
+++ b/_snippets/firecrawl-reader-reference.mdx
@@ -4,3 +4,4 @@
 | `params` | `Optional[Dict]` | `None` | Additional parameters to pass to the Firecrawl API |
 | `mode` | `Literal["scrape", "crawl"]` | `"scrape"` | Mode of operation - "scrape" for single page, "crawl" for multiple pages |
 | `url` | `str` | Required | URL of the website to scrape or crawl |
+| `allowed_hosts` | `Optional[List[str]]` | `None` | Hostnames the reader is allowed to fetch from. See [Restricting URL Fetches](/knowledge/concepts/readers/overview#restricting-url-fetches). |

--- a/_snippets/llms-txt-reader-reference.mdx
+++ b/_snippets/llms-txt-reader-reference.mdx
@@ -1,0 +1,9 @@
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `url` | `str` | Required | URL of the `llms.txt` file to read |
+| `max_urls` | `int` | `20` | Maximum number of linked URLs to fetch from the file |
+| `timeout` | `int` | `60` | HTTP timeout in seconds |
+| `proxy` | `Optional[str]` | `None` | Optional HTTP proxy URL |
+| `skip_optional` | `bool` | `False` | Skip entries under the `## Optional` section |
+| `chunking_strategy` | `Optional[ChunkingStrategy]` | `FixedSizeChunking()` | Strategy for chunking content |
+| `allowed_hosts` | `Optional[List[str]]` | `None` | Hostnames the reader is allowed to fetch from. See [Restricting URL Fetches](/knowledge/concepts/readers/overview#restricting-url-fetches). |

--- a/_snippets/web-search-reader-reference.mdx
+++ b/_snippets/web-search-reader-reference.mdx
@@ -11,3 +11,4 @@
 | `rate_limit_delay` | `float` | `5.0` | Delay when rate limited in seconds |
 | `exponential_backoff` | `bool` | `True` | Whether to use exponential backoff for retries |
 | `chunking_strategy` | `Optional[ChunkingStrategy]` | `SemanticChunking()` | Strategy for chunking content |
+| `allowed_hosts` | `Optional[List[str]]` | `None` | Hostnames the reader is allowed to fetch from. See [Restricting URL Fetches](/knowledge/concepts/readers/overview#restricting-url-fetches). |

--- a/_snippets/website-reader-reference.mdx
+++ b/_snippets/website-reader-reference.mdx
@@ -3,3 +3,4 @@
 | `url` | `str` | Required | URL of the website to crawl and read |
 | `max_depth` | `int` | `3` | Maximum depth level for crawling links |
 | `max_links` | `int` | `10` | Maximum number of links to crawl |
+| `allowed_hosts` | `Optional[List[str]]` | `None` | Hostnames the reader is allowed to fetch from. See [Restricting URL Fetches](/knowledge/concepts/readers/overview#restricting-url-fetches). |

--- a/docs.json
+++ b/docs.json
@@ -743,6 +743,7 @@
                           "knowledge/concepts/readers/json-reader",
                           "knowledge/concepts/readers/markdown-reader",
                           "knowledge/concepts/readers/website-reader",
+                          "knowledge/concepts/readers/llms-txt-reader",
                           "knowledge/concepts/readers/youtube-reader"
                         ]
                       },

--- a/knowledge/concepts/readers/llms-txt-reader.mdx
+++ b/knowledge/concepts/readers/llms-txt-reader.mdx
@@ -52,15 +52,9 @@ agent.print_response("What is Agno?", markdown=True)
   <Snippet file="run-pgvector-step.mdx" />
 
   <Step title="Run Agent">
-    <CodeGroup>
-    ```bash Mac
+    ```bash
     python examples/basics/knowledge/concepts/readers/overview/llms_txt_reader.py
     ```
-
-    ```bash Windows
-    python examples/basics/knowledge/concepts/readers/overview/llms_txt_reader.py
-    ```
-    </CodeGroup>
   </Step>
 </Steps>
 

--- a/knowledge/concepts/readers/llms-txt-reader.mdx
+++ b/knowledge/concepts/readers/llms-txt-reader.mdx
@@ -1,0 +1,69 @@
+---
+title: LLMs.txt Reader
+---
+
+The **LLMs.txt Reader** reads an [llms.txt](https://llmstxt.org) file, follows the linked documentation pages, and turns them into documents for your knowledge base.
+
+## Code
+
+```python examples/basics/knowledge/concepts/readers/overview/llms_txt_reader.py
+from agno.agent import Agent
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.llms_txt_reader import LLMsTxtReader
+from agno.vectordb.pgvector import PgVector
+
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+knowledge = Knowledge(
+    name="LLMs.txt Docs",
+    vector_db=PgVector(table_name="llms_txt_docs", db_url=db_url),
+)
+
+knowledge.insert(
+    url="https://docs.agno.com/llms.txt",
+    reader=LLMsTxtReader(max_urls=10),
+)
+
+agent = Agent(
+    knowledge=knowledge,
+    search_knowledge=True,
+)
+
+agent.print_response("What is Agno?", markdown=True)
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U beautifulsoup4 sqlalchemy psycopg pgvector agno openai
+    ```
+  </Step>
+
+  <Step title="Set environment variables">
+    ```bash
+    export OPENAI_API_KEY=xxx
+    ```
+  </Step>
+
+  <Snippet file="run-pgvector-step.mdx" />
+
+  <Step title="Run Agent">
+    <CodeGroup>
+    ```bash Mac
+    python examples/basics/knowledge/concepts/readers/overview/llms_txt_reader.py
+    ```
+
+    ```bash Windows
+    python examples/basics/knowledge/concepts/readers/overview/llms_txt_reader.py
+    ```
+    </CodeGroup>
+  </Step>
+</Steps>
+
+## Params
+
+<Snippet file="llms-txt-reader-reference.mdx" />

--- a/knowledge/concepts/readers/overview.mdx
+++ b/knowledge/concepts/readers/overview.mdx
@@ -156,11 +156,15 @@ See [Chunking](/knowledge/concepts/chunking/overview) for available strategies.
 
 ## Restricting URL Fetches
 
-Pass `allowed_hosts` to a URL-fetching reader to limit which hostnames it will fetch from. URLs outside the list are skipped and return no documents. Each hostname must match exactly, so include every subdomain you want to permit.
+By default, URL-fetching readers will fetch any reachable URL. When a reader is wired up to accept URLs from untrusted input — for example an endpoint that takes a user-supplied link — an attacker-influenced URL can reach internal services or cloud metadata endpoints.
+
+Pass `allowed_hosts` to lock the reader to an explicit hostname allowlist. URLs outside the list are skipped and return no documents. Each hostname must match exactly, so include every subdomain you want to permit.
 
 ```python
 reader = WebsiteReader(allowed_hosts=["docs.agno.com"])
 ```
+
+For `WebsiteReader`, `WebSearchReader`, and `LLMsTxtReader`, every redirect hop is re-validated against the same allowlist, so a permitted host cannot 3xx-bounce the request to a disallowed one. `FirecrawlReader` and `DoclingReader` validate the initial URL only; redirects in those paths are handled by the underlying library.
 
 ## Error Handling
 

--- a/knowledge/concepts/readers/overview.mdx
+++ b/knowledge/concepts/readers/overview.mdx
@@ -48,6 +48,7 @@ Document(
 | `WebsiteReader` | Crawl websites recursively |
 | `WebSearchReader` | Web search results |
 | `FirecrawlReader` | Web scraping via Firecrawl API |
+| `LLMsTxtReader` | Read `llms.txt` files |
 
 ## Using Readers with Knowledge
 
@@ -152,6 +153,14 @@ reader = PDFReader(
 ```
 
 See [Chunking](/knowledge/concepts/chunking/overview) for available strategies.
+
+## Restricting URL Fetches
+
+Pass `allowed_hosts` to a URL-fetching reader to limit which hostnames it will fetch from. URLs outside the list are skipped and return no documents. Each hostname must match exactly, so include every subdomain you want to permit.
+
+```python
+reader = WebsiteReader(allowed_hosts=["docs.agno.com"])
+```
 
 ## Error Handling
 

--- a/knowledge/concepts/readers/overview.mdx
+++ b/knowledge/concepts/readers/overview.mdx
@@ -156,15 +156,13 @@ See [Chunking](/knowledge/concepts/chunking/overview) for available strategies.
 
 ## Restricting URL Fetches
 
-By default, URL-fetching readers will fetch any reachable URL. When a reader is wired up to accept URLs from untrusted input — for example an endpoint that takes a user-supplied link — an attacker-influenced URL can reach internal services or cloud metadata endpoints.
-
-Pass `allowed_hosts` to lock the reader to an explicit hostname allowlist. URLs outside the list are skipped and return no documents. Each hostname must match exactly, so include every subdomain you want to permit.
+By default, a URL-fetching reader will fetch any URL passed to it. Use `allowed_hosts` to restrict the reader to a fixed hostname allowlist. URLs outside the list are skipped and return no documents. Hostnames are matched exactly, so list every subdomain you want to permit.
 
 ```python
 reader = WebsiteReader(allowed_hosts=["docs.agno.com"])
 ```
 
-For `WebsiteReader`, `WebSearchReader`, and `LLMsTxtReader`, every redirect hop is re-validated against the same allowlist, so a permitted host cannot 3xx-bounce the request to a disallowed one. `FirecrawlReader` and `DoclingReader` validate the initial URL only; redirects in those paths are handled by the underlying library.
+`WebsiteReader`, `WebSearchReader`, and `LLMsTxtReader` also re-check the allowlist on each redirect, so an allowed host can't redirect to a blocked one. `FirecrawlReader` and `DoclingReader` validate the initial URL only.
 
 ## Error Handling
 

--- a/knowledge/concepts/readers/overview.mdx
+++ b/knowledge/concepts/readers/overview.mdx
@@ -156,7 +156,7 @@ See [Chunking](/knowledge/concepts/chunking/overview) for available strategies.
 
 ## Restricting URL Fetches
 
-By default, a URL-fetching reader will fetch any URL passed to it. Use `allowed_hosts` to restrict the reader to a fixed hostname allowlist. URLs outside the list are skipped and return no documents. Hostnames are matched exactly, so list every subdomain you want to permit.
+By default, a URL-fetching reader will fetch any URL passed to it. Use `allowed_hosts` to restrict the reader to a fixed hostname allowlist. URLs outside the list are skipped and return no documents. Matching is case-insensitive and applies to the whole hostname, so list every subdomain you want to permit.
 
 ```python
 reader = WebsiteReader(allowed_hosts=["docs.agno.com"])


### PR DESCRIPTION
## Description

Adds documentation for the `LLMsTxtReader` and the new `allowed_hosts` kwarg shipped in [agno-agi/agno#7892](https://github.com/agno-agi/agno/pull/7892).

- New page `knowledge/concepts/readers/llms-txt-reader` with a runnable PgVector example.
- New `_snippets/llms-txt-reader-reference.mdx` param table.
- `readers/overview`: adds `LLMsTxtReader` row to the Supported Readers table and a short **Restricting URL Fetches** section explaining the `allowed_hosts` allowlist.
- `_snippets/{website,firecrawl,docling,web-search}-reader-reference.mdx`: each gets a one-row `allowed_hosts` entry deep-linking to the new section.
- `docs.json`: registers the new LLMs.txt reader page in the Readers sidebar group.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [x] Content improvement
- [ ] Other: ____

## Related Issues/PRs (if applicable)

- Related SDK PR: agno-agi/agno#7892

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)