### PR TITLE
docs: add document processing use-case section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -173,6 +173,17 @@
                   "use-cases/deep-research/institutional-learning",
                   "use-cases/deep-research/serve-and-embed"
                 ]
+              },
+              {
+                "group": "Document Processing",
+                "pages": [
+                  "use-cases/document-processing/overview",
+                  "use-cases/document-processing/invoices-and-receipts",
+                  "use-cases/document-processing/contracts",
+                  "use-cases/document-processing/forms-and-intake",
+                  "use-cases/document-processing/batch-and-durability",
+                  "use-cases/document-processing/human-routing-and-eval"
+                ]
               }
             ]
           },

--- a/index.mdx
+++ b/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Welcome to Agno
-description: '**An agent platform for building, running, and managing agents.**'
+description: '**An agent platform for building, running, and managing a fleet of agents.**'
 mode: wide
 ---
 
-Agno lets you build your own agent platform and run a fleet of agents that power every part of your product.
+Agno lets you build your own agent platform and run a fleet of agents to power every part of your product and operations. Workloads that were previously tedious and time-consuming are now one agent away.
 
-Workloads that were previously tedious and time-consuming are now one agent away. From data labeling and document extraction to product copilots and dynamic agent-driven software.
+From data labeling and document extraction to product copilots, research assistants, and agent-driven software. Agno's AgentOS productionizes any agent built with any framework.
 
 <img
   src="/images/demo-os.png"
@@ -29,11 +29,11 @@ Thousands of engineering teams use Agno because it frees them up. They can:
 - Run agents as production services with tracing, scheduling, RBAC, and audit trails.
 - Manage the entire agent development lifecycle using coding agents.
 
-Most importantly. Your data stays in your database. You log and store everything (sessions, memory, traces) in your database, then use this data to auto-improve your agents via claude code.
+Most importantly, your data stays in your database. You log and store everything (sessions, memory, traces) there, then use it to auto-improve your agents via claude code.
 
 Everything runs in your cloud, managed through a beautiful UI.
 
-## Get Started
+## Get started
 
 - [Build your first agent →](/first-agent)
 - [Build an agent platform managed entirely by claude code →](/agent-platform/overview)

--- a/use-cases/data-agents/overview.mdx
+++ b/use-cases/data-agents/overview.mdx
@@ -4,7 +4,9 @@ sidebarTitle: "Overview"
 description: "Agents that work on your data, grounded in business context."
 ---
 
-Every company with 30+ people is building an internal data agent. OpenAI, Vercel, Uber, LinkedIn, and Salesforce have each published theirs. The key themes are: ground the model in curated context, let it self-correct, enforce hard boundaries on writes.
+Every company with 30+ people needs an internal data agent. OpenAI, Vercel, Uber, LinkedIn, and Salesforce are each building one.
+
+The key themes are: ground the model in curated context, let it self-correct, enforce hard boundaries on writes.
 
 ## Learn How To
 

