### PR TITLE
docs: update Seltz toolkit parameters

### DIFF
--- a/tools/toolkits/search/seltz.mdx
+++ b/tools/toolkits/search/seltz.mdx
@@ -27,7 +27,7 @@ from agno.tools.seltz import SeltzTools
 
 agent = Agent(
     model=OpenAIChat(id="gpt-4o"),
-    tools=[SeltzTools(show_results=True)],
+    tools=[SeltzTools(max_results=5, show_results=True)],
     markdown=True,
 )
 
@@ -41,7 +41,10 @@ agent.print_response("Search for current AI safety reports")
 | `api_key` | `Optional[str]` | `None` | Seltz API key. If not provided, uses `SELTZ_API_KEY` environment variable. |
 | `endpoint` | `Optional[str]` | `None` | Custom Seltz gRPC endpoint. If not provided, uses SDK default. |
 | `insecure` | `bool` | `False` | Use an insecure gRPC channel. |
-| `max_documents` | `int` | `10` | Default maximum number of documents to return per search. |
+| `max_results` | `Optional[int]` | `None` | Default maximum number of results to return per search. Defaults to `10` when unset. |
+| `max_documents` | `Optional[int]` | `None` | Deprecated alias for `max_results`. |
+| `context` | `Optional[str]` | `None` | Legacy SDK context to improve search quality. Ignored by current Seltz SDK versions. |
+| `profile` | `Optional[str]` | `None` | Legacy SDK search profile to use for ranking. |
 | `show_results` | `bool` | `False` | Log search results for debugging. |
 | `enable_search` | `bool` | `True` | Enable search tool functionality. |
 | `all` | `bool` | `False` | Enable all tools. Overrides individual flags when True. |
@@ -50,7 +53,7 @@ agent.print_response("Search for current AI safety reports")
 
 | Function | Description |
 | -------- | ----------- |
-| `search_seltz` | Search Seltz for a query. Returns results as JSON with document URLs and content. Accepts `query` (str) and optional `max_documents` (int) parameters. |
+| `search_seltz` | Search Seltz for a query. Returns results as JSON with document URLs and content. Accepts `query` (str), optional `max_results` (int), and optional filters: `scope`, `include_domains`, `exclude_domains`, `from_date`, and `to_date`. `max_documents` remains available as a deprecated alias for `max_results`. |
 
 ## Developer Resources
 


### PR DESCRIPTION
## Description

Updates the Seltz toolkit docs to match the current Agno SDK API:
- Documents `max_results` as the primary result limit
- Notes `max_documents` as a deprecated alias
- Adds `context` and `profile` toolkit parameters
- Lists the supported `search_seltz` filters

## Type of Change

- [x] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: ______

## Related Issues/PRs (if applicable)

- Related SDK PR: agno-agi/agno#8177

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [x] Screenshots updated (if applicable)