### PR TITLE
docs: add Gemini managed agents (Deep Research + Antigravity)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1201,7 +1201,19 @@
                                   "models/providers/native/google/usage/interactions-multi-turn",
                                   "models/providers/native/google/usage/interactions-thinking",
                                   "models/providers/native/google/usage/interactions-search",
-                                  "models/providers/native/google/usage/interactions-structured-output"
+                                  "models/providers/native/google/usage/interactions-structured-output",
+                                  "models/providers/native/google/usage/interactions-deep-research",
+                                  "models/providers/native/google/usage/interactions-deep-research-streaming",
+                                  "models/providers/native/google/usage/interactions-deep-research-multi-turn",
+                                  "models/providers/native/google/usage/interactions-deep-research-collaborative-planning",
+                                  "models/providers/native/google/usage/interactions-deep-research-file-search",
+                                  "models/providers/native/google/usage/interactions-deep-research-mcp",
+                                  "models/providers/native/google/usage/interactions-deep-research-multimodal",
+                                  "models/providers/native/google/usage/interactions-deep-research-visualization",
+                                  "models/providers/native/google/usage/interactions-antigravity",
+                                  "models/providers/native/google/usage/interactions-antigravity-streaming",
+                                  "models/providers/native/google/usage/interactions-antigravity-multi-turn",
+                                  "models/providers/native/google/usage/interactions-antigravity-environment-config"
                                 ]
                               }
                             ]
@@ -2983,7 +2995,19 @@
                               "models/providers/native/google/usage/interactions-multi-turn",
                               "models/providers/native/google/usage/interactions-thinking",
                               "models/providers/native/google/usage/interactions-search",
-                              "models/providers/native/google/usage/interactions-structured-output"
+                              "models/providers/native/google/usage/interactions-structured-output",
+                              "models/providers/native/google/usage/interactions-deep-research",
+                              "models/providers/native/google/usage/interactions-deep-research-streaming",
+                              "models/providers/native/google/usage/interactions-deep-research-multi-turn",
+                              "models/providers/native/google/usage/interactions-deep-research-collaborative-planning",
+                              "models/providers/native/google/usage/interactions-deep-research-file-search",
+                              "models/providers/native/google/usage/interactions-deep-research-mcp",
+                              "models/providers/native/google/usage/interactions-deep-research-multimodal",
+                              "models/providers/native/google/usage/interactions-deep-research-visualization",
+                              "models/providers/native/google/usage/interactions-antigravity",
+                              "models/providers/native/google/usage/interactions-antigravity-streaming",
+                              "models/providers/native/google/usage/interactions-antigravity-multi-turn",
+                              "models/providers/native/google/usage/interactions-antigravity-environment-config"
                             ]
                           }
                         ]

--- a/models/providers/native/google/gemini-interactions.mdx
+++ b/models/providers/native/google/gemini-interactions.mdx
@@ -85,6 +85,12 @@ This is transparent to the user. The `Agent` class handles `interaction_id` trac
   <Card title="Background Execution" icon="clock" href="#background-execution">
     Long-running tasks
   </Card>
+  <Card title="Deep Research" icon="magnifying-glass-chart" href="#deep-research">
+    Autonomous research with citations
+  </Card>
+  <Card title="Antigravity" icon="robot" href="#antigravity">
+    Autonomous sandboxed agent
+  </Card>
 </CardGroup>
 
 ## Multi-turn Conversations
