### PR TITLE
chore: add docs parity for recent sdk releases

### DIFF
--- a/agent-os/interfaces/slack/hitl.mdx
+++ b/agent-os/interfaces/slack/hitl.mdx
@@ -1,0 +1,89 @@
+---
+title: Human-in-the-Loop
+sidebarTitle: Human-in-the-Loop
+description: "Pause agents and teams for approval directly in Slack, rendered as interactive TaskCards."
+keywords: [slack, hitl, human-in-the-loop, approval, confirmation, task cards]
+---
+
+When an agent or team pauses for [human-in-the-loop](/hitl/overview), the Slack interface renders the pause as an interactive TaskCard in the channel. The user resolves it with buttons and inputs, and the run resumes. All four pause types are supported.
+
+## Example
+
+A paused run is persisted to the database and resumed by `run_id` when the user resolves the TaskCard, so the Slack interface needs a `db`.
+
+```python cookbook/05_agent_os/interfaces/slack/hitl_simple.py
+import json
+import httpx
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.slack import Slack
+from agno.tools import tool
+
+
+@tool(requires_confirmation=True)
+def get_top_hackernews_stories(num_stories: int) -> str:
+    """Fetch top stories from Hacker News."""
+    response = httpx.get("https://hacker-news.firebaseio.com/v0/topstories.json")
+    story_ids = response.json()
+    return json.dumps(story_ids[:num_stories])
+
+
+db = SqliteDb(
+    db_file="tmp/hitl_simple.db",
+    session_table="agent_sessions",
+    approvals_table="approvals",  # only needed for AgentOS admin-gated approvals
+)
+
+agent = Agent(
+    name="HN Agent",
+    id="hn-agent",
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[get_top_hackernews_stories],
+    db=db,
+)
+
+agent_os = AgentOS(
+    agents=[agent],
+    db=db,
+    interfaces=[Slack(agent=agent, reply_to_mentions_only=True)],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="hitl_simple:app", reload=True, port=7777)
+```
+
+## Pause Types
+
+Each pause type renders a different TaskCard:
+
+| Pause type            | Slack UI                                                                 | Trigger                                              |
+| --------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------- |
+| Confirmation          | Approve / Reject buttons. Multiple pending tools render as separate rows. | `@tool(requires_confirmation=True)`                  |
+| User input            | Text fields, or dropdowns for `Literal`/`Enum`-typed fields.             | `@tool(requires_user_input=True)`                    |
+| User feedback         | Option buttons from a structured question.                               | [`UserFeedbackTools`](/tools/toolkits/others/user-feedback) |
+| External execution    | Confirm button. The tool runs outside the agent, result is fed back.     | `@tool(external_execution=True)`                     |
+
+Rejections collect a reason where applicable, which is passed back to the agent so it can adjust.
+
+## Teams and Workflows
+
+The same TaskCards work for teams and workflows. When a member agent inside a team pauses, the pause propagates to the team run and surfaces in Slack. Workflow step and executor pauses surface the same way.
+
+| Pattern  | Cookbook |
+|----------|----------|
+| Agent confirmation | [hitl_confirmation.py](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/interfaces/slack/hitl_confirmation.py) |
+| User input | [hitl_user_input.py](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/interfaces/slack/hitl_user_input.py) |
+| External execution | [hitl_external_execution.py](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/interfaces/slack/hitl_external_execution.py) |
+| Structured feedback | [hitl_user_feedback.py](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/interfaces/slack/hitl_user_feedback.py) |
+| Team confirmation | [team_hitl_confirmation.py](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/interfaces/slack/team_hitl_confirmation.py) |
+
+## Next Steps
+
+| Task | Guide |
+|------|-------|
+| Understand pause types | [HITL overview](/hitl/overview) |
+| Set up the Slack interface | [Slack introduction](/agent-os/interfaces/slack/introduction) |
+| Manage approvals in AgentOS | [Approvals overview](/agent-os/approvals/overview) |

