### PR TITLE
docs: remove unused available_models from EvalsConfig examples

### DIFF
--- a/_snippets/agent-os-configuration-reference.mdx
+++ b/_snippets/agent-os-configuration-reference.mdx
@@ -21,7 +21,6 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `available_models` | `List[str]` | `None` | List of models available in the Evals page |
 | `display_name` | `str` | `None` | Display name for the Evals page |
 | `dbs` | `Optional[List[DatabaseConfig[EvalsDomainConfig]]]` | `None` | List of configurations for each database |
 

--- a/agent-os/config.mdx
+++ b/agent-os/config.mdx
@@ -64,18 +64,13 @@ session:
       domain_config:
         display_name: Production sessions
 
-# Configure Evals page (supports both global and per-database available models)
+# Configure Evals page
 evals:
   display_name: "Evaluations"
-  available_models:
-    - "openai:gpt-4"
-    - "anthropic:claude-sonnet-4"
   dbs:
     - db_id: db-0001
       domain_config:
         display_name: Production evals
-        available_models:
-          - "openai:gpt-4o-mini"
 ```
 
 2. Pass the configuration to your AgentOS using the `config` parameter:

--- a/reference/agent-os/configuration.mdx
+++ b/reference/agent-os/configuration.mdx
@@ -30,16 +30,10 @@ chat:
 
 # Configuration for the Evals page
 evals:
-  available_models:
-    - <MODEL_STRING>
-    ...
   display_name: <DISPLAY_NAME>
   dbs:
     - <DB_ID>
       domain_config:
-        available_models:
-          - <MODEL_STRING>
-          ...
         display_name: <DISPLAY_NAME>
     ...
 


### PR DESCRIPTION
## Description

Documented `evals.available_models` and `evals.dbs[].domain_config.available_models` were never plumbed through on the SDK side — setting them was a silent no-op that left the Evals UI "Evaluation model" dropdown empty (the reported bug).

The only path the frontend actually reads is the top-level `AgentOSConfig.available_models` returned by `GET /config` (sourced at `libs/agno/agno/os/router.py:174` and `libs/agno/agno/os/mcp.py:82`).

This PR updates three places:

- **`_snippets/agent-os-configuration-reference.mdx`** — drop the `available_models` row from the `EvalsConfig` parameter table.
- **`agent-os/config.mdx`** — drop both the top-level `evals.available_models` and the nested `evals.dbs[].domain_config.available_models` from the YAML example; trim the misleading comment.
- **`reference/agent-os/configuration.mdx`** — drop the same nested blocks from the YAML schema reference.

After these edits, the only `available_models` mentioned in the docs is the legitimate top-level field (sibling of `evals:`, not nested under it).

## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: ____

## Related Issues/PRs (if applicable)

- Related SDK PR: agno-agi/agno#7993

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working (\`mint broken-links\` clean)
- [x] Code examples verified (Python/YAML round-tripped through `TestClient` against `GET /config`)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (not applicable)