### PR TITLE
docs: fix FileTools chunk parameter name

### DIFF
--- a/tools/toolkits/local/file.mdx
+++ b/tools/toolkits/local/file.mdx
@@ -23,7 +23,7 @@ agent.print_response("What is the most advanced LLM currently? Save the answer t
 | `enable_save_file`    | `bool` | `True`  | Enables functionality to save files                           |
 | `enable_delete_file`  | `bool` | `False` | Enables functionality to delete files                         |
 | `enable_read_file`    | `bool` | `True`  | Enables functionality to read files                           |
-| `enable_read_file_chunks` | `bool` | `True` | Enables functionality to read files in chunks              |
+| `enable_read_file_chunk` | `bool` | `True` | Enables functionality to read files in chunks               |
 | `enable_replace_file_chunk` | `bool` | `True` | Enables functionality to update files in chunks          |
 | `enable_list_files`   | `bool` | `True`  | Enables functionality to list files in directories            |
 | `enable_search_files` | `bool` | `True`  | Enables functionality to search for files                     |


### PR DESCRIPTION
## Summary
- rename the File toolkit parameter in `tools/toolkits/local/file.mdx` from `enable_read_file_chunks` to `enable_read_file_chunk`
- keep the docs aligned with the implementation and example usage

## Validation
- searched the docs repo to confirm the toolkit page now matches the example usage in `examples/tools/file-tools.mdx`

Closes #655