--- a/agent-os/interfaces/slack/hitl.mdx
+++ b/agent-os/interfaces/slack/hitl.mdx
@@ -33,7 +33,6 @@ def get_top_hackernews_stories(num_stories: int) -> str:
 db = SqliteDb(
     db_file="tmp/hitl_simple.db",
     session_table="agent_sessions",
-    approvals_table="approvals",  # only needed for AgentOS admin-gated approvals
 )
 
 agent = Agent(

--- a/agent-os/security/rbac.mdx
+++ b/agent-os/security/rbac.mdx
@@ -414,6 +414,41 @@ export JWT_VERIFICATION_KEY="your-public-key"
 export JWT_JWKS_FILE="/path/to/jwks.json"
 ```
 
+## Per-User Data Isolation
+
+RBAC controls which operations a caller can perform. Per-user data isolation controls which rows a caller can see and write. Opt in with `user_isolation=True`:
+
+```python
+from agno.os import AgentOS
+from agno.os.config import AuthorizationConfig
+
+agent_os = AgentOS(
+    id="my-agent-os",
+    agents=[agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=["your-jwt-verification-key"],
+        algorithm="RS256",
+        user_isolation=True,
+    ),
+)
+```
+
+When enabled, AgentOS uses the JWT `sub` claim as the `user_id` for every non-admin caller:
+
+| Operation | Behavior with `user_isolation=True` |
+|-----------|-------------------------------------|
+| Reads (sessions, memory, traces) | Scoped to the caller's `user_id`. Other users' rows are not returned. |
+| Writes (sessions, memories, traces) | `user_id` is coerced to the caller's `sub`. A caller cannot persist rows attributed to another user. |
+| Cancel / resume / continue routes | Require `session_id` and verify the caller owns the run. |
+| WebSocket reconnect | Requires `session_id` (and `workflow_id`) for non-admins. |
+
+A caller holding `admin_scope` (default `agent_os:admin`) bypasses isolation and sees all data. Set a custom override with `admin_scope="ops:admin"`.
+
+<Note>
+Isolation is off by default. JWT/RBAC still apply when `user_isolation=False`, but routes operate on the unscoped database and add no per-user ownership gates on top of RBAC. Per-user isolation requires a database that records `user_id` (PostgreSQL recommended for production).
+</Note>
+
 ## Excluded Routes
 
 These routes are excluded from RBAC checks by default:
@@ -443,6 +478,13 @@ These routes are excluded from RBAC checks by default:
     href="/agent-os/usage/rbac/per-agent-permissions"
   >
     Grant specific permissions to specific agents
+  </Card>
+  <Card
+    title="Per-User Data Isolation"
+    icon="users"
+    href="https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/rbac/symmetric/user_isolation.py"
+  >
+    Scope sessions, memory, and traces per user with user_isolation=True
   </Card>
 </CardGroup>
 

--- a/context-providers/providers/workspace.mdx
+++ b/context-providers/providers/workspace.mdx
@@ -1,0 +1,78 @@
+---
+title: Workspace
+sidebarTitle: Workspace
+description: "Give an agent read-only, project-aware access to a local working directory."
+keywords: [context providers, workspace, filesystem, repository, code]
+---
+
+Wrap a project directory and expose a single `query_<id>` tool. The tool routes through a read-only sub-agent with the [`Workspace`](/tools/toolkits/local/workspace) toolkit scoped to `root`: list files, search content, and read files with line numbers. Common dependency directories, build outputs, caches, and virtualenvs are excluded by default.
+
+```python cookbook/12_context/13_workspace.py
+from pathlib import Path
+from agno.agent import Agent
+from agno.context.workspace import WorkspaceContextProvider
+from agno.models.openai import OpenAIResponses
+
+project = WorkspaceContextProvider(
+    id="agno",
+    name="Agno Project",
+    root=Path("/path/to/repo"),
+    model=OpenAIResponses(id="gpt-5.4-mini"),
+)
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=project.get_tools(),
+    instructions=project.instructions(),
+    markdown=True,
+)
+
+await agent.aprint_response("Where is the Workspace toolkit implemented? Cite the files you read.")
+```
+
+## Workspace vs Filesystem provider
+
+| Provider                       | Use for                                                                 |
+| ------------------------------ | ----------------------------------------------------------------------- |
+| `WorkspaceContextProvider`     | Repository roots and active project trees. Excludes build/dependency noise by default. |
+| [`FilesystemContextProvider`](/context-providers/providers/filesystem) | A scoped directory of documents with no project-aware exclusions.       |
+
+## Configuration
+
+| Parameter          | Type                  | Default     | Description                                                       |
+| ------------------ | --------------------- | ----------- | ----------------------------------------------------------------- |
+| `root`             | `Optional[str\|Path]` | `cwd`       | Directory the workspace is rooted at.                             |
+| `id`               | `str`                 | `"workspace"` | Tool becomes `query_<id>`.                                      |
+| `name`             | `str`                 | `"Workspace"` | Display name used in instructions.                              |
+| `model`            | `Model`               | `None`      | Model for the read-only sub-agent.                               |
+| `instructions`     | `Optional[str]`       | defaults    | Override the sub-agent's instructions. `{root}` is substituted.   |
+| `exclude_patterns` | `Optional[List[str]]` | noise dirs  | Patterns skipped when listing/searching. Pass `[]` to disable.    |
+| `max_file_lines`   | `int`                 | `100000`    | Maximum lines the sub-agent reads per file.                       |
+| `max_file_length`  | `int`                 | `10000000`  | Maximum file size (bytes) the sub-agent reads.                    |
+
+## Tools Exposed
+
+| Tool         | Description                                              |
+| ------------ | -------------------------------------------------------- |
+| `query_<id>` | Ask a question about the project. The sub-agent lists, searches, and reads files to answer. Read-only. |
+
+The provider is read-only by design. No save, edit, delete, move, or shell tools are exposed. For write access to a working directory, use the [`Workspace` toolkit](/tools/toolkits/local/workspace) directly with confirmation gates.
+
+## Example queries
+
+| Query | What happens |
+|-------|--------------|
+| "Where is authentication handled in this repo?" | Sub-agent searches and reads relevant files |
+| "Summarize the structure of the cookbook directory" | Lists the directory tree, summarizes |
+| "What does the workflow module export?" | Reads `__init__.py` and reports |
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="Workspace Toolkit" icon="wrench" href="/tools/toolkits/local/workspace">
+    The underlying read/write toolkit
+  </Card>
+  <Card title="Cookbook Example" icon="book" href="https://github.com/agno-agi/agno/blob/main/cookbook/12_context/13_workspace.py">
+    Project-aware workspace example
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -2002,7 +2002,8 @@
                       "context-providers/providers/filesystem",
                       "context-providers/providers/web",
                       "context-providers/providers/mcp",
-                      "context-providers/providers/wiki"
+                      "context-providers/providers/wiki",
+                      "context-providers/providers/workspace"
                     ]
                   },
                   "context-providers/custom-providers"
@@ -2171,12 +2172,14 @@
                         "group": "Local",
                         "pages": [
                           "tools/toolkits/local/calculator",
+                          "tools/toolkits/local/coding",
                           "tools/toolkits/local/docker",
                           "tools/toolkits/local/file",
                           "tools/toolkits/local/local-file-system",
                           "tools/toolkits/local/python",
                           "tools/toolkits/local/shell",
-                          "tools/toolkits/local/sleep"
+                          "tools/toolkits/local/sleep",
+                          "tools/toolkits/local/workspace"
                         ]
                       },
                       {
@@ -2224,6 +2227,7 @@
                           "tools/toolkits/others/giphy",
                           "tools/toolkits/others/github",
                           "tools/toolkits/others/gitlab",
+                          "tools/toolkits/others/google-drive",
                           "tools/toolkits/others/google-maps",
                           "tools/toolkits/others/googlecalendar",
                           "tools/toolkits/others/google-sheets",
@@ -2231,6 +2235,7 @@
                           "tools/toolkits/others/jira",
                           "tools/toolkits/others/knowledge",
                           "tools/toolkits/others/linear",
+                          "tools/toolkits/others/llms-txt",
                           "tools/toolkits/others/lumalabs",
                           "tools/toolkits/others/mem0",
                           "tools/toolkits/others/mlx-transcribe",
@@ -2251,6 +2256,7 @@
                           "tools/toolkits/others/todoist",
                           "tools/toolkits/others/trello",
                           "tools/toolkits/others/user-control-flow",
+                          "tools/toolkits/others/user-feedback",
                           "tools/toolkits/others/visualization",
                           "tools/toolkits/others/web-browser",
                           "tools/toolkits/others/webtools",
@@ -4533,6 +4539,7 @@
                     "group": "Slack",
                     "pages": [
                       "agent-os/interfaces/slack/introduction",
+                      "agent-os/interfaces/slack/hitl",
                       "agent-os/interfaces/slack/reference"
                     ]
                   },

--- a/models/providers/native/anthropic/usage/prompt-caching.mdx
+++ b/models/providers/native/anthropic/usage/prompt-caching.mdx
@@ -43,6 +43,66 @@ agent = Agent(
 )
 ```
 