@@ -215,6 +221,84 @@ agent = Agent(
 agent.print_response("Research the history of quantum computing.")
 ```
 
+## Managed Agents
+
+Setting `agent` instead of `id` switches `GeminiInteractions` to Google's managed agent path (`agent` + `agent_config` instead of `model` + `generation_config`). Two agents are supported:
+
+| Agent | Model ID | Description |
+|-------|----------|-------------|
+| Deep Research | `deep-research-preview-04-2026`, `deep-research-pro-preview-12-2025` | Autonomous research agent that plans, browses, and returns a report with citations. Runs in background. |
+| Antigravity | `antigravity-preview-05-2026` | General-purpose autonomous agent that plans, runs code, browses, and produces artifacts inside a managed Linux sandbox. Runs in foreground. |
+
+`agent` is mutually exclusive with `id`. Per-agent semantics (background execution, sandbox provisioning) are forced by the SDK based on the agent ID.
+
+### Deep Research
+
+Deep Research plans the task, searches the web, and returns a researched report with citations. The model forces `background=True` and `store=True`, and the non-streaming path polls until the result is ready.
+
+```python
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="deep-research-preview-04-2026",
+        thinking_summaries="auto",
+        visualization="auto",
+    ),
+    markdown=True,
+)
+
+agent.print_response(
+    "Research the current state of solid-state battery commercialization."
+)
+```
+
+Deep Research config knobs:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `collaborative_planning` | `bool` | Turn 1 returns a plan instead of executing. Flip to `False` to execute the approved plan. |
+| `thinking_summaries` | `"auto"` / `"none"` | Stream intermediate reasoning during execution. Required for streaming progress. |
+| `visualization` | `"auto"` / `"off"` | Allow the agent to generate charts and graphs. |
+| `agent_poll_interval` | `float` | Seconds between status polls. Default `10.0`. |
+| `mcp_servers` | `list[dict]` | Remote MCP servers the agent can call. |
+| `file_search_store_names` | `list[str]` | File Search store names to ground research on your own documents. |
+
+Read more about Deep Research [here](/models/providers/native/google/usage/interactions-deep-research).
+
+### Antigravity
+
+Antigravity is a general-purpose autonomous agent that plans, runs code, browses the web, and produces artifacts inside a managed Linux sandbox. Unlike Deep Research, it runs in the foreground.
+
+```python
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="antigravity-preview-05-2026",
+        environment="remote",
+    ),
+    markdown=True,
+)
+
+agent.print_response(
+    "Read Hacker News, summarize the top 5 stories, and save the summary "
+    "as a Markdown report."
+)
+```
+
+The `environment` parameter selects the sandbox:
+
+| Value | Behavior |
+|-------|----------|
+| `"remote"` | Fresh remote Linux sandbox. Default for new sessions. |
+| `"env_<id>"` | Reuse a previously provisioned sandbox. Faster startup, state persists. |
+| `dict` | Full `EnvironmentConfig` (sources, network rules, etc.). |
+
+Read more about Antigravity [here](/models/providers/native/google/usage/interactions-antigravity).
+
 ## Interactions API vs generateContent
 
 | Feature | GeminiInteractions | Gemini |
@@ -229,7 +313,8 @@ agent.print_response("Research the history of quantum computing.")
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `id` | `str` | `"gemini-3-flash-preview"` | The model identifier |
+| `id` | `str` | `"gemini-3-flash-preview"` | The model identifier. Mutually exclusive with `agent`. |
+| `agent` | `Optional[str]` | `None` | Managed agent ID (e.g. `"deep-research-preview-04-2026"`, `"antigravity-preview-05-2026"`). Mutually exclusive with `id`. |
 | `name` | `str` | `"GeminiInteractions"` | The name of the model |
 | `provider` | `str` | `"Google"` | The provider of the model |
 | `api_key` | `Optional[str]` | `None` | Google API key (defaults to `GOOGLE_API_KEY` env var) |
@@ -246,6 +331,13 @@ agent.print_response("Research the history of quantum computing.")
 | `url_context` | `bool` | `False` | Enable URL context extraction |
 | `code_execution` | `bool` | `False` | Enable code execution |
 | `service_tier` | `Optional[str]` | `None` | Inference tier: `"flex"`, `"standard"`, or `"priority"` |
+| `mcp_servers` | `Optional[list[dict]]` | `None` | Remote MCP server configs available to managed agents. |
+| `file_search_store_names` | `Optional[list[str]]` | `None` | File Search store names available to managed agents. |
+| `collaborative_planning` | `Optional[bool]` | `None` | Deep Research: return a plan on turn 1 instead of executing. |
+| `thinking_summaries` | `Optional[str]` | `None` | Deep Research: `"auto"` or `"none"`. Stream intermediate reasoning. |
+| `visualization` | `Optional[str]` | `None` | Deep Research: `"auto"` or `"off"`. Allow chart/graph generation. |
+| `environment` | `Optional[Union[str, Dict]]` | `None` | Antigravity sandbox: `"remote"`, `"env_<id>"`, or full `EnvironmentConfig` dict. |
+| `agent_poll_interval` | `float` | `10.0` | Seconds between status polls for background agents. |
 | `timeout` | `Optional[float]` | `None` | Request timeout in seconds |
 | `client_params` | `Optional[Dict[str, Any]]` | `None` | Additional client parameters |
 

--- a/models/providers/native/google/usage/interactions-antigravity-environment-config.mdx
+++ b/models/providers/native/google/usage/interactions-antigravity-environment-config.mdx
@@ -1,0 +1,78 @@
+---
+title: Antigravity Environment Config (Interactions)
+---
+
+Two non-default ways to control the Antigravity sandbox:
+
+| Option | When to use |
+|--------|-------------|
+| Reuse by id (`"env_<id>"`) | Agent needs to build on prior work in the same sandbox (iterative project). Faster startup, state persists across runs. |
+| Full `EnvironmentConfig` dict | Need a specific source repo, package set, or network policy. |
+
+The dict shape mirrors the API's `EnvironmentConfig`. Only the keys you set are sent; the API applies defaults for the rest.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/antigravity_environment_config.py
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+# Reuse an existing environment by id
+agent_reuse = Agent(
+    model=GeminiInteractions(
+        agent="antigravity-preview-05-2026",
+        environment="env_xxxxxxxx",
+    ),
+    markdown=True,
+)
+
+# Full EnvironmentConfig
+agent_custom = Agent(
+    model=GeminiInteractions(
+        agent="antigravity-preview-05-2026",
+        environment={
+            "type": "remote",
+            "sources": [
+                {"type": "git", "url": "https://github.com/agno-agi/agno"},
+            ],
+            "network": {"allow_internet_access": True},
+        },
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent_reuse.print_response(
+        "Continue the project we started last time and ship the next "
+        "iteration of the report."
+    )
+
+    agent_custom.print_response(
+        "Skim the repo we cloned, summarize the module layout, and save "
+        "the summary to STRUCTURE.md inside the sandbox."
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/antigravity_environment_config.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-antigravity-multi-turn.mdx
+++ b/models/providers/native/google/usage/interactions-antigravity-multi-turn.mdx
@@ -1,0 +1,69 @@
+---
+title: Antigravity Multi-turn (Interactions)
+---
+
+Continue an Antigravity interaction across turns. Each response carries an `interaction_id`; the next turn references it via `previous_interaction_id` so only the new user message is sent on the wire. The server keeps the sandbox state (files written, packages installed, browser history) attached to the interaction chain. Subsequent turns build on what the agent already did.
+
+Persisting the interaction ID requires a database. The assistant message stores it under `provider_data`, and the next turn reads it back.
+
+<Note>
+When continuing a chain, the existing sandbox is already attached server-side. Re-sending `environment="remote"` is safe; the API treats it as a hint that's reconciled against the running env. To be explicit, swap to the returned `env_<id>` after the first turn.
+</Note>
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/antigravity_multi_turn.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="antigravity-preview-05-2026",
+        environment="remote",
+    ),
+    add_history_to_context=True,
+    db=SqliteDb(db_file="tmp/data.db"),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Plot the growth of global solar energy generation over the last "
+        "decade and save the plot as solar.png in the sandbox."
+    )
+
+    agent.print_response(
+        "Take solar.png and produce a 3-slide HTML deck that embeds it, "
+        "with a title slide and a short takeaway per slide."
+    )
+
+    agent.print_response(
+        "Review the deck for clarity and tighten the takeaways. Save the "
+        "revised version as deck_v2.html."
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/antigravity_multi_turn.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-antigravity-streaming.mdx
+++ b/models/providers/native/google/usage/interactions-antigravity-streaming.mdx
@@ -1,0 +1,61 @@
+---
+title: Antigravity Streaming (Interactions)
+---
+
+Stream the Antigravity agent's progress (tool calls, intermediate text, generated artifacts) instead of waiting for the final result. Antigravity runs in the foreground, so the stream stays open for the duration of the autonomous loop. No background reconnect is needed.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/antigravity_streaming.py
+import asyncio
+
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="antigravity-preview-05-2026",
+        environment="remote",
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Read Hacker News, summarize the top 5 stories, and save the "
+        "summary as a Markdown report.",
+        stream=True,
+    )
+
+    asyncio.run(
+        agent.aprint_response(
+            "Find the three most-starred new Python repos on GitHub this "
+            "week and write a one-paragraph blurb for each.",
+            stream=True,
+        )
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/antigravity_streaming.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-antigravity.mdx
+++ b/models/providers/native/google/usage/interactions-antigravity.mdx
@@ -1,0 +1,57 @@
+---
+title: Antigravity (Interactions)
+---
+
+Run the Antigravity managed agent through the Gemini Interactions API. Antigravity is a general-purpose autonomous agent (Gemini 3.5 Flash) that plans, runs code, browses the web, and produces artifacts (PDFs, HTML, slides) inside a managed Linux sandbox.
+
+The `environment` parameter selects the sandbox:
+
+| Value | Behavior |
+|-------|----------|
+| `"remote"` | Fresh remote Linux sandbox. |
+| `"env_<id>"` | Reuse a previously provisioned sandbox. |
+| `dict` | Full `EnvironmentConfig` (sources, network rules). |
+
+Unlike Deep Research, Antigravity runs in the foreground. The model still forces `store=True` so the interaction is retrievable.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/antigravity.py
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="antigravity-preview-05-2026",
+        environment="remote",
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response("What is the capital of France?")
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/antigravity.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-deep-research-collaborative-planning.mdx
+++ b/models/providers/native/google/usage/interactions-deep-research-collaborative-planning.mdx
@@ -1,0 +1,81 @@
+---
+title: Deep Research Collaborative Planning (Interactions)
+---
+
+Human-in-the-loop research: the agent proposes a plan, you refine it, then approve it to run the full research.
+
+The flow chains turns through `previous_interaction_id`:
+
+1. `collaborative_planning=True` → agent returns a research plan.
+2. `collaborative_planning=True` → refine the plan (optional).
+3. `collaborative_planning=False` → agent executes the approved plan.
+
+`collaborative_planning` is read fresh on every request, so flipping it on the model between turns switches plan-mode to execute-mode within the same conversation.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/deep_research_collaborative_planning.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="deep-research-preview-04-2026",
+        collaborative_planning=True,
+        thinking_summaries="auto",
+        agent_poll_interval=5.0,
+    ),
+    add_history_to_context=True,
+    db=SqliteDb(db_file="tmp/deep_research_collab.db"),
+    markdown=True,
+)
+
+SESSION_ID = "deep-research-collab-1"
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Do some research on Google TPUs.",
+        session_id=SESSION_ID,
+    )
+
+    agent.print_response(
+        "Focus more on the differences between Google TPUs and competitor "
+        "hardware, and less on the history.",
+        session_id=SESSION_ID,
+    )
+
+    agent.model.collaborative_planning = False
+    agent.print_response(
+        "Plan looks good!",
+        session_id=SESSION_ID,
+    )
+```
+
+<Note>
+Mutating `agent.model.collaborative_planning` mid-conversation is safe only when the model instance is not shared across concurrent runs. For concurrent use, prefer two separate agents (a planner and an executor) sharing a session.
+</Note>
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/deep_research_collaborative_planning.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-deep-research-file-search.mdx
+++ b/models/providers/native/google/usage/interactions-deep-research-file-search.mdx
@@ -1,0 +1,83 @@
+---
+title: Deep Research with File Search (Interactions)
+---
+
+Ground the Deep Research agent on your own documents. Create a File Search store, upload documents, then pass the store name to `file_search_store_names`. The agent searches that store alongside the public web.
+
+In production, create and populate the store once offline and reference it by name at query time.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/deep_research_file_search.py
+import tempfile
+import time
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+from google import genai
+
+client = genai.Client()
+
+store = client.file_search_stores.create(
+    config={"display_name": "agno-deep-research-demo"}
+)
+print(f"Created store: {store.name}")
+
+sample = Path(tempfile.gettempdir()) / "agno_fy2025_summary.txt"
+sample.write_text(
+    "Agno FY2025 internal summary.\n"
+    "Revenue grew 240% year over year, driven by AgentOS adoption.\n"
+    "Headcount doubled. The flagship launch was the Antigravity integration.\n"
+)
+
+operation = client.file_search_stores.upload_to_file_search_store(
+    file_search_store_name=store.name,
+    file=str(sample),
+    config={"display_name": "fy2025-summary"},
+)
+print("Uploading + indexing document...")
+while not operation.done:
+    time.sleep(3)
+    operation = client.operations.get(operation)
+print("Document indexed.")
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="deep-research-preview-04-2026",
+        thinking_summaries="auto",
+        file_search_store_names=[store.name],
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Using our internal FY2025 summary, compare our reported growth drivers "
+        "against current public news about the AI agent framework market."
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/deep_research_file_search.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-deep-research-mcp.mdx
+++ b/models/providers/native/google/usage/interactions-deep-research-mcp.mdx
@@ -1,0 +1,59 @@
+---
+title: Deep Research with MCP (Interactions)
+---
+
+Give the Deep Research agent access to external tools via remote MCP servers. Pass server configs through `mcp_servers`; the `type: "mcp_server"` field is added automatically.
+
+Only `url` is required. `name`, `headers`, and `allowed_tools` are optional. Custom Function Calling tools are not supported by Deep Research, but remote MCP servers are.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/deep_research_mcp.py
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="deep-research-preview-04-2026",
+        thinking_summaries="auto",
+        mcp_servers=[
+            {
+                "name": "Deployment Tracker",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"Authorization": "Bearer my-token"},
+                # "allowed_tools": ["get_status"],  # optionally restrict
+            }
+        ],
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Check the status of my last server deployment and summarize any issues."
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/deep_research_mcp.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-deep-research-multi-turn.mdx
+++ b/models/providers/native/google/usage/interactions-deep-research-multi-turn.mdx
@@ -1,0 +1,65 @@
+---
+title: Deep Research Multi-turn (Interactions)
+---
+
+Continue a Deep Research interaction across turns. Each response carries an `interaction_id`; the next turn references it via `previous_interaction_id` so only the new user message is sent on the wire. The server already has the prior research and its citations.
+
+Persisting the interaction ID requires a database. The assistant message stores it under `provider_data`, and the next turn reads it back.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/deep_research_multi_turn.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="deep-research-preview-04-2026",
+        thinking_summaries="auto",
+    ),
+    add_history_to_context=True,
+    db=SqliteDb(db_file="tmp/data.db"),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Research the current state of solid-state battery commercialization "
+        "and summarize the leading approaches."
+    )
+
+    agent.print_response(
+        "Dive deeper into the sulfide-electrolyte approach: who the leading "
+        "labs and companies are, and what their reported milestones look like."
+    )
+
+    agent.print_response(
+        "Based on everything we've covered, which approach has the clearest "
+        "path to mass-market EV deployment in the next five years?"
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/deep_research_multi_turn.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-deep-research-multimodal.mdx
+++ b/models/providers/native/google/usage/interactions-deep-research-multimodal.mdx
@@ -1,0 +1,62 @@
+---
+title: Deep Research Multimodal Input (Interactions)
+---
+
+Deep Research accepts images and documents (PDFs) as input, then conducts web-based research grounded in that content. Pass them as Agno `Image` / `File` objects with a URL. GCS and Gemini URIs pass through; regular HTTP URLs are downloaded and base64-encoded automatically.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/deep_research_multimodal.py
+from agno.agent import Agent
+from agno.media import File, Image
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="deep-research-preview-04-2026",
+        thinking_summaries="auto",
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Analyze the interspecies dynamics in this image and research the "
+        "symbiotic relationships shown.",
+        images=[
+            Image(
+                url="https://storage.googleapis.com/generativeai-downloads/images/generated_elephants_giraffes_zebras_sunset.jpg"
+            )
+        ],
+    )
+
+    agent.print_response(
+        "What is this document about, and how does it relate to current "
+        "research trends?",
+        files=[File(url="https://arxiv.org/pdf/1706.03762")],
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/deep_research_multimodal.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-deep-research-streaming.mdx
+++ b/models/providers/native/google/usage/interactions-deep-research-streaming.mdx
@@ -1,0 +1,59 @@
+---
+title: Deep Research Streaming (Interactions)
+---
+
+Stream real-time progress (thought summaries, text, generated images) from a Deep Research task instead of waiting for the final report. Set `thinking_summaries="auto"` to receive intermediate reasoning during streaming. Background execution is required for agents and is enabled automatically.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/deep_research_streaming.py
+import asyncio
+
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="deep-research-preview-04-2026",
+        thinking_summaries="auto",
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Research the history and impact of Google TPUs.",
+        stream=True,
+    )
+
+    asyncio.run(
+        agent.aprint_response(
+            "Research the current state of open-source LLM inference engines.",
+            stream=True,
+        )
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/deep_research_streaming.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-deep-research-visualization.mdx
+++ b/models/providers/native/google/usage/interactions-deep-research-visualization.mdx
@@ -1,0 +1,53 @@
+---
+title: Deep Research Visualization (Interactions)
+---
+
+With `visualization="auto"` the agent can generate charts and graphs to support its findings. The capability is enabled by the config, but the agent only produces visuals when the prompt explicitly asks for them.
+
+Generated images come back in the response steps (and as image deltas when streaming). Agno parses them into the response's images.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/deep_research_visualization.py
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="deep-research-preview-04-2026",
+        thinking_summaries="auto",
+        visualization="auto",
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Analyze global semiconductor market trends. Include graphics showing "
+        "market share changes over time."
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/deep_research_visualization.py
+    ```
+  </Step>
+</Steps>

--- a/models/providers/native/google/usage/interactions-deep-research.mdx
+++ b/models/providers/native/google/usage/interactions-deep-research.mdx
@@ -1,0 +1,60 @@
+---
+title: Deep Research (Interactions)
+---
+
+Run the Deep Research managed agent through the Gemini Interactions API. The agent plans the task, searches the web, and returns a researched report with citations. The model forces `background=True` and `store=True`, and the non-streaming path polls until the result is ready.
+
+## Code
+
+```python cookbook/90_models/google/gemini_interactions/deep_research.py
+import asyncio
+
+from agno.agent import Agent
+from agno.models.google import GeminiInteractions
+
+agent = Agent(
+    model=GeminiInteractions(
+        agent="deep-research-preview-04-2026",
+        thinking_summaries="auto",
+        visualization="auto",
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Research the current state of solid-state battery commercialization "
+        "and summarize the leading approaches."
+    )
+
+    asyncio.run(
+        agent.aprint_response(
+            "Compare the major open-source vector databases on indexing and query latency.",
+            stream=True,
+        )
+    )
+```
+
+## Usage
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Set your API key">
+    ```bash
+    export GOOGLE_API_KEY=xxx
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "google-genai>=2.0" agno
+    ```
+  </Step>
+
+  <Step title="Run Agent">
+    ```bash
+    python cookbook/90_models/google/gemini_interactions/deep_research.py
+    ```
+  </Step>
+</Steps>


### PR DESCRIPTION
## Summary

Covers [agno-agi/agno#7975](https://github.com/agno-agi/agno/pull/7975), which added Deep Research and Antigravity managed agents to `GeminiInteractions`.

- Updates `models/providers/native/google/gemini-interactions.mdx` with a Managed Agents section (Deep Research + Antigravity), capability cards, and new params (`agent`, `environment`, `collaborative_planning`, `thinking_summaries`, `visualization`, `agent_poll_interval`, `mcp_servers`, `file_search_store_names`).
- Adds 12 usage pages under `models/providers/native/google/usage/` mirroring the cookbook examples:
  - Deep Research: basic, streaming, multi-turn, collaborative planning, file search, MCP, multimodal, visualization
  - Antigravity: basic, streaming, multi-turn, environment config
- Wires all 12 into both Interactions Usage groups in `docs.json`.

## Test plan

- [ ] `mint dev` renders the new pages
- [ ] `mint broken-links` shows no new failures
- [ ] Navigation lists the new pages under Interactions Usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)