--- a/use-cases/document-processing/batch-and-durability.mdx
+++ b/use-cases/document-processing/batch-and-durability.mdx
@@ -1,0 +1,186 @@
+---
+title: "Batch and durability"
+description: "Workflows over a folder, background runs, scheduled jobs with retries."
+---
+
+A single `agent.run(files=[File(...)])` handles one document. Production runs see folders, queues, and nightly drops. Three primitives cover the production shape: concurrent runs for ad-hoc batches, background runs for long jobs, scheduled runs for nightly intake.
+
+## Concurrent batch over a list
+
+The simplest batch is a folder of files. `agent.arun` is async, so a semaphore plus `asyncio.gather` is enough.
+
+```python
+import asyncio
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.media import File
+from agno.models.openai import OpenAIResponses
+from pydantic import BaseModel
+
+from your_schemas import Invoice  # define your output schema once
+
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions="Extract invoice fields and line items. Null for missing.",
+    output_schema=Invoice,
+)
+
+
+async def extract_one(path: Path, sem: asyncio.Semaphore) -> Invoice:
+    async with sem:
+        run = await agent.arun(
+            "Extract this invoice.",
+            files=[File(filepath=str(path))],
+        )
+        return run.content
+
+
+async def extract_folder(folder: Path, concurrency: int = 8) -> list[Invoice]:
+    sem = asyncio.Semaphore(concurrency)
+    paths = sorted(folder.glob("*.pdf"))
+    return await asyncio.gather(*(extract_one(p, sem) for p in paths))
+
+
+invoices = asyncio.run(extract_folder(Path("./incoming-invoices")))
+# [Invoice(invoice_number='1042', ...), Invoice(invoice_number='1043', ...), ...]
+```
+
+A semaphore is the smallest concurrency control. It keeps you under the provider's rate limit and bounds memory. Tune the `concurrency` to the slowest of: your rate quota, your DB write throughput, your memory budget.
+
+## Background runs for long jobs
+
+Sync runs hold an HTTP connection until the model returns. For multi-page contracts or scanned PDFs that take minutes, start the run in the background and poll.
+
+```python
+import asyncio
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.models.openai import OpenAIResponses
+from agno.run.base import RunStatus
+
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+agent = Agent(model=OpenAIResponses(id="gpt-5.5"), db=db, output_schema=Invoice)
+
+
+async def extract_long(file_url: str) -> Invoice:
+    started = await agent.arun(
+        "Extract this invoice.",
+        files=[File(url=file_url)],
+        background=True,
+    )
+    # started.status is RunStatus.pending; the work continues in the background.
+
+    while True:
+        await asyncio.sleep(2)
+        run = await agent.aget_run_output(
+            run_id=started.run_id,
+            session_id=started.session_id,
+        )
+        if run is None:
+            continue
+        if run.status == RunStatus.completed:
+            return run.content
+        if run.status == RunStatus.error:
+            raise RuntimeError(f"Run {started.run_id} failed")
+```
+
+The background run is persisted in `db`. The agent process can restart and a different process can poll the same `run_id`. That is the durability property: state lives in the database, not in the calling process.
+
+## Scheduled batch with retries
+
+For nightly intake (an SFTP drop, a Drive folder, a queue), put an AgentOS in front of your agent and let the scheduler fire the run on cron.
+
+```python
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+extractor = Agent(
+    id="invoice-extractor",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    output_schema=Invoice,
+)
+
+agent_os = AgentOS(
+    agents=[extractor],
+    db=db,
+    scheduler=True,
+    scheduler_poll_interval=15,    # check for due jobs every N seconds
+)
+app = agent_os.get_app()
+```
+
+Then create the schedule in Python. `ScheduleManager` writes to the same `db` the AgentOS polls.
+
+```python
+from agno.scheduler import ScheduleManager
+
+mgr = ScheduleManager(db)
+
+mgr.create(
+    name="nightly-invoice-intake",
+    cron="0 2 * * *",                 # 2am every day
+    endpoint="/agents/invoice-extractor/runs",
+    payload={"message": "Process the overnight invoice drop."},
+    timezone="America/New_York",
+    max_retries=2,
+    retry_delay_seconds=300,
+    if_exists="update",
+)
+```
+
+`if_exists="update"` makes the call idempotent. Re-running the bootstrap script does not create duplicates. The scheduler retries on HTTP failure with the configured delay, and every fire writes a row to `agno_schedule_runs` with status and timing.
+
+## Pattern comparison
+
+| Pattern | When to reach for it | Process lifetime |
+|---------|----------------------|------------------|
+| `asyncio.gather` over `agent.arun` | One-time backfill, a fixed list of files | One process, end-to-end |
+| `agent.arun(background=True)` + poll | Single long document, restart-tolerant | State in `db`, process can restart |
+| `AgentOS(scheduler=True)` + `ScheduleManager` | Recurring intake (nightly, hourly) | Long-running AgentOS process |
+| `Workflow` with `Loop` / `Parallel` steps | Multi-step pipelines per document | Either ad-hoc or scheduled |
+
+The scheduler fires endpoints. Endpoints are agents, teams, or workflows. So a nightly job that ingests a folder, extracts each file, and writes to your warehouse is a workflow exposed at `/workflows/<id>/runs`, scheduled with the same `ScheduleManager.create` call. See [Workflows](/workflows/overview).
+
+## Observability
+
+Every scheduled fire creates a row in `agno_schedule_runs` with the schedule id, attempt number, status, and the `run_id` of the underlying agent run. To see the last day of activity:
+
+```python
+runs = mgr.get_runs(schedule_id, limit=100)
+for r in runs:
+    print(r.triggered_at, r.status, r.attempt, r.error or "")
+```
+
+Failed attempts keep their error text. Retries are separate rows with the same `schedule_id` and an incrementing `attempt`. That is the audit trail you can hand to ops.
+
+## Production checklist
+
+| Concern | What to add |
+|---------|-------------|
+| Idempotency per document | Pass a deterministic `session_id` (e.g. document hash) so re-runs upsert. |
+| Dead-letter queue | After `max_retries`, the row stays in `agno_schedule_runs` with `status="failed"`. Read it and route to a manual queue. |
+| Per-provider rate limiting | The `asyncio.Semaphore` is enough for one provider. For mixed providers, run one semaphore per provider. |
+| Storage of inputs | `File(url=...)` keeps the URL but not the bytes. If retention matters, store the source PDF before extraction. |
+| Authoritative cost | `RunMetrics.cost` is populated when the provider returns it. For exact reconciliation, attach a token-rate table downstream. |
+
+## Next steps
+
+| Task | Guide |
+|------|-------|
+| Pause on low-confidence fields | [Human routing and eval](/use-cases/document-processing/human-routing-and-eval) |
+| Compose multiple agents into a pipeline | [Workflows](/workflows/overview) |
+| See the workflow + scheduler integration | [Scheduling](/runtime/scheduling) |
+
+## Developer Resources
+
+- [Scheduler cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/05_agent_os/scheduler)
+- [Background execution cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/02_agents/14_advanced/background_execution.py)
+- [Workflows cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/04_workflows)