+## Multi-block caching with per-block TTL
+
+Split the system prompt into independently-cacheable blocks with `system_prompt_blocks`. Each `SystemPromptBlock` controls its own `cache` flag and `ttl`. This lets you cache static instructions while leaving dynamic per-request content uncached.
+
+```python cookbook/11_models/anthropic/prompt_caching_multi_block.py
+from datetime import datetime
+from agno.agent import Agent
+from agno.models.anthropic import Claude, SystemPromptBlock
+
+blocks = [
+    # Static instructions, cached for 1 hour
+    SystemPromptBlock(
+        text="You are a senior software architect. Give concise, opinionated advice.",
+        cache=True,
+        ttl="1h",
+    ),
+    # Dynamic per-request context, never cached
+    SystemPromptBlock(
+        text=f"Current time: {datetime.now().isoformat()}",
+        cache=False,
+    ),
+]
+
+agent = Agent(
+    model=Claude(
+        id="claude-sonnet-4-5-20250929",
+        cache_system_prompt=True,
+        extended_cache_time=True,
+        system_prompt_blocks=blocks,
+    ),
+    markdown=True,
+)
+```
+
+Blocks are appended after the agent-built system message in the Anthropic `system` array. `system_prompt_blocks` may also be a zero-arg callable that returns the list, evaluated on every request, which is how you inject dynamic content into a cached prompt without reinstantiating the model.
+
+| `SystemPromptBlock` field | Type | Default | Description |
+|---------------------------|------|---------|-------------|
+| `text` | `str` | required | The block content. |
+| `cache` | `bool` | `True` | Add `cache_control` to this block. Independent of `cache_system_prompt`. |
+| `ttl` | `Optional["5m" \| "1h"]` | `None` | Per-block TTL. Overrides the model-level `extended_cache_time` for this block. |
+
+<Warning>
+Anthropic requires any `1h` cached block to appear before any `5m` block in the request. Since the agent-built block comes first and inherits the model-level TTL, set `extended_cache_time=True` whenever any `SystemPromptBlock` uses `ttl="1h"`. Agno validates this ordering at assembly time and raises a clear error if it is violated.
+</Warning>
+
+## Tool caching
+
+Set `cache_tools=True` to cache tool definitions. Anthropic caches all tools as a prefix when `cache_control` is on the last tool.
+
+```python
+agent = Agent(
+    model=Claude(
+        id="claude-sonnet-4-5-20250929",
+        cache_tools=True,
+    ),
+    tools=[...],
+)
+```
+
 ## Working example
 
 ```python cookbook/11_models/anthropic/prompt_caching_extended.py

--- a/tools/toolkits/local/coding.mdx
+++ b/tools/toolkits/local/coding.mdx
@@ -1,0 +1,70 @@
+---
+title: Coding
+description: "CodingTools gives an agent four core file/shell tools to perform any coding task in a scoped directory."
+---
+
+`CodingTools` is a minimal toolkit for coding agents. Four core tools (read, edit, write, shell) let an agent run tests, use git, install packages, and edit code. Three exploration tools (grep, find, ls) are opt-in.
+
+## Example
+
+```python cookbook/91_tools/coding_tools/01_basic_usage.py
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.coding import CodingTools
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[CodingTools(base_dir=".")],
+    instructions="You are a coding assistant. Use the coding tools to help the user.",
+    markdown=True,
+)
+
+agent.print_response(
+    "List the files in the current directory and read the README.md file if it exists.",
+    stream=True,
+)
+```
+
+<Warning>
+`CodingTools` can run arbitrary shell commands. By default `restrict_to_base_dir=True` scopes file and shell operations to `base_dir` and only allows commands in `allowed_commands`. Keep human supervision for untrusted prompts, and run inside a sandbox (container, VM, or [Daytona](/tools/toolkits/others/daytona)) for untrusted code execution.
+</Warning>
+
+## Toolkit Params
+
+| Parameter             | Type                  | Default        | Description                                                          |
+| --------------------- | --------------------- | -------------- | -------------------------------------------------------------------- |
+| `base_dir`            | `Optional[Path\|str]` | `cwd`          | Root directory for file operations.                                  |
+| `restrict_to_base_dir`| `bool`                | `True`         | When True, file and shell operations cannot escape `base_dir`.       |
+| `max_lines`           | `int`                 | `2000`         | Maximum lines returned before truncating.                            |
+| `max_bytes`           | `int`                 | `50000`        | Maximum bytes returned before truncating.                            |
+| `shell_timeout`       | `int`                 | `120`          | Timeout in seconds for shell commands.                               |
+| `enable_read_file`    | `bool`                | `True`         | Enable the `read_file` tool.                                         |
+| `enable_edit_file`    | `bool`                | `True`         | Enable the `edit_file` tool.                                         |
+| `enable_write_file`   | `bool`                | `True`         | Enable the `write_file` tool.                                        |
+| `enable_run_shell`    | `bool`                | `True`         | Enable the `run_shell` tool.                                         |
+| `enable_grep`         | `bool`                | `False`        | Enable the `grep` tool.                                              |
+| `enable_find`         | `bool`                | `False`        | Enable the `find` tool.                                              |
+| `enable_ls`           | `bool`                | `False`        | Enable the `ls` tool.                                                |
+| `all`                 | `bool`                | `False`        | Enable all tools regardless of individual flags.                     |
+| `allowed_commands`    | `Optional[List[str]]` | sensible set   | Allowed shell command names when `restrict_to_base_dir` is True.     |
+
+## Toolkit Functions
+
+| Function     | Description                                                       |
+| ------------ | ----------------------------------------------------------------- |
+| `read_file`  | Read a file with line numbers and pagination (`offset`, `limit`). |
+| `edit_file`  | Exact text find-and-replace, returns a diff.                      |
+| `write_file` | Create or overwrite a file.                                       |
+| `run_shell`  | Execute a shell command with a timeout.                           |
+| `grep`       | Search file contents (opt-in).                                    |
+| `find`       | Find files by glob pattern (opt-in).                              |
+| `ls`         | List directory contents (opt-in).                                 |
+
+All functions have sync and async variants.
+
+## Developer Resources
+
+- [Tools source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/coding.py)
+- [Basic usage](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/coding_tools/01_basic_usage.py)
+- [All tools](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/coding_tools/02_all_tools.py)
+- [Workspace toolkit](/tools/toolkits/local/workspace) for a confirmation-gated alternative

--- a/tools/toolkits/local/file.mdx
+++ b/tools/toolkits/local/file.mdx
@@ -26,9 +26,11 @@ agent.print_response("What is the most advanced LLM currently? Save the answer t
 | `enable_read_file_chunks` | `bool` | `True` | Enables functionality to read files in chunks              |
 | `enable_replace_file_chunk` | `bool` | `True` | Enables functionality to update files in chunks          |
 | `enable_list_files`   | `bool` | `True`  | Enables functionality to list files in directories            |
-| `enable_search_files` | `bool` | `True`  | Enables functionality to search for files                     |
+| `enable_search_files` | `bool` | `True`  | Enables functionality to search for files by name pattern     |
+| `enable_search_content` | `bool` | `True` | Enables functionality to search file contents (`search_content`) |
 | `all`                 | `bool` | `False` | Enables all functionality when set to True                    |
 | `expose_base_directory` | `bool` | `False` | Adds 'base_directory' to the tool responses if set to True  |
+| `exclude_patterns` | `Optional[List[str]]` | noise dirs | fnmatch-style patterns skipped by `list_files`, `search_files`, and `search_content`. Pass `[]` to disable exclusion. Does not parse `.gitignore`. |
 | `max_file_length` | `int` | `10000000` | Maximum file length to read in bytes. Reading will fail if the file is larger. |
 | `max_file_lines` | `int` | `100000` | Maximum number of lines to read from a file. Reading will fail if the file has more lines. |
 | `line_separator` | `str` | `"\n"` | The separator to use when interacting with chunks. |
@@ -43,6 +45,8 @@ agent.print_response("What is the most advanced LLM currently? Save the answer t
 | `replace_file_chunk` | Partial replace of the contents of the file `file_name`  |
 | `delete_file` | Deletes the file `file_name` if successful. |
 | `list_files` | Returns a list of files in the base directory                                            |
+| `search_files` | Finds files by name using an fnmatch-style `pattern`. |
+| `search_content` | Searches file contents for a `query` within an optional `directory`, returning up to `limit` matches. |
 
 ## Developer Resources
 

--- a/tools/toolkits/local/workspace.mdx
+++ b/tools/toolkits/local/workspace.mdx
@@ -1,0 +1,96 @@
+---
+title: Workspace
+description: "Workspace gives an agent read/write/edit/search/shell access to a directory, with destructive operations gated behind human confirmation by default."
+---
+
+`Workspace` is a local-machine toolkit scoped to a single `root` directory. Reads (`read`, `list`, `search`) run silently; destructive operations (`write`, `edit`, `move`, `delete`, `shell`) require human confirmation by default, which AgentOS renders as approval prompts in the run timeline.
+
+## Example
+
+```python cookbook/91_tools/workspace_tools/basic_usage.py
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.workspace import Workspace
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[
+        Workspace(
+            "/path/to/project",
+            allowed=["read", "list", "search"],
+            confirm=["write", "edit", "move", "delete", "shell"],
+        )
+    ],
+    markdown=True,
+)
+
+agent.print_response("Read README.md, then write a 2-line summary to NOTES.md.")
+```
+
+## Permission Model
+
+`allowed` and `confirm` are mutually exclusive partitions of short aliases:
+
+| In list      | Behavior                                                            |
+| ------------ | ------------------------------------------------------------------- |
+| `allowed`    | Runs silently.                                                      |
+| `confirm`    | Requires user approval via [HITL](/hitl/overview) pause/resume.     |
+| neither      | Not registered with the toolkit. The LLM never sees it.             |
+| both         | Raises `ValueError`.                                                |
+
+When both lists are `None`, reads auto-pass and writes require confirmation (the safe default). When only one is set, the other defaults to `[]`. Use `Workspace.ALL_TOOLS` to register every tool.
+
+| Alias    | Registered tool   | What it does                              |
+| -------- | ----------------- | ----------------------------------------- |
+| `read`   | `read_file`       | Read a file (line-numbered).              |
+| `list`   | `list_files`      | List a directory (recursive option).      |
+| `search` | `search_content`  | Recursive content grep.                   |
+| `write`  | `write_file`      | Create or overwrite a file (atomic).      |
+| `edit`   | `edit_file`       | Replace a substring (with `replace_all`). |
+| `move`   | `move_file`       | Move or rename a file.                    |
+| `delete` | `delete_file`     | Delete a file.                            |
+| `shell`  | `run_command`     | Run a shell command in `root`.            |
+
+<Warning>
+This is a path-scoping boundary, not a process sandbox. Paths resolving outside `root` are rejected, but the agent can still read environment variables and make network calls via shell. For untrusted code execution, run the agent inside a real sandbox (container, VM, or [Daytona](/tools/toolkits/others/daytona)).
+</Warning>
+
+## Toolkit Params
+
+| Parameter                   | Type                    | Default      | Description                                                                 |
+| --------------------------- | ----------------------- | ------------ | --------------------------------------------------------------------------- |
+| `root`                      | `Optional[str\|Path]`   | `cwd`        | Directory all operations are scoped to.                                     |
+| `allowed`                   | `Optional[List[str]]`   | `None`       | Aliases that run silently.                                                  |
+| `confirm`                   | `Optional[List[str]]`   | `None`       | Aliases that require confirmation.                                          |
+| `require_read_before_write` | `bool`                  | `False`      | Block writes/edits/move/delete on existing files until read this session.   |
+| `max_file_lines`            | `int`                   | `100000`     | Maximum lines `read_file` will load.                                        |
+| `max_file_length`           | `int`                   | `10000000`   | Maximum file size (bytes) `read_file` will load.                            |
+| `exclude_patterns`          | `Optional[List[str]]`   | noise dirs   | Patterns skipped by `list_files`/`search_content`. Pass `[]` to disable.    |
+
+`list_files` and `search_content` skip common noise directories (`.venv`, `.git`, `__pycache__`, `node_modules`, etc.) by default.
+
+## Confirmation Flow
+
+With aliases in `confirm`, the run pauses when the agent calls a gated tool. Resolve the requirement and continue the run:
+
+```python
+run_response = agent.run("Delete the old logs in /tmp/project")
+
+while run_response.is_paused:
+    for requirement in run_response.active_requirements:
+        if requirement.needs_confirmation:
+            requirement.confirm()  # or requirement.reject()
+    run_response = agent.continue_run(
+        run_id=run_response.run_id,
+        requirements=run_response.requirements,
+    )
+```
+
+See [Workspace with confirmation](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/workspace_tools/workspace_tools_with_confirmation.py) for the full pause/resume example, and [User Confirmation](/hitl/user-confirmation) for the HITL pattern.
+
+## Developer Resources
+
+- [Tools source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/workspace.py)
+- [Basic usage](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/workspace_tools/basic_usage.py)
+- [With confirmation](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/workspace_tools/workspace_tools_with_confirmation.py)
+- [WorkspaceContextProvider](/context-providers/providers/workspace) wraps this toolkit read-only as a context provider

--- a/tools/toolkits/others/google-drive.mdx
+++ b/tools/toolkits/others/google-drive.mdx
@@ -1,0 +1,103 @@
+---
+title: Google Drive
+description: "GoogleDriveTools let an Agent list, search, read, upload, and download Google Drive files, with smart export of Workspace documents."
+---
+
+`GoogleDriveTools` give an Agent access to Google Drive. Reading tools (`list_files`, `search_files`, `read_file`) are enabled by default. Writing tools (`upload_file`, `download_file`) are off by default and must be opted into. Workspace files (Docs, Sheets, Slides) are auto-exported to text the LLM can consume.
+
+## Getting Started
+
+<Steps>
+  <Step title="Install dependencies">
+    ```shell
+    uv pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib
+    ```
+  </Step>
+  <Step title="Setup Google Cloud project">
+    Enable the [Google Drive API](https://console.cloud.google.com/apis/enableflow?apiid=drive.googleapis.com), create OAuth credentials, and download the client JSON. First run opens a browser for consent and saves a token for reuse.
+  </Step>
+</Steps>
+
+## Example
+
+```python cookbook/91_tools/google/drive_tools.py
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.google.drive import GoogleDriveTools
+
+# Read-only agent (default: upload and download disabled)
+read_only_agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[GoogleDriveTools()],
+    markdown=True,
+)
+
+# Full-access agent with upload and download enabled
+full_agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[GoogleDriveTools(upload_file=True, download_file=True)],
+    markdown=True,
+)
+```
+
+## Authentication
+
+| Method          | How                                                                                            |
+| --------------- | ---------------------------------------------------------------------------------------------- |
+| OAuth           | Pass `creds_path` (client JSON) and `token_path`, or use the default `credentials.json`.       |
+| Service account | Pass `service_account_path` (or set `GOOGLE_SERVICE_ACCOUNT_FILE`). Use `delegated_user` for domain-wide delegation. |
+| Pre-built creds | Pass a `Credentials` object directly via `creds`.                                              |
+
+Scopes are auto-inferred from the enabled tools (read-only by default, write scope added when `upload_file=True`). Override with `scopes`.
+
+## Shared Drives
+
+Set the Drive API passthrough params to search across Shared Drives:
+
+```python
+GoogleDriveTools(
+    corpora="drive",          # "user" | "domain" | "drive" | "allDrives"
+    drive_id="0AB...",        # required when corpora="drive"
+    supports_all_drives=True,
+    include_items_from_all_drives=True,
+)
+```
+
+## Toolkit Params
+
+| Parameter              | Type                  | Default        | Description                                                       |
+| ---------------------- | --------------------- | -------------- | ----------------------------------------------------------------- |
+| `list_files`           | `bool`                | `True`         | Enable the `list_files` tool.                                     |
+| `search_files`         | `bool`                | `True`         | Enable the `search_files` tool.                                   |
+| `read_file`            | `bool`                | `True`         | Enable the `read_file` tool.                                      |
+| `upload_file`          | `bool`                | `False`        | Enable the `upload_file` tool.                                    |
+| `download_file`        | `bool`                | `False`        | Enable the `download_file` tool.                                  |
+| `download_dir`         | `Path`                | `.`            | Save location for `download_file`. Writes are sandboxed here.     |
+| `include_trashed`      | `bool`                | `False`        | Include trashed files in search/list results.                     |
+| `max_read_size`        | `int`                 | `10485760`     | Max file size (bytes) `read_file` loads for non-Workspace files.  |
+| `scopes`               | `Optional[List[str]]` | auto-inferred  | OAuth scopes. Inferred from enabled tools when `None`.            |
+| `creds_path`           | `Optional[str]`       | `None`         | OAuth client credentials JSON path.                               |
+| `token_path`           | `Optional[str]`       | `None`         | OAuth token file path.                                            |
+| `service_account_path` | `Optional[str]`       | `None`         | Service account JSON path. Alternative to OAuth.                  |
+| `delegated_user`       | `Optional[str]`       | `None`         | User to impersonate via domain-wide delegation.                   |
+| `corpora`              | `str`                 | `"user"`       | Shared Drive scope: `user`/`domain`/`drive`/`allDrives`.          |
+| `drive_id`             | `Optional[str]`       | `None`         | Shared Drive ID. Required when `corpora="drive"`.                 |
+
+## Toolkit Functions
+
+| Function        | Description                                                              |
+| --------------- | ------------------------------------------------------------------------ |
+| `list_files`    | List files, optionally filtered by a Drive query.                        |
+| `search_files`  | Search files by Drive query, returns metadata and links.                 |
+| `read_file`     | Read a file's content. Workspace files are exported to text/CSV.         |
+| `upload_file`   | Upload a local file to Drive.                                            |
+| `download_file` | Download a file to `download_dir`. Workspace files export to native formats. |
+
+All functions have sync and async variants.
+
+## Developer Resources
+
+- [Tools source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/google/drive.py)
+- [Drive tools example](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/google/drive_tools.py)
+- [File search example](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/google/drive_file_search.py)
+- [Google Drive context provider](/context-providers/providers/drive)

--- a/tools/toolkits/others/llms-txt.mdx
+++ b/tools/toolkits/others/llms-txt.mdx
@@ -1,0 +1,69 @@
+---
+title: LLMs.txt
+description: "LLMsTxtTools lets an agent discover and read documentation from an llms.txt index, optionally loading it into Knowledge."
+---
+
+`LLMsTxtTools` reads [llms.txt](https://llmstxt.org) files. The format is a standardized way for websites to publish an LLM-friendly documentation index. The toolkit operates in two modes depending on whether you pass a `Knowledge` instance.
+
+## Agentic Mode
+
+Without `knowledge`, the agent reads the index and decides which pages to fetch.
+
+```python cookbook/91_tools/llms_txt_tools.py
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.llms_txt import LLMsTxtTools
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[LLMsTxtTools()],
+    instructions=[
+        "First use get_llms_txt_index to see what pages are available.",
+        "Then use read_llms_txt_url to fetch only the pages relevant to the question.",
+    ],
+    markdown=True,
+)
+
+agent.print_response(
+    "Using the llms.txt at https://docs.agno.com/llms.txt, "
+    "find and read the documentation about how to create an agent with tools",
+    stream=True,
+)
+```
+
+## Knowledge Mode
+
+Pass a `Knowledge` instance and the toolkit exposes `read_llms_txt_and_load_knowledge`, which ingests the indexed pages into your knowledge base for retrieval.
+
+```python cookbook/91_tools/llms_txt_tools_knowledge.py
+from agno.knowledge.knowledge import Knowledge
+from agno.tools.llms_txt import LLMsTxtTools
+
+tools = LLMsTxtTools(knowledge=knowledge)
+```
+
+## Toolkit Params
+
+| Parameter       | Type                  | Default | Description                                                            |
+| --------------- | --------------------- | ------- | ---------------------------------------------------------------------- |
+| `knowledge`     | `Optional[Knowledge]` | `None`  | When set, switches to Knowledge mode (load pages instead of returning).|
+| `max_urls`      | `int`                 | `20`    | Maximum number of pages to read from an index.                         |
+| `timeout`       | `int`                 | `60`    | HTTP timeout in seconds.                                               |
+| `skip_optional` | `bool`                | `False` | Skip pages listed under the index's optional section.                  |
+| `allowed_hosts` | `Optional[List[str]]` | `None`  | SSRF guard. Only fetch from these hosts. `None` allows any host.       |
+
+## Toolkit Functions
+
+| Function                            | Mode      | Description                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------- |
+| `get_llms_txt_index`                | Agentic   | Fetch and parse an llms.txt index.                   |
+| `read_llms_txt_url`                 | Agentic   | Read a single page referenced by the index.          |
+| `read_llms_txt_and_load_knowledge`  | Knowledge | Read indexed pages and load them into Knowledge.     |
+
+All functions have sync and async variants.
+
+## Developer Resources
+
+- [Tools source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/llms_txt.py)
+- [Agentic mode example](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/llms_txt_tools.py)
+- [Knowledge mode example](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/llms_txt_tools_knowledge.py)

--- a/tools/toolkits/others/user-feedback.mdx
+++ b/tools/toolkits/others/user-feedback.mdx
@@ -1,0 +1,75 @@
+---
+title: User Feedback
+description: "UserFeedbackTools lets an agent pause and ask the user structured questions with predefined options."
+---
+
+`UserFeedbackTools` exposes a single `ask_user` tool. The agent presents structured questions with predefined options (single or multi-select), the run pauses, and execution resumes once the user provides their selections. This is a [human-in-the-loop](/hitl/overview) pattern for clarifying intent mid-run.
+
+## Example
+
+```python cookbook/02_agents/10_human_in_the_loop/user_feedback.py
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.tools.user_feedback import UserFeedbackTools
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[UserFeedbackTools()],
+    instructions=[
+        "You are a helpful travel assistant.",
+        "When the user asks you to plan a trip, use the ask_user tool to clarify their preferences.",
+    ],
+    db=SqliteDb(db_file="tmp/user_feedback.db"),
+    markdown=True,
+)
+
+run_response = agent.run("Help me plan a vacation")
+```
+
+## Resolving the Pause
+
+When the agent calls `ask_user`, the run pauses with a `user_feedback_schema`. Collect the user's selections and continue the run:
+
+```python
+while run_response.is_paused:
+    for requirement in run_response.active_requirements:
+        if requirement.needs_user_feedback:
+            selections = {}
+            for question in requirement.user_feedback_schema:
+                # present question.header, question.question, question.options
+                # collect selected option labels (multi if question.multi_select)
+                selections[question.question] = [...]
+            requirement.provide_user_feedback(selections)
+
+    run_response = agent.continue_run(
+        run_id=run_response.run_id,
+        requirements=run_response.requirements,
+    )
+```
+
+## Question Schema
+
+`ask_user` accepts a list of `AskUserQuestion` objects:
+
+| Field          | Type                  | Description                                                |
+| -------------- | --------------------- | ---------------------------------------------------------- |
+| `question`     | `str`                 | The question. Must end with a question mark.               |
+| `header`       | `str`                 | Short label (max 12 chars), e.g. `"Destination"`.          |
+| `options`      | `List[AskUserOption]` | 2-4 options to choose from.                                |
+| `multi_select` | `bool`                | If True, the user can select multiple options.             |
+
+Each `AskUserOption` has a `label` (1-5 words) and an optional `description`.
+
+## Toolkit Params
+
+| Parameter          | Type            | Default  | Description                                          |
+| ------------------ | --------------- | -------- | ---------------------------------------------------- |
+| `instructions`     | `Optional[str]` | defaults | Override the default LLM instructions.               |
+| `add_instructions` | `bool`          | `True`   | Add the instructions to the agent's system message.  |
+
+## Developer Resources
+
+- [Tools source](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/user_feedback.py)
+- [Cookbook example](https://github.com/agno-agi/agno/blob/main/cookbook/02_agents/10_human_in_the_loop/user_feedback.py)
+- [Human-in-the-Loop overview](/hitl/overview)


### PR DESCRIPTION
## Description

Documents SDK features released since v2.5.0 that had no docs coverage, and patches pages that were missing shipped params. Audited every `feat`/`fix` PR from v2.5.0 through the latest v2.6.x release.

### 7 new pages (all registered in `docs.json`, valid JSON, cross-links resolve)

| Page | Covers |
|------|--------|
| `tools/toolkits/local/coding.mdx` | `CodingTools` — 4 core + 3 opt-in tools, sandbox warning |
| `tools/toolkits/local/workspace.mdx` | `Workspace` — allowed/confirm permission model, HITL confirmation flow |
| `tools/toolkits/others/llms-txt.mdx` | `LLMsTxtTools` — agentic + knowledge modes |
| `tools/toolkits/others/user-feedback.mdx` | `UserFeedbackTools` — structured questions, pause/resume |
| `tools/toolkits/others/google-drive.mdx` | `GoogleDriveTools` rewrite — smart export, service-account auth, Shared Drives |
| `context-providers/providers/workspace.mdx` | `WorkspaceContextProvider` — read-only project access |
| `agent-os/interfaces/slack/hitl.mdx` | Slack HITL TaskCards for all 4 pause types, teams/workflows |

### 4 pages extended (no deletions)

- `agent-os/security/rbac.mdx` — new "Per-User Data Isolation" section (`user_isolation=True`, admin bypass) + example card
- `models/providers/native/anthropic/usage/prompt-caching.mdx` — multi-block caching (`SystemPromptBlock`, per-block TTL) + tool caching
- `tools/toolkits/local/file.mdx` — `exclude_patterns`, `enable_search_content`, `search_files`/`search_content`

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
