### PR TITLE
fix: correct MCPTools link in YouTools docs

### DIFF
--- a/tools/toolkits/search/youcom.mdx
+++ b/tools/toolkits/search/youcom.mdx
@@ -14,7 +14,7 @@ export YDC_API_KEY=***
 export YDC_BASE_URL=https://api.you.com
 ```
 
-No API key? You.com also hosts a free MCP profile at `https://api.you.com/mcp?profile=free` (`you-search`, 100 queries/day, no signup). Plug that URL into Agno's [MCPTools](/tools/toolkits/others/mcp) instead of YouTools.
+No API key? You.com also hosts a free MCP profile at `https://api.you.com/mcp?profile=free` (`you-search`, 100 queries/day, no signup). Plug that URL into Agno's [MCPTools](/tools/mcp/overview) instead of YouTools.
 
 ## Example
 


### PR DESCRIPTION
## Summary

- The YouTools page linked to `/tools/toolkits/others/mcp`, which does not exist in the current docs layout.
- MCP docs live under `/tools/mcp/`, so the link now points at `/tools/mcp/overview`.
- Caught by the `mintlify broken-links` CI check after #663 merged.

## Changes

`tools/toolkits/search/youcom.mdx:17` — one-line link fix.

## Test plan

- [ ] `mintlify broken-links` passes in CI
- [ ] Manual click-through on the rendered YouTools page lands on the MCP overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)