--- a/use-cases/document-processing/contracts.mdx
+++ b/use-cases/document-processing/contracts.mdx
@@ -1,0 +1,138 @@
+---
+title: "Contracts"
+description: "Parties, dates, and a clause-level breakdown for legal review queues."
+---
+
+Contracts are denser than invoices. A header (parties, effective date, term) plus a clause list with stable categories that downstream review tooling can filter on.
+
+```python
+from typing import List, Literal, Optional
+
+from agno.agent import Agent
+from agno.media import File
+from agno.models.openai import OpenAIResponses
+from pydantic import BaseModel, Field
+
+
+ClauseCategory = Literal[
+    "term_and_termination",
+    "payment",
+    "confidentiality",
+    "indemnification",
+    "limitation_of_liability",
+    "warranty",
+    "ip_assignment",
+    "governing_law",
+    "dispute_resolution",
+    "non_compete",
+    "other",
+]
+
+
+class Clause(BaseModel):
+    category: ClauseCategory
+    heading: Optional[str] = Field(None, description="Section heading as printed")
+    text: str = Field(..., description="Clause text, verbatim")
+    page: Optional[int] = Field(None, description="1-indexed page where the clause begins")
+
+
+class Party(BaseModel):
+    name: str
+    role: Optional[str] = Field(None, description="e.g. Customer, Vendor, Licensor")
+    address: Optional[str] = None
+
+
+class Contract(BaseModel):
+    title: Optional[str] = None
+    contract_type: Optional[str] = Field(None, description="e.g. MSA, SOW, NDA, EULA")
+    parties: List[Party] = Field(default_factory=list)
+    effective_date: Optional[str] = None
+    term: Optional[str] = Field(None, description="Stated term, e.g. '3 years from Effective Date'")
+    governing_law: Optional[str] = None
+    clauses: List[Clause] = Field(default_factory=list)
+
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=(
+        "Extract the contract header and every clause from the attached PDF. "
+        "Clause text must be verbatim from the document. Assign each clause "
+        "to the closest category; use 'other' if nothing fits. Do not "
+        "summarize, paraphrase, or skip clauses."
+    ),
+    output_schema=Contract,
+)
+
+contract = agent.run(
+    "Extract this contract.",
+    files=[File(url="https://example.com/msa-acme.pdf")],
+).content
+# Contract(title='Master Services Agreement', contract_type='MSA',
+#          parties=[Party(name='Acme Corp', role='Customer'),
+#                   Party(name='Beta Labs', role='Vendor')],
+#          effective_date='2026-01-15', term='3 years from Effective Date',
+#          governing_law='State of Delaware',
+#          clauses=[Clause(category='term_and_termination', ...), ...])
+```
+
+The `Literal` on `category` is what makes the output usable. Downstream review queues filter by category, so the categories must be a closed set. Free-text categories are unfilterable.
+
+## Review queues by clause type
+
+Once clauses carry a category, route them by team. Indemnification and limitation-of-liability go to legal; payment and term go to finance.
+
+```python
+def route_for_review(contract: Contract) -> dict[str, list[Clause]]:
+    legal = {"indemnification", "limitation_of_liability", "warranty", "ip_assignment"}
+    finance = {"payment", "term_and_termination"}
+
+    buckets: dict[str, list[Clause]] = {"legal": [], "finance": [], "other": []}
+    for clause in contract.clauses:
+        if clause.category in legal:
+            buckets["legal"].append(clause)
+        elif clause.category in finance:
+            buckets["finance"].append(clause)
+        else:
+            buckets["other"].append(clause)
+    return buckets
+```
+
+The agent does the extraction. The routing is plain Python, against a typed object. The split is auditable because each clause keeps its verbatim `text` and `page`.
+
+## Diff against a template
+
+For contract review, the question is often "what changed from our standard?" Extract both the incoming contract and your template into the same `Contract` schema, then diff by category.
+
+```python
+incoming = agent.run("Extract.", files=[File(url=incoming_url)]).content
+template = agent.run("Extract.", files=[File(filepath="templates/msa-v3.pdf")]).content
+
+incoming_by_cat = {c.category: c for c in incoming.clauses}
+template_by_cat = {c.category: c for c in template.clauses}
+
+deltas = [
+    (cat, incoming_by_cat.get(cat), template_by_cat.get(cat))
+    for cat in set(incoming_by_cat) | set(template_by_cat)
+    if (incoming_by_cat.get(cat) and incoming_by_cat[cat].text)
+       != (template_by_cat.get(cat) and template_by_cat[cat].text)
+]
+```
+
+For a richer comparison, hand both contracts to a reviewer agent with `output_schema` set to a `ClauseDelta` model and let the model summarize the differences.
+
+## Long contracts and chunking
+
+`OpenAIResponses(id="gpt-5.5")` handles contract-length PDFs in a single call. For documents over the model's context, split by section in your own code and run the agent per chunk. The schema is the same; you concatenate the `clauses` lists at the end.
+
+## Next steps
+
+| Task | Guide |
+|------|-------|
+| Schedule a nightly contract intake run | [Batch and durability](/use-cases/document-processing/batch-and-durability) |
+| Send risky clauses to a human reviewer | [Human routing and eval](/use-cases/document-processing/human-routing-and-eval) |
+| Apply the same shape to intake forms | [Forms and intake](/use-cases/document-processing/forms-and-intake) |
+
+## Developer Resources
+
+- [Document extraction cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/data_labeling/_16_document_extraction)
+- [Structured output](/input-output/structured-output/agent)

