### PR TITLE
docs: add YouTools (You.com Search) reference and example pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2114,6 +2114,7 @@
                           "tools/toolkits/search/tavily",
                           "tools/toolkits/search/valyu",
                           "tools/toolkits/search/wikipedia",
+                          "tools/toolkits/search/youcom",
                           "tools/toolkits/search/bravesearch"
                         ]
                       },
@@ -6684,7 +6685,8 @@
                   "examples/tools/trafilatura-tools",
                   "examples/tools/web-tools",
                   "examples/tools/webbrowser-tools",
-                  "examples/tools/websearch-tools"
+                  "examples/tools/websearch-tools",
+                  "examples/tools/youcom-tools"
                 ]
               },
               {

--- a/examples/tools/youcom-tools.mdx
+++ b/examples/tools/youcom-tools.mdx
@@ -1,0 +1,60 @@
+---
+title: "You.com"
+description: "Search the web from your Agno agents with the You.com Search API."
+---
+
+```python
+from agno.agent import Agent
+from agno.tools.youcom import YouTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# Example 1: Default search agent
+agent = Agent(
+    tools=[YouTools(show_results=True)],
+    markdown=True,
+)
+
+# Example 2: Search with a domain allowlist and a larger result count
+agent_filtered = Agent(
+    tools=[
+        YouTools(
+            include_domains=["cnbc.com", "reuters.com", "bloomberg.com"],
+            num_results=8,
+            show_results=True,
+        )
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response("Search for the latest AAPL news", markdown=True)
+
+    agent_filtered.print_response(
+        "What did major financial outlets say about NVDA earnings this week?",
+        markdown=True,
+    )
+```
+
+## Run the Example
+
+```bash
+# Clone and setup repo
+git clone https://github.com/agno-agi/agno.git
+cd agno/cookbook/91_tools
+
+# Create and activate virtual environment
+./scripts/demo_setup.sh
+source .venvs/demo/bin/activate
+
+export YDC_API_KEY=***
+
+python youcom_tools.py
+```
+
+For details, see the [You.com cookbook](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/youcom_tools.py).

--- a/tools/toolkits/search/youcom.mdx
+++ b/tools/toolkits/search/youcom.mdx
@@ -1,0 +1,62 @@
+---
+title: You.com
+---
+
+**YouTools** enable an Agent to search the web using the You.com Search API.
+
+## Prerequisites
+
+YouTools uses the `httpx` client already bundled with Agno. The only requirement is a You.com API key, available at [you.com/platform/api-keys](https://you.com/platform/api-keys).
+
+```shell
+export YDC_API_KEY=***
+# optional: point at a non-default endpoint (e.g. staging)
+export YDC_BASE_URL=https://api.you.com
+```
+
+No API key? You.com also hosts a free MCP profile at `https://api.you.com/mcp?profile=free` (`you-search`, 100 queries/day, no signup). Plug that URL into Agno's [MCPTools](/tools/toolkits/others/mcp) instead of YouTools.
+
+## Example
+
+The following agent searches You.com for AAPL news and prints the response.
+
+```python cookbook/91_tools/youcom_tools.py
+from agno.agent import Agent
+from agno.tools.youcom import YouTools
+
+agent = Agent(
+    tools=[YouTools(
+        include_domains=["cnbc.com", "reuters.com", "bloomberg.com"],
+        num_results=8,
+        show_results=True,
+    )],
+)
+agent.print_response("Search for AAPL news", markdown=True)
+```
+
+## Toolkit Functions
+
+| Function | Description |
+| -------- | ----------- |
+| `you_search` | Search the web for a given query. Accepts `query` (str) and an optional `num_results` (int) to override the configured count. Returns results as JSON or markdown. |
+
+## Toolkit Params
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `api_key` | `Optional[str]` | `None` | You.com API key. Falls back to the `YDC_API_KEY` environment variable. |
+| `base_url` | `Optional[str]` | `None` | Override the API base URL. Falls back to `YDC_BASE_URL`, then `https://api.you.com`. |
+| `num_results` | `int` | `5` | Default number of search results. |
+| `livecrawl` | `Literal['always', 'fallback', 'never', 'web']` | `'web'` | Live-crawl mode for the search API. |
+| `livecrawl_formats` | `str` | `'markdown'` | Comma-separated content formats to request from livecrawl (e.g. `markdown`, `text`). |
+| `text_length_limit` | `int` | `1000` | Maximum length of text content per result. |
+| `include_domains` | `Optional[List[str]]` | `None` | Restrict results to these domains. |
+| `exclude_domains` | `Optional[List[str]]` | `None` | Exclude results from these domains. |
+| `timeout` | `int` | `30` | Maximum time in seconds to wait for API responses. |
+| `format` | `Literal['json', 'markdown']` | `'json'` | Output format for search results. |
+| `show_results` | `bool` | `False` | Log responses for debugging. |
+
+## Developer Resources
+
+- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/youcom.py)
+- View [Cookbook example](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/youcom_tools.py)


### PR DESCRIPTION
## Summary

Adds docs for `YouTools`, the new You.com Search toolkit added in agno-agi/agno#7727. Mirrors the existing Exa pages so the new tool slots into the Search nav alongside Exa, Tavily, and Brave.

- `tools/toolkits/search/youcom.mdx` — prerequisites, example, toolkit functions, full parameter table
- `examples/tools/youcom-tools.mdx` — runnable two-agent example (default + domain-filtered)
- `docs.json` — registers both pages under **Search** and **Search & Web**

## Notes

- Triggered by reviewer feedback on agno-agi/agno#7727 ([approval comment](https://github.com/agno-agi/agno/pull/7727#issuecomment-4558408393)).
- No new pip dependency — `YouTools` uses the `httpx` already in Agno core. The page covers `YDC_API_KEY` setup and the free MCP-profile fallback (`https://api.you.com/mcp?profile=free`).
- Param table reflects the actual `YouTools` constructor on `feat/youcom-tools` (api_key, base_url, num_results, livecrawl, livecrawl_formats, text_length_limit, include_domains, exclude_domains, timeout, format, show_results).

## Test plan

- [ ] `mint dev` renders both new pages without errors
- [ ] `mint broken-links` reports no new broken links
- [ ] Pages appear under **Tools → Toolkits → Search → You.com** and **Examples → Tools → Search & Web → You.com**