--- a/use-cases/document-processing/forms-and-intake.mdx
+++ b/use-cases/document-processing/forms-and-intake.mdx
@@ -1,0 +1,123 @@
+---
+title: "Forms and intake"
+description: "Resumes, applications, KYC. Lists inside lists, same File() plumbing."
+---
+
+Forms and intake documents bring a different shape: a person identity at the top, then several parallel lists (employment, education, skills, references). The agent fills out the nested structure in one pass.
+
+```python
+from typing import List, Optional
+
+from agno.agent import Agent
+from agno.media import File
+from agno.models.openai import OpenAIResponses
+from pydantic import BaseModel, Field
+
+
+class Employment(BaseModel):
+    company: str
+    title: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = Field(None, description="Null if current")
+    summary: Optional[str] = Field(None, description="Bullet points joined into one string")
+
+
+class Education(BaseModel):
+    institution: str
+    degree: Optional[str] = None
+    field_of_study: Optional[str] = None
+    graduation_year: Optional[int] = None
+
+
+class Resume(BaseModel):
+    full_name: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    location: Optional[str] = None
+    headline: Optional[str] = Field(None, description="Top-of-page summary line")
+    employment: List[Employment] = Field(default_factory=list)
+    education: List[Education] = Field(default_factory=list)
+    skills: List[str] = Field(default_factory=list)
+
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=(
+        "Extract every field from the attached resume PDF. Preserve the "
+        "candidate's wording for titles and summaries. Use null when a "
+        "field is missing. Do not infer skills that are not on the page."
+    ),
+    output_schema=Resume,
+)
+
+resume = agent.run(
+    "Extract this resume.",
+    files=[File(url="https://example.com/resume-sjohnson.pdf")],
+).content
+# Resume(full_name='Sarah Johnson', email='sarah@example.com',
+#        headline='Senior Platform Engineer',
+#        employment=[Employment(company='Acme Corp', title='Staff Engineer',
+#                               start_date='2023-02', end_date=None, ...),
+#                    Employment(company='Beta Labs', title='Senior Engineer',
+#                               start_date='2019-06', end_date='2023-01', ...)],
+#        education=[Education(institution='University of Texas',
+#                             degree='B.S.', field_of_study='Computer Science',
+#                             graduation_year=2018)],
+#        skills=['Python', 'PostgreSQL', 'Kubernetes', 'Terraform'])
+```
+
+The same shape covers job applications and KYC intake. Swap the schema's outer model and the instructions; the `File()` plumbing and the agent definition do not change.
+
+## KYC intake
+
+Identity verification forms add typed fields the downstream system has to accept verbatim (passport numbers, dates of birth, addresses). The schema should be conservative about types: keep IDs as strings to preserve leading zeros and country-specific formats.
+
+```python
+class KYCSubmission(BaseModel):
+    full_name: str
+    date_of_birth: Optional[str] = Field(None, description="ISO 8601")
+    country_of_residence: Optional[str] = Field(None, description="ISO 3166-1 alpha-2")
+    national_id_type: Optional[str] = Field(None, description="passport, driver_license, national_id")
+    national_id_number: Optional[str] = Field(None, description="As printed, including any leading zeros")
+    address: Optional[str] = None
+    declared_source_of_funds: Optional[str] = None
+```
+
+For KYC, every field is review-worthy. Combine this schema with the [confidence pattern](/use-cases/data-labeling/structured-extraction#per-field-confidence) so the downstream queue knows what to send to a compliance reviewer.
+
+## Multi-page applications
+
+Job applications often arrive as multi-page PDFs with attachments. `File(url=...)` handles a single combined PDF. For loose attachments (cover letter, resume, references), run the agent once per attachment, each with the right `output_schema`, and merge.
+
+```python
+class Application(BaseModel):
+    candidate: Resume
+    cover_letter: Optional[str] = None
+    references: List[str] = Field(default_factory=list)
+```
+
+For the resume and the references list, two `agent.run(...)` calls return typed objects. Compose them into an `Application` in plain Python.
+
+## Schema-shape comparison
+
+| Workload | Header | Repeated structure | Notes |
+|----------|--------|---------------------|-------|
+| Invoice | Vendor, totals, dates | `List[LineItem]` | Numbers stay numeric |
+| Contract | Parties, dates, governing law | `List[Clause]` with category Literal | Verbatim clause text |
+| Resume | Identity, headline | Parallel lists: employment, education, skills | Preserve candidate wording |
+| KYC | Identity | Few sub-lists; conservative typing | Keep IDs as strings |
+
+The agent code is the same across all four. The schema decides the workload.
+
+## Next steps
+
+| Task | Guide |
+|------|-------|
+| Process every PDF in a Drive folder | [Batch and durability](/use-cases/document-processing/batch-and-durability) |
+| Flag low-confidence KYC fields for review | [Human routing and eval](/use-cases/document-processing/human-routing-and-eval) |
+| Validate extraction against a labeled set | [Human routing and eval](/use-cases/document-processing/human-routing-and-eval) |
+
+## Developer Resources
+
+- [Document extraction cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/data_labeling/_16_document_extraction)
+- [Structured output](/input-output/structured-output/agent)

--- a/use-cases/document-processing/human-routing-and-eval.mdx
+++ b/use-cases/document-processing/human-routing-and-eval.mdx
@@ -1,0 +1,205 @@
+---
+title: "Human routing and eval"
+description: "Confidence-gated approval and accuracy tracking against a golden set."
+---
+
+Two production concerns the labeling docs leave open: routing low-confidence fields to a human, and tracking accuracy as the system runs over time. Both are short patterns on top of the same extraction agent.
+
+## Per-field confidence
+
+Wrap each field in a confidence carrier so a downstream check can decide what needs review. The schema is identical to the one in [data labeling](/use-cases/data-labeling/structured-extraction#per-field-confidence); the routing logic is the part that lives here.
+
+```python
+from typing import Literal, Optional
+
+from agno.agent import Agent
+from agno.media import File
+from agno.models.openai import OpenAIResponses
+from pydantic import BaseModel
+
+
+Confidence = Literal["high", "medium", "low"]
+
+
+class ConfidentField(BaseModel):
+    value: Optional[str] = None
+    confidence: Confidence
+
+
+class Invoice(BaseModel):
+    invoice_number: ConfidentField
+    vendor: ConfidentField
+    invoice_date: ConfidentField
+    total: ConfidentField
+
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=(
+        "Extract invoice fields. For each field, report confidence: "
+        "high (explicit on the document), medium (inferred from structure), "
+        "low (guessed, partly obscured, or ambiguous). Be conservative."
+    ),
+    output_schema=Invoice,
+)
+
+invoice = agent.run(
+    "Extract this invoice.",
+    files=[File(url="https://example.com/scan-low-quality.pdf")],
+).content
+# Invoice(invoice_number=ConfidentField(value='1042', confidence='high'),
+#         vendor=ConfidentField(value='Acme Corp', confidence='high'),
+#         invoice_date=ConfidentField(value=None, confidence='low'),
+#         total=ConfidentField(value='1296.0', confidence='medium'))
+```
+
+## Route on low confidence
+
+The trigger is plain Python. Walk the fields, find anything below threshold, and decide what to do with it.
+
+```python
+def low_confidence_fields(invoice: Invoice) -> list[str]:
+    return [
+        name
+        for name, field in invoice.model_dump().items()
+        if field.get("confidence") == "low"
+    ]
+
+
+flagged = low_confidence_fields(invoice)
+if flagged:
+    send_to_human_queue(invoice, flagged)
+else:
+    write_to_database(invoice)
+```
+
+The model returns confidence. Your code decides the threshold and the action. Two declaratives, no model-side branching.
+
+## Gate the next action with `requires_confirmation`
+
+For a tighter loop, wrap the downstream action (the database write, the ERP push) in a tool that requires approval, and only invoke it when confidence is high. The agent pauses on low confidence and a human can release the run.
+
+```python
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.tools import tool
+
+
+@tool(requires_confirmation=True)
+def post_to_erp(invoice_id: str, vendor: str, total: float) -> str:
+    """Post an extracted invoice to the AP ledger."""
+    # ...real ERP call...
+    return f"Posted {invoice_id} for {vendor}: {total}"
+
+
+writer = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[post_to_erp],
+    db=SqliteDb(db_file="tmp/extraction.db"),
+    instructions=(
+        "Given a parsed invoice, post it to the ERP with post_to_erp. "
+        "If any value is unclear, call the tool with what you have and "
+        "wait for human confirmation."
+    ),
+)
+
+run = writer.run(
+    f"Post this invoice: {invoice.model_dump_json()}"
+)
+
+if run.is_paused:
+    for requirement in run.active_requirements:
+        if requirement.needs_confirmation:
+            # Surface this to a reviewer UI; here we approve directly.
+            print(f"Approve: {requirement.tool_execution.tool_name}")
+            requirement.confirm()
+
+    run = writer.continue_run(
+        run_id=run.run_id,
+        requirements=run.requirements,
+    )
+```
+
+The pause is durable. `run.run_id` is persisted in `db`, so the approval can come from a different process minutes or hours later. See [human approval](/runtime/human-approval) for the full surface, including async variants and listing pending approvals from the database.
+
+## Accuracy against a golden set
+
+Confidence routes individual documents. Eval tells you whether the system as a whole is still extracting what it should. Build a small golden set (50 to a few hundred labeled documents) and grade the agent against it.
+
+```python
+from agno.agent import Agent
+from agno.eval.accuracy import AccuracyEval
+from agno.media import File
+from agno.models.openai import OpenAIResponses
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions="Extract invoice fields. Null if missing.",
+    output_schema=Invoice,
+)
+
+evaluation = AccuracyEval(
+    name="invoice-extraction-golden",
+    model=OpenAIResponses(id="gpt-5.5"),
+    agent=agent,
+    input=lambda: agent.run(
+        "Extract this invoice.",
+        files=[File(url="https://example.com/golden/invoice-001.pdf")],
+    ),
+    expected_output=(
+        "Invoice number 1042, vendor Acme Corp, dated 2026-04-12, "
+        "total 1296.00 USD."
+    ),
+    num_iterations=3,
+)
+
+result = evaluation.run(print_results=True)
+# AccuracyResult(name='invoice-extraction-golden', avg_score=9.0, ...)
+assert result is not None and result.avg_score >= 8
+```
+
+`AccuracyEval` runs the agent `num_iterations` times against the same input, asks a grader model to score each run against the expected output, and reports the average. Loop the call over your golden set to get a per-document score.
+
+```python
+results = []
+for doc in golden_set:
+    eval_ = AccuracyEval(
+        name=f"invoice-{doc.id}",
+        model=OpenAIResponses(id="gpt-5.5"),
+        agent=agent,
+        input=lambda doc=doc: agent.run(
+            "Extract this invoice.",
+            files=[File(filepath=doc.path)],
+        ),
+        expected_output=doc.expected_description,
+        num_iterations=1,
+    )
+    results.append(eval_.run(print_results=False))
+```
+
+Persist the per-document score to the same `db` you use for runs, and you have a regression signal. A drop in average score after a model swap or prompt change tells you the new configuration is worse before it reaches production. See the [evals cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/09_evals/accuracy) for `db_logging` and the team variant.
+
+## Two patterns, one job
+
+| Pattern | What it answers | When it fires |
+|---------|------------------|---------------|
+| Confidence routing | "Which fields on this document need a human?" | Every run, per document |
+| Approval-gated tools | "Should we let the agent take the next action?" | At a specific tool boundary |
+| AccuracyEval over a golden set | "Is the extractor still as accurate as last week?" | On CI, after a prompt or model change, on a schedule |
+
+The first two protect a single document. The third protects the system.
+
+## Next steps
+
+| Task | Guide |
+|------|-------|
+| Schedule the eval to run nightly | [Batch and durability](/use-cases/document-processing/batch-and-durability) |
+| Approve from an external UI | [Human approval](/runtime/human-approval) |
+| Add a two-labeler review step | [Quality pipeline](/use-cases/data-labeling/quality-pipeline) |
+
+## Developer Resources
+
+- [Approval cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/02_agents/11_approvals)
+- [Accuracy eval cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/09_evals/accuracy)
+- [Human approval](/runtime/human-approval)

--- a/use-cases/document-processing/invoices-and-receipts.mdx
+++ b/use-cases/document-processing/invoices-and-receipts.mdx
@@ -1,0 +1,123 @@
+---
+title: "Invoices and receipts"
+description: "Header fields, line items, and the path from PDF to a database row."
+---
+
+The shape AP teams need: a header (vendor, totals, dates) and a list of line items. The schema is the contract with downstream systems.
+
+```python
+from typing import List, Optional
+
+from agno.agent import Agent
+from agno.media import File
+from agno.models.openai import OpenAIResponses
+from pydantic import BaseModel, Field
+
+
+class LineItem(BaseModel):
+    description: str = Field(..., description="Line description as printed")
+    quantity: Optional[float] = None
+    unit_price: Optional[float] = None
+    amount: Optional[float] = Field(None, description="Line total in invoice currency")
+
+
+class Invoice(BaseModel):
+    invoice_number: Optional[str] = None
+    vendor: Optional[str] = None
+    vendor_tax_id: Optional[str] = None
+    bill_to: Optional[str] = None
+    invoice_date: Optional[str] = Field(None, description="ISO 8601 if possible")
+    due_date: Optional[str] = None
+    currency: Optional[str] = Field(None, description="ISO 4217, e.g. USD, EUR")
+    subtotal: Optional[float] = None
+    tax: Optional[float] = None
+    total: Optional[float] = None
+    lines: List[LineItem] = Field(default_factory=list)
+
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=(
+        "Extract every field and every line item from the attached invoice. "
+        "Numbers stay as numbers. Use ISO 8601 for dates when the format is "
+        "unambiguous. Null for missing fields. Do not invent line items."
+    ),
+    output_schema=Invoice,
+)
+
+invoice = agent.run(
+    "Extract this invoice.",
+    files=[File(url="https://example.com/invoice-1042.pdf")],
+).content
+# Invoice(invoice_number='1042', vendor='Acme Corp', invoice_date='2026-04-12',
+#         total=1296.0, currency='USD', lines=[LineItem(description='Pro plan',
+#         quantity=12, unit_price=99.0, amount=1188.0), LineItem(...)])
+```
+
+The hard part is the missing-field discipline. A hallucinated `total` corrupts the AP ledger. Two lines in the instructions ("use exactly what the document shows", "null if missing") cut the hallucination rate substantially on noisy scans.
+
+## Persist the row
+
+The agent's job ends at a validated `Invoice`. The next step is a normal INSERT. Pydantic `.model_dump()` gives you a dict you can hand to any driver.
+
+```python
+from sqlalchemy import create_engine, text
+
+engine = create_engine("postgresql+psycopg://ai:ai@localhost:5532/ap")
+
+with engine.begin() as conn:
+    invoice_id = conn.execute(
+        text(
+            "INSERT INTO invoices (invoice_number, vendor, invoice_date, "
+            "due_date, currency, subtotal, tax, total) "
+            "VALUES (:invoice_number, :vendor, :invoice_date, :due_date, "
+            ":currency, :subtotal, :tax, :total) RETURNING id"
+        ),
+        invoice.model_dump(exclude={"lines"}),
+    ).scalar_one()
+
+    for line in invoice.lines:
+        conn.execute(
+            text(
+                "INSERT INTO invoice_lines (invoice_id, description, "
+                "quantity, unit_price, amount) "
+                "VALUES (:invoice_id, :description, :quantity, "
+                ":unit_price, :amount)"
+            ),
+            {"invoice_id": invoice_id, **line.model_dump()},
+        )
+```
+
+Two writes per invoice. The schema decides the table layout; the agent decides the values.
+
+## Receipts
+
+Receipts are invoices with a thinner header. Drop `due_date`, `vendor_tax_id`, and `bill_to`. Keep the same line-item shape. The same agent and the same instructions work; only `output_schema` changes.
+
+```python
+class Receipt(BaseModel):
+    merchant: Optional[str] = None
+    purchase_date: Optional[str] = None
+    currency: Optional[str] = None
+    total: Optional[float] = None
+    lines: List[LineItem] = Field(default_factory=list)
+```
+
+For phone-camera receipts (skewed, low light), the input becomes an image rather than a PDF. See [multimodal inputs](/use-cases/data-labeling/multimodal-inputs) for the input argument.
+
+## Confidence on noisy scans
+
+Production AP sees faxed copies, partial scans, and mixed-language invoices. When you need a flag for "send this to a human", wrap each value in a confidence carrier. The pattern is identical to the [data labeling pattern](/use-cases/data-labeling/structured-extraction#per-field-confidence) and feeds the routing logic in [human routing and eval](/use-cases/document-processing/human-routing-and-eval).
+
+## Next steps
+
+| Task | Guide |
+|------|-------|
+| Process a folder of invoices | [Batch and durability](/use-cases/document-processing/batch-and-durability) |
+| Route low-confidence invoices to AP review | [Human routing and eval](/use-cases/document-processing/human-routing-and-eval) |
+| Extract contract clauses with the same primitive | [Contracts](/use-cases/document-processing/contracts) |
+
+## Developer Resources
+
+- [Document extraction cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/data_labeling/_16_document_extraction)
+- [Structured output](/input-output/structured-output/agent)

--- a/use-cases/document-processing/overview.mdx
+++ b/use-cases/document-processing/overview.mdx
@@ -1,0 +1,102 @@
+---
+title: "Document processing"
+sidebarTitle: "Overview"
+description: "Turn PDFs and scanned documents into typed rows for your production systems."
+---
+
+Every business runs on documents. Invoices land in AP, contracts go to legal, claims hit operations, resumes route to recruiting. Agno turns each of those into a typed Python object you can persist, route, or hand to the next system.
+
+Define the schema, pass the PDF, get a validated object back.
+
+```python
+from typing import List, Optional
+
+from agno.agent import Agent
+from agno.media import File
+from agno.models.openai import OpenAIResponses
+from pydantic import BaseModel, Field
+
+
+class LineItem(BaseModel):
+    description: str
+    quantity: Optional[float] = None
+    unit_price: Optional[float] = None
+    amount: Optional[float] = None
+
+
+class Invoice(BaseModel):
+    invoice_number: Optional[str] = Field(None, description="As printed on the invoice")
+    vendor: Optional[str] = None
+    invoice_date: Optional[str] = None
+    due_date: Optional[str] = None
+    subtotal: Optional[float] = None
+    tax: Optional[float] = None
+    total: Optional[float] = None
+    currency: Optional[str] = Field(None, description="ISO 4217, e.g. USD, EUR")
+    lines: List[LineItem] = Field(default_factory=list)
+
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=(
+        "Extract invoice fields and line items from the attached PDF. "
+        "Use exactly what the document shows. If a field is missing, "
+        "leave it null. Do not guess."
+    ),
+    output_schema=Invoice,
+)
+
+result = agent.run(
+    "Extract the invoice.",
+    files=[File(url="https://example.com/invoice-1042.pdf")],
+).content
+# Invoice(invoice_number='1042', vendor='Acme Corp', invoice_date='2026-04-12',
+#         due_date='2026-05-12', subtotal=1200.0, tax=96.0, total=1296.0,
+#         currency='USD', lines=[LineItem(...), LineItem(...)])
+```
+
+`result` is a validated `Invoice`. The next line in your code is an `INSERT`, an ERP call, or a queue message. The model has done its job.
+
+## Workloads
+
+| Workload | Page |
+|----------|------|
+| Invoices, receipts, statements | [Invoices and receipts](/use-cases/document-processing/invoices-and-receipts) |
+| Contracts, MSAs, policies | [Contracts](/use-cases/document-processing/contracts) |
+| Resumes, applications, KYC intake | [Forms and intake](/use-cases/document-processing/forms-and-intake) |
+
+## Production concerns
+
+| You need to | Page |
+|-------------|------|
+| Process a folder or a queue of documents | [Batch and durability](/use-cases/document-processing/batch-and-durability) |
+| Schedule a nightly run that retries on failure | [Batch and durability](/use-cases/document-processing/batch-and-durability) |
+| Route low-confidence fields to a human | [Human routing and eval](/use-cases/document-processing/human-routing-and-eval) |
+| Track accuracy against a labeled golden set | [Human routing and eval](/use-cases/document-processing/human-routing-and-eval) |
+
+## Explore
+
+<CardGroup cols={2}>
+  <Card title="Invoices and receipts" icon="file-invoice-dollar" href="/use-cases/document-processing/invoices-and-receipts">
+    Header fields, line items, and the path from PDF to a database row.
+  </Card>
+  <Card title="Contracts" icon="file-signature" href="/use-cases/document-processing/contracts">
+    Parties, dates, and a clause-level breakdown for review queues.
+  </Card>
+  <Card title="Forms and intake" icon="clipboard-list" href="/use-cases/document-processing/forms-and-intake">
+    Resumes, applications, KYC. Lists inside lists, same `File()` plumbing.
+  </Card>
+  <Card title="Batch and durability" icon="layer-group" href="/use-cases/document-processing/batch-and-durability">
+    Workflows over a folder, background runs, scheduled jobs with retries.
+  </Card>
+  <Card title="Human routing and eval" icon="user-check" href="/use-cases/document-processing/human-routing-and-eval">
+    Confidence-gated approval and accuracy tracking against a golden set.
+  </Card>
+</CardGroup>
+
+## Developer Resources
+
+- [Document extraction cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/data_labeling/_16_document_extraction)
+- [Structured output](/input-output/structured-output/agent)
+- [Workflows](/workflows/overview)
+- [Scheduler cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/05_agent_os/scheduler)

--- a/use-cases/product-agents/overview.mdx
+++ b/use-cases/product-agents/overview.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Product agents"
+title: "Product Copilots & Agents"
 sidebarTitle: "Overview"
-description: "Build agents to power every part of your product, from chat to proactive assistance."
+description: "Run a fleet of agents to power every part of your product and operations, from chat to proactive assistance."
 ---
 
 Software is becoming agentic and many parts of your product will become agent-driven.
 
 Most products start with a chat copilot, then add more agent-driven surfaces: smart empty states, inline workflow recommendations, personalized help notes, proactive nudges. Each one is its own agent with its own job.
 
-Agno runs all of them from one backend. Sessions, memory, knowledge, and auth are shared across every surface, so the product feels like one system.
+Agno runs all of them in one place. Sessions, memory, knowledge, and auth are shared across every surface, so the product feels like one system.
 
 ```python
 from agno.agent import Agent


### PR DESCRIPTION
## Summary
- Adds a new **Document Processing** group under Use Cases in `docs.json` with six pages: overview, invoices and receipts, contracts, forms and intake, batch and durability, and human routing and eval.
- Tweaks the landing copy in `index.mdx` (description and intro paragraphs).
- Small copy polish on `use-cases/data-agents/overview.mdx` and `use-cases/product-agents/overview.mdx`.

## Test plan
- [ ] `mint dev` renders the new Document Processing section under Use Cases
- [ ] `mint broken-links` passes
- [ ] `mint build` passes
- [ ] Spot-check each of the six new pages in the local preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)