### PR TITLE
docs: add Task API and Monitor API to ParallelTools

### DIFF
--- a/examples/tools/mcp/parallel.mdx
+++ b/examples/tools/mcp/parallel.mdx
@@ -67,9 +67,11 @@ if __name__ == "__main__":
   <Step title="Export API keys">
     ```bash
     export ANTHROPIC_API_KEY=***
-    # Optional — keyless access is rate-limited
     export PARALLEL_API_KEY=***
     ```
+    <Tip>
+    The Parallel API key is optional. Keyless access is rate-limited; setting a key raises the ceiling.
+    </Tip>
   </Step>
   <Step title="Run the example">
     ```bash

--- a/examples/tools/mcp/parallel.mdx
+++ b/examples/tools/mcp/parallel.mdx
@@ -6,18 +6,6 @@ keywords: [mcp, parallel, web search, mcp server]
 
 Web search using Parallel's MCP server. API key is optional (keyless access is rate-limited).
 
-## Prerequisites
-
-```bash
-uv pip install agno mcp anthropic
-```
-
-```bash
-export ANTHROPIC_API_KEY=***
-# Optional — keyless access is rate-limited
-export PARALLEL_API_KEY=***
-```
-
 ## Example
 
 ```python
@@ -63,12 +51,29 @@ if __name__ == "__main__":
 
 ## Run the Example
 
-```bash
-git clone https://github.com/agno-agi/agno.git
-cd agno
-
-./scripts/demo_setup.sh
-source .venvs/demo/bin/activate
-
-python cookbook/91_tools/mcp/parallel.py
-```
+<Steps>
+  <Step title="Clone and set up">
+    ```bash
+    git clone https://github.com/agno-agi/agno.git
+    cd agno
+    ```
+  </Step>
+  <Step title="Create virtual environment">
+    ```bash
+    ./scripts/demo_setup.sh
+    source .venvs/demo/bin/activate
+    ```
+  </Step>
+  <Step title="Export API keys">
+    ```bash
+    export ANTHROPIC_API_KEY=***
+    # Optional — keyless access is rate-limited
+    export PARALLEL_API_KEY=***
+    ```
+  </Step>
+  <Step title="Run the example">
+    ```bash
+    python cookbook/91_tools/mcp/parallel.py
+    ```
+  </Step>
+</Steps>

--- a/examples/tools/mcp/parallel.mdx
+++ b/examples/tools/mcp/parallel.mdx
@@ -1,6 +1,7 @@
 ---
 title: "MCP Parallel Agent"
 description: "Create an agent that uses Parallel for searching information using the Parallel MCP server."
+keywords: [mcp, parallel, web search, mcp server]
 ---
 
 Web search using Parallel's MCP server. API key is optional (keyless access is rate-limited).

--- a/examples/tools/mcp/parallel.mdx
+++ b/examples/tools/mcp/parallel.mdx
@@ -1,19 +1,25 @@
 ---
 title: "MCP Parallel Agent"
-description: "Create an agent that uses Parallel for web search via the MCP server."
+description: "Create an agent that uses Parallel for searching information using the Parallel MCP server."
 ---
 
+Web search using Parallel's MCP server. API key is optional (keyless access is rate-limited).
+
+## Prerequisites
+
+```bash
+uv pip install agno mcp anthropic
+```
+
+```bash
+export ANTHROPIC_API_KEY=***
+# Optional — keyless access is rate-limited
+export PARALLEL_API_KEY=***
+```
+
+## Example
+
 ```python
-"""Parallel MCP Agent - Web Search via Parallel MCP
-
-Setup:
-1. Install: uv pip install agno mcp anthropic
-2. Set ANTHROPIC_API_KEY environment variable
-3. Optionally set PARALLEL_API_KEY (keyless access is rate-limited)
-
-Parallel MCP Docs: https://docs.parallel.ai/integrations/mcp/search-mcp
-"""
-
 import asyncio
 from datetime import timedelta
 from os import getenv
@@ -25,7 +31,6 @@ from agno.tools.mcp.params import StreamableHTTPClientParams
 
 
 async def run_agent(message: str) -> None:
-    # Build headers — only add auth if key is present
     headers: dict[str, str] = {}
     api_key = getenv("PARALLEL_API_KEY")
     if api_key:
@@ -63,9 +68,6 @@ cd agno
 
 ./scripts/demo_setup.sh
 source .venvs/demo/bin/activate
-
-# Optional — keyless access is rate-limited
-export PARALLEL_API_KEY="***"
 
 python cookbook/91_tools/mcp/parallel.py
 ```

--- a/examples/tools/mcp/parallel.mdx
+++ b/examples/tools/mcp/parallel.mdx
@@ -1,80 +1,71 @@
 ---
 title: "MCP Parallel Agent"
-description: "Create an agent that uses Parallel for searching information using the Parallel MCP server."
+description: "Create an agent that uses Parallel for web search via the MCP server."
 ---
+
 ```python
-"""MCP Parallel Agent - Search for Parallel
+"""Parallel MCP Agent - Web Search via Parallel MCP
 
-This example shows how to create an agent that uses Parallel to search for information using the Parallel MCP server.
+Setup:
+1. Install: uv pip install agno mcp anthropic
+2. Set ANTHROPIC_API_KEY environment variable
+3. Optionally set PARALLEL_API_KEY (keyless access is rate-limited)
 
-Run: `uv pip install anthropic mcp agno` to install the dependencies
-
-Prerequisites:
-- Set the environment variable "PARALLEL_API_KEY" with your Parallel API key.
-- You can get the API key from the Parallel website: https://parallel.ai/
-
-Usage:
-  python cookbook/90_tools/mcp/parallel.py
-
-Example:
-  python cookbook/90_tools/mcp/parallel.py "What is the weather in Tokyo?"
+Parallel MCP Docs: https://docs.parallel.ai/integrations/mcp/search-mcp
 """
 
 import asyncio
+from datetime import timedelta
 from os import getenv
 
 from agno.agent import Agent
 from agno.models.anthropic import Claude
 from agno.tools.mcp import MCPTools
 from agno.tools.mcp.params import StreamableHTTPClientParams
-from agno.utils.pprint import apprint_run_response
-
-# ---------------------------------------------------------------------------
-# Create Agent
-# ---------------------------------------------------------------------------
-
-
-server_params = StreamableHTTPClientParams(
-    url="https://search-mcp.parallel.ai/mcp",
-    headers={
-        "authorization": f"Bearer {getenv('PARALLEL_API_KEY')}",
-    },
-)
 
 
 async def run_agent(message: str) -> None:
+    # Build headers — only add auth if key is present
+    headers: dict[str, str] = {}
+    api_key = getenv("PARALLEL_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    server_params = StreamableHTTPClientParams(
+        url="https://search.parallel.ai/mcp",
+        headers=headers,
+        timeout=timedelta(seconds=300),
+    )
+
     async with MCPTools(
-        transport="streamable-http", server_params=server_params
+        transport="streamable-http",
+        server_params=server_params,
+        include_tools=["web_search", "web_fetch"],
+        timeout_seconds=300,
     ) as parallel_mcp_server:
         agent = Agent(
             model=Claude(id="claude-sonnet-4-20250514"),
             tools=[parallel_mcp_server],
             markdown=True,
         )
-        response_stream = await agent.arun(message)
-        await apprint_run_response(response_stream)
+        await agent.aprint_response(message, stream=True)
 
-
-# ---------------------------------------------------------------------------
-# Run Agent
-# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
     asyncio.run(run_agent("What is the weather in Tokyo?"))
 ```
 
 ## Run the Example
-```bash
-# Clone and setup repo
-git clone https://github.com/agno-agi/agno.git
-cd agno/cookbook/91_tools/mcp
 
-# Create and activate virtual environment
+```bash
+git clone https://github.com/agno-agi/agno.git
+cd agno
+
 ./scripts/demo_setup.sh
 source .venvs/demo/bin/activate
 
-# Export relevant API keys
+# Optional — keyless access is rate-limited
 export PARALLEL_API_KEY="***"
 
-python parallel.py
+python cookbook/91_tools/mcp/parallel.py
 ```

--- a/examples/tools/parallel-tools.mdx
+++ b/examples/tools/parallel-tools.mdx
@@ -4,17 +4,7 @@ description: "Web search, deep research, and continuous monitoring with Parallel
 keywords: [parallel, web search, task api, monitor api, deep research, web monitoring]
 ---
 
-ParallelTools provide four APIs: Search (quick lookups), Extract (pull URL content), Task (deep research), and Monitor (track changes over time).
-
-## Prerequisites
-
-```bash
-uv pip install parallel-web
-```
-
-```bash
-export PARALLEL_API_KEY=***
-```
+Enable Agno agents with web search and extraction infrastructure from Parallel that prioritizes token efficiency and multi-hop reasoning.
 
 ## Search API
 
@@ -107,21 +97,36 @@ agent.print_response("List my monitors and fetch recent events", stream=True)
 
 ## Run the Examples
 
-```bash
-git clone https://github.com/agno-agi/agno.git
-cd agno
+<Steps>
+  <Step title="Clone and set up">
+    ```bash
+    git clone https://github.com/agno-agi/agno.git
+    cd agno
+    ```
+  </Step>
+  <Step title="Create virtual environment">
+    ```bash
+    ./scripts/demo_setup.sh
+    source .venvs/demo/bin/activate
+    ```
+  </Step>
+  <Step title="Export your API key">
+    ```bash
+    export PARALLEL_API_KEY=***
+    ```
+  </Step>
+  <Step title="Run an example">
+    ```bash
+    # Search API
+    python cookbook/91_tools/parallel/news_search.py
 
-./scripts/demo_setup.sh
-source .venvs/demo/bin/activate
+    # Task API
+    python cookbook/91_tools/parallel/company_enrichment.py
 
-# Search API
-python cookbook/91_tools/parallel/news_search.py
-
-# Task API
-python cookbook/91_tools/parallel/company_enrichment.py
-
-# Monitor API
-python cookbook/91_tools/parallel/competitor_tracker.py
-```
+    # Monitor API
+    python cookbook/91_tools/parallel/competitor_tracker.py
+    ```
+  </Step>
+</Steps>
 
 For more examples, see the [Parallel cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/parallel).

--- a/examples/tools/parallel-tools.mdx
+++ b/examples/tools/parallel-tools.mdx
@@ -114,6 +114,9 @@ agent.print_response("List my monitors and fetch recent events", stream=True)
     ```bash
     export PARALLEL_API_KEY=***
     ```
+    <Tip>
+    The API key is optional. Keyless access is rate-limited; setting a key raises the ceiling.
+    </Tip>
   </Step>
   <Step title="Run an example">
     ```bash

--- a/examples/tools/parallel-tools.mdx
+++ b/examples/tools/parallel-tools.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Parallel"
 description: "Web search, deep research, and continuous monitoring with Parallel."
+keywords: [parallel, web search, task api, monitor api, deep research, web monitoring]
 ---
 
 ParallelTools provide four APIs: Search (quick lookups), Extract (pull URL content), Task (deep research), and Monitor (track changes over time).

--- a/examples/tools/parallel-tools.mdx
+++ b/examples/tools/parallel-tools.mdx
@@ -5,6 +5,16 @@ description: "Web search, deep research, and continuous monitoring with Parallel
 
 ParallelTools provide four APIs: Search (quick lookups), Extract (pull URL content), Task (deep research), and Monitor (track changes over time).
 
+## Prerequisites
+
+```bash
+uv pip install parallel-web
+```
+
+```bash
+export PARALLEL_API_KEY=***
+```
+
 ## Search API
 
 Fast web search for recent information.
@@ -113,4 +123,4 @@ python cookbook/91_tools/parallel/company_enrichment.py
 python cookbook/91_tools/parallel/competitor_tracker.py
 ```
 
-For details, see the [Parallel cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/parallel).
+For more examples, see the [Parallel cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/parallel).

--- a/examples/tools/parallel-tools.mdx
+++ b/examples/tools/parallel-tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Parallel"
-description: "Web search, deep research, and continuous monitoring with Parallel."
+description: "Use Parallel tools with Agno agents."
 keywords: [parallel, web search, task api, monitor api, deep research, web monitoring]
 ---
 

--- a/examples/tools/parallel-tools.mdx
+++ b/examples/tools/parallel-tools.mdx
@@ -1,48 +1,116 @@
 ---
 title: "Parallel"
-description: "Use Parallel tools with Agno agents."
+description: "Web search, deep research, and continuous monitoring with Parallel."
 ---
 
-Enable Agno agents with web search and extraction infrastructure from Parallel that prioritizes token efficiency and multi-hop reasoning.
+ParallelTools provide four APIs: Search (quick lookups), Extract (pull URL content), Task (deep research), and Monitor (track changes over time).
+
+## Search API
+
+Fast web search for recent information.
 
 ```python
-
 from agno.agent import Agent
 from agno.models.openai import OpenAIResponses
 from agno.tools.parallel import ParallelTools
 
-# ---------------------------------------------------------------------------
-# Create Agent
-# ---------------------------------------------------------------------------
-
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.1"),
-    tools=[ParallelTools()],
-    instructions="No need to tell me its based on your research.",
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[ParallelTools(
+        max_results=10,
+        include_domains=["techcrunch.com", "wired.com"],
+    )],
     markdown=True,
 )
 
-# ---------------------------------------------------------------------------
-# Run Agent
-# ---------------------------------------------------------------------------
-if __name__ == "__main__":
-    agent.print_response(
-        "Tell me about Agno's AgentOS?",
-        stream=True,
-        stream_events=True,
-    )
+agent.print_response("What are the latest developments in AI agents?", stream=True)
 ```
 
-## Run the Example
-```bash
-# Clone and setup repo
-git clone https://github.com/agno-agi/agno.git
-cd agno/cookbook/91_tools
+## Task API
 
-# Create and activate virtual environment
+Deep research with structured output and citations.
+
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.parallel import ParallelTools
+
+enrichment_tools = ParallelTools(
+    enable_search=False,
+    enable_extract=False,
+    enable_task=True,
+    default_processor="base",
+    default_output_schema={
+        "type": "json",
+        "json_schema": {
+            "type": "object",
+            "properties": {
+                "company_name": {"type": "string"},
+                "headquarters": {"type": "string"},
+                "total_funding": {"type": "string"},
+                "key_investors": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["company_name"],
+        },
+    },
+)
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[enrichment_tools],
+    markdown=True,
+    instructions="Use create_task() to research, then get_task_result() to retrieve.",
+)
+
+agent.print_response("Research Anthropic and return structured company data", stream=True)
+```
+
+## Monitor API
+
+Track topics over time and detect changes.
+
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.parallel import ParallelTools
+
+monitor_tools = ParallelTools(
+    enable_search=False,
+    enable_extract=False,
+    enable_monitor=True,
+    default_monitor_frequency="1d",
+)
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[monitor_tools],
+    markdown=True,
+)
+
+# Create monitors
+agent.print_response("Create a monitor to track OpenAI product launches", stream=True)
+
+# Later: check for events
+agent.print_response("List my monitors and fetch recent events", stream=True)
+```
+
+## Run the Examples
+
+```bash
+git clone https://github.com/agno-agi/agno.git
+cd agno
+
 ./scripts/demo_setup.sh
 source .venvs/demo/bin/activate
 
-python parallel_tools.py
+# Search API
+python cookbook/91_tools/parallel/news_search.py
+
+# Task API
+python cookbook/91_tools/parallel/company_enrichment.py
+
+# Monitor API
+python cookbook/91_tools/parallel/competitor_tracker.py
 ```
-For details, see [Parallel cookbook](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/parallel_tools.py).
+
+For details, see the [Parallel cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/parallel).

--- a/examples/tools/parallel-tools.mdx
+++ b/examples/tools/parallel-tools.mdx
@@ -6,9 +6,9 @@ keywords: [parallel, web search, task api, monitor api, deep research, web monit
 
 Enable Agno agents with web search and extraction infrastructure from Parallel that prioritizes token efficiency and multi-hop reasoning.
 
-## Search API
+## Search
 
-Fast web search for recent information.
+Natural-language web search that returns LLM-optimized excerpts. Use when the model needs current facts, specific entities, or web data to ground a response.
 
 ```python
 from agno.agent import Agent
@@ -27,9 +27,9 @@ agent = Agent(
 agent.print_response("What are the latest developments in AI agents?", stream=True)
 ```
 
-## Task API
+## Task
 
-Deep research with structured output and citations.
+Deep research that takes a plain-language input and returns comprehensive, cited results. Use for multi-hop research that needs minutes (not seconds) and synthesis across many sources.
 
 ```python
 from agno.agent import Agent
@@ -66,9 +66,9 @@ agent = Agent(
 agent.print_response("Research Anthropic and return structured company data", stream=True)
 ```
 
-## Monitor API
+## Monitor
 
-Track topics over time and detect changes.
+Continuously track the web for changes relevant to a natural-language query, on a schedule you control. Use for news tracking, regulatory watchlists, or competitor monitoring.
 
 ```python
 from agno.agent import Agent
@@ -117,13 +117,13 @@ agent.print_response("List my monitors and fetch recent events", stream=True)
   </Step>
   <Step title="Run an example">
     ```bash
-    # Search API
+    # Search
     python cookbook/91_tools/parallel/news_search.py
 
-    # Task API
+    # Task (deep research)
     python cookbook/91_tools/parallel/company_enrichment.py
 
-    # Monitor API
+    # Monitor (continuous tracking)
     python cookbook/91_tools/parallel/competitor_tracker.py
     ```
   </Step>

--- a/tools/mcp/usage/parallel.mdx
+++ b/tools/mcp/usage/parallel.mdx
@@ -18,7 +18,6 @@ from agno.tools.mcp.params import StreamableHTTPClientParams
 
 
 async def run_agent(message: str) -> None:
-    # Build headers — only add auth if key is present
     headers: dict[str, str] = {}
     api_key = getenv("PARALLEL_API_KEY")
     if api_key:

--- a/tools/mcp/usage/parallel.mdx
+++ b/tools/mcp/usage/parallel.mdx
@@ -1,5 +1,6 @@
 ---
 title: Parallel MCP agent
+keywords: [mcp, parallel, web search, mcp server]
 ---
 
 Using the [Parallel MCP server](https://docs.parallel.ai/integrations/mcp/search-mcp) to create an Agent that can search the web using Parallel's AI-optimized search capabilities.

--- a/tools/mcp/usage/parallel.mdx
+++ b/tools/mcp/usage/parallel.mdx
@@ -2,55 +2,65 @@
 title: Parallel MCP agent
 ---
 
-Using the [Parallel MCP server](https://docs.parallel.ai/integrations/mcp/search-mcp) to create an Agent that can search the web using Parallel's AI-optimized search capabilities:
+Using the [Parallel MCP server](https://docs.parallel.ai/integrations/mcp/search-mcp) to create an Agent that can search the web using Parallel's AI-optimized search capabilities.
 
-```python
-"""MCP Parallel Agent - Search for Parallel
+The API key is optional. Keyless access is rate-limited; setting a key raises the ceiling.
 
-This example shows how to create an agent that uses Parallel to search for information using the Parallel MCP server.
-
-Run: `uv pip install anthropic mcp agno` to install the dependencies
-
-Prerequisites:
-- Set the environment variable "PARALLEL_API_KEY" with your Parallel API key.
-- Set the environment variable "ANTHROPIC_API_KEY" with your Anthropic API key.
-- You can get the Parallel API key from: https://platform.parallel.ai/
-- You can get the Anthropic API key from: https://console.anthropic.com/
-
-Usage:
-  python cookbook/14_tools/mcp/parallel.py
-"""
-
+```python cookbook/91_tools/mcp/parallel.py
 import asyncio
+from datetime import timedelta
 from os import getenv
 
 from agno.agent import Agent
 from agno.models.anthropic import Claude
 from agno.tools.mcp import MCPTools
 from agno.tools.mcp.params import StreamableHTTPClientParams
-from agno.utils.pprint import apprint_run_response
-
-server_params = StreamableHTTPClientParams(
-    url="https://search-mcp.parallel.ai/mcp",
-    headers={
-        "authorization": f"Bearer {getenv('PARALLEL_API_KEY')}",
-    },
-)
 
 
 async def run_agent(message: str) -> None:
+    # Build headers — only add auth if key is present
+    headers: dict[str, str] = {}
+    api_key = getenv("PARALLEL_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    server_params = StreamableHTTPClientParams(
+        url="https://search.parallel.ai/mcp",
+        headers=headers,
+        timeout=timedelta(seconds=300),
+    )
+
     async with MCPTools(
-        transport="streamable-http", server_params=server_params
+        transport="streamable-http",
+        server_params=server_params,
+        include_tools=["web_search", "web_fetch"],
+        timeout_seconds=300,
     ) as parallel_mcp_server:
         agent = Agent(
             model=Claude(id="claude-sonnet-4-20250514"),
             tools=[parallel_mcp_server],
             markdown=True,
         )
-        response_stream = await agent.arun(message)
-        await apprint_run_response(response_stream)
+        await agent.aprint_response(message, stream=True)
 
 
 if __name__ == "__main__":
     asyncio.run(run_agent("What is the weather in Tokyo?"))
 ```
+
+## Prerequisites
+
+```shell
+uv pip install agno mcp anthropic
+```
+
+```shell
+export ANTHROPIC_API_KEY=***
+# Optional — keyless access is rate-limited
+export PARALLEL_API_KEY=***
+```
+
+## Developer Resources
+
+- [Parallel MCP Documentation](https://docs.parallel.ai/integrations/mcp/search-mcp)
+- [ParallelTools (native SDK)](/tools/toolkits/search/parallel)

--- a/tools/toolkits/search/parallel.mdx
+++ b/tools/toolkits/search/parallel.mdx
@@ -1,6 +1,7 @@
 ---
 title: Parallel
 description: "Web search, content extraction, deep research, and continuous monitoring with Parallel."
+keywords: [parallel, web search, extract, task api, monitor api, deep research, web monitoring, citations]
 ---
 
 **ParallelTools** provide AI-optimized web capabilities through four APIs:

--- a/tools/toolkits/search/parallel.mdx
+++ b/tools/toolkits/search/parallel.mdx
@@ -15,6 +15,8 @@ keywords: [parallel, web search, extract, task api, monitor api, deep research, 
 
 ## Prerequisites
 
+The following examples require the `parallel-web` library and an API key which can be obtained from [Parallel](https://platform.parallel.ai).
+
 ```shell
 uv pip install -U parallel-web
 ```
@@ -23,7 +25,9 @@ uv pip install -U parallel-web
 export PARALLEL_API_KEY=***
 ```
 
-Get an API key from [Parallel](https://platform.parallel.ai).
+<Tip>
+The API key is optional. Keyless access is rate-limited; setting a key raises the ceiling.
+</Tip>
 
 ## Search API
 

--- a/tools/toolkits/search/parallel.mdx
+++ b/tools/toolkits/search/parallel.mdx
@@ -1,13 +1,18 @@
 ---
 title: Parallel
-description: "Use Parallel with Agno for AI-optimized web search and content extraction."
+description: "Web search, content extraction, deep research, and continuous monitoring with Parallel."
 ---
 
-**ParallelTools** enable an Agent to perform AI-optimized web search and content extraction using [Parallel's APIs](https://docs.parallel.ai/home).
+**ParallelTools** provide AI-optimized web capabilities through four APIs:
+
+| API | Speed | Use Case |
+|-----|-------|----------|
+| **Search** | 1-5s | Quick web lookups, gather sources |
+| **Extract** | 1-5s | Pull content from specific URLs |
+| **Task** | 10s-25min | Deep research with structured output and citations |
+| **Monitor** | Scheduled | Track topics over time, detect changes |
 
 ## Prerequisites
-
-The following example requires the `parallel-web` library and an API key which can be obtained from [Parallel](https://platform.parallel.ai).
 
 ```shell
 uv pip install -U parallel-web
@@ -17,64 +22,207 @@ uv pip install -U parallel-web
 export PARALLEL_API_KEY=***
 ```
 
-## Example
+Get an API key from [Parallel](https://platform.parallel.ai).
 
-The following agent will search for information on AI agents and autonomous systems, then extract content from specific URLs:
+## Search API
 
-```python cookbook/14_tools/parallel_tools.py
+Fast web search for recent information. Returns raw results that your agent synthesizes.
+
+```python
 from agno.agent import Agent
 from agno.tools.parallel import ParallelTools
 
 agent = Agent(
-    tools=[
-        ParallelTools(
-            enable_search=True,
-            enable_extract=True,
-            max_results=5,
-            max_chars_per_result=8000,
-        )
-    ],
+    tools=[ParallelTools(
+        max_results=10,
+        include_domains=["techcrunch.com", "wired.com"],
+    )],
     markdown=True,
 )
 
-# Should use parallel_search
-agent.print_response(
-    "Search for the latest information on 'AI agents and autonomous systems' and summarize the key findings"
+agent.print_response("What are the latest developments in AI agents?")
+```
+
+## Extract API
+
+Pull content from specific URLs in clean markdown format. Handles JavaScript-heavy pages and PDFs.
+
+```python
+from agno.agent import Agent
+from agno.tools.parallel import ParallelTools
+
+agent = Agent(
+    tools=[ParallelTools(
+        enable_search=False,
+        enable_extract=True,
+    )],
+    markdown=True,
 )
 
-# Should use parallel_extract
 agent.print_response(
-    "Extract information about the product features from https://parallel.ai and https://docs.parallel.ai"
+    "Extract the product features from https://parallel.ai and https://docs.parallel.ai"
 )
 ```
+
+## Task API
+
+Deep research with structured output and citations. Use for company enrichment, market research, and analysis tasks.
+
+```python
+from agno.agent import Agent
+from agno.tools.parallel import ParallelTools
+
+# Define the schema for structured output
+enrichment_tools = ParallelTools(
+    enable_search=False,
+    enable_extract=False,
+    enable_task=True,
+    default_processor="base",
+    default_output_schema={
+        "type": "json",
+        "json_schema": {
+            "type": "object",
+            "properties": {
+                "company_name": {"type": "string"},
+                "headquarters": {"type": "string"},
+                "employee_count": {"type": "string"},
+                "total_funding": {"type": "string"},
+                "key_investors": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+            "required": ["company_name"],
+        },
+    },
+)
+
+agent = Agent(
+    tools=[enrichment_tools],
+    markdown=True,
+    instructions="Use create_task() to research, then get_task_result() to retrieve data.",
+)
+
+agent.print_response("Research Anthropic and return structured company data")
+```
+
+### Task Processors
+
+| Processor | Speed | Depth | Use Case |
+|-----------|-------|-------|----------|
+| `lite` | ~10s | Surface | Quick facts, simple lookups |
+| `base` | ~60s | Standard | Company research, market analysis |
+| `pro` | ~5min | Deep | Comprehensive reports |
+| `ultra` | ~25min | Exhaustive | Due diligence, academic research |
+
+Set with `default_processor` at toolkit level.
+
+### Output Schema Types
+
+| Type | Description |
+|------|-------------|
+| `{"type": "auto"}` | Auto-detect structure from query |
+| `{"type": "text"}` | Plain text response |
+| `{"type": "json", "json_schema": {...}}` | Structured JSON matching your schema |
+| `"description string"` | Auto-generate schema from description |
+
+## Monitor API
+
+Track topics over time and detect changes. Run monitors on a schedule to catch new developments.
+
+```python
+from agno.agent import Agent
+from agno.tools.parallel import ParallelTools
+
+monitor_tools = ParallelTools(
+    enable_search=False,
+    enable_extract=False,
+    enable_monitor=True,
+    default_monitor_frequency="1d",
+    default_monitor_processor="lite",
+)
+
+agent = Agent(
+    tools=[monitor_tools],
+    markdown=True,
+    instructions="""Track competitors using:
+    - create_monitor(query): Start tracking
+    - list_monitors(): See active monitors
+    - get_monitor_events(monitor_id): Get detected changes
+    - cancel_monitor(monitor_id): Stop tracking
+    """,
+)
+
+# Create monitors
+agent.print_response("Create monitors to track OpenAI and Anthropic product launches")
+
+# Later: check for events
+agent.print_response("List my monitors and fetch recent events")
+```
+
+### Monitor Frequencies
+
+| Frequency | Value | Use Case |
+|-----------|-------|----------|
+| Hourly | `"1h"` | Fast-moving markets, breaking news |
+| Daily | `"1d"` | General competitive intel |
+| Weekly | `"1w"` | Industry trends |
+| Monthly | `"30d"` | Quarterly reviews |
 
 ## Toolkit Params
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `api_key` | `Optional[str]` | `None` | Parallel API key. If not provided, will use PARALLEL_API_KEY environment variable. |
-| `enable_search` | `bool` | `True` | Enable Search API functionality for AI-optimized web search. |
-| `enable_extract` | `bool` | `True` | Enable Extract API functionality for content extraction from URLs. |
-| `all` | `bool` | `False` | Enable all tools. Overrides individual flags when True. |
-| `max_results` | `int` | `10` | Default maximum number of results for search operations. |
-| `max_chars_per_result` | `int` | `10000` | Default maximum characters per result for search operations. |
+| `api_key` | `Optional[str]` | `None` | Parallel API key. Falls back to `PARALLEL_API_KEY` env var. |
+| `enable_search` | `bool` | `True` | Enable Search API. |
+| `enable_extract` | `bool` | `True` | Enable Extract API. |
+| `enable_task` | `bool` | `False` | Enable Task API (deep research). |
+| `enable_monitor` | `bool` | `False` | Enable Monitor API (web tracking). |
+| `all` | `bool` | `False` | Enable all tools. Overrides individual flags. |
+| `max_results` | `int` | `10` | Default max results for search. |
+| `max_chars_per_result` | `int` | `10000` | Default max characters per search result. |
+| `mode` | `Optional[str]` | `None` | Search mode: `"one-shot"` or `"agentic"`. |
+| `include_domains` | `Optional[List[str]]` | `None` | Restrict search to these domains. |
+| `exclude_domains` | `Optional[List[str]]` | `None` | Exclude these domains from search. |
+| `max_age_seconds` | `Optional[int]` | `None` | Cache age threshold (minimum 600). |
+| `disable_cache_fallback` | `Optional[bool]` | `None` | Disable cache fallback behavior. |
+| `default_processor` | `str` | `"base"` | Task API processor tier. |
+| `default_monitor_processor` | `Literal["lite", "base"]` | `"lite"` | Monitor API processor. |
+| `default_monitor_frequency` | `str` | `"1d"` | Monitor run frequency. |
+| `default_timeout` | `int` | `1800` | Task result timeout in seconds. |
+| `default_output_schema` | `Optional[Union[Dict, str]]` | `None` | Schema for structured task output. |
 | `beta_version` | `str` | `"search-extract-2025-10-10"` | Beta API version header. |
-| `mode` | `Optional[str]` | `None` | Default search mode. Options: "one-shot" or "agentic". |
-| `include_domains` | `Optional[List[str]]` | `None` | Default domains to restrict results to. |
-| `exclude_domains` | `Optional[List[str]]` | `None` | Default domains to exclude from results. |
-| `max_age_seconds` | `Optional[int]` | `None` | Default cache age threshold. When set, minimum value is 600 seconds. |
-| `timeout_seconds` | `Optional[float]` | `None` | Default timeout for content retrieval. |
-| `disable_cache_fallback` | `Optional[bool]` | `None` | Default cache fallback behavior. |
 
 ## Toolkit Functions
 
+### Search API
+
 | Function | Description |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `parallel_search` | Search the web using Parallel's Search API with natural language objective. Parameters include `objective` (str) for natural-language description, `search_queries` (list) for traditional keyword queries, `max_results` (int) for maximum number of results, and `max_chars_per_result` (int) for maximum characters per result. Returns JSON formatted string with URLs, titles, publish dates, and relevant excerpts. |
-| `parallel_extract` | Extract content from specific URLs using Parallel's Extract API. Parameters include `urls` (list) for URLs to extract from, `objective` (str) to guide extraction, `search_queries` (list) for targeting relevant content, `excerpts` (bool, default=True) to include text snippets, `max_chars_per_excerpt` (int) to limit excerpt characters, `full_content` (bool, default=False) to include complete page text, and `max_chars_for_full_content` (int) to limit full content characters. Returns JSON formatted string with extracted content in clean markdown format. |
+|----------|-------------|
+| `parallel_search` | Search the web with natural language objective. Returns URLs, titles, publish dates, and excerpts. Parameters: `objective` (str), `search_queries` (list), `max_results` (int), `max_chars_per_result` (int). |
+| `parallel_extract` | Extract content from URLs. Returns clean markdown with excerpts or full content. Parameters: `urls` (list), `objective` (str), `excerpts` (bool), `full_content` (bool). |
+
+### Task API
+
+| Function | Description |
+|----------|-------------|
+| `create_task` | Create a research task without waiting. Returns `run_id` for later retrieval. Parameter: `query` (str). |
+| `get_task_result` | Get completed task result. Blocks until done or timeout. Returns structured content and citations. Parameter: `run_id` (str). |
+| `get_task_status` | Check task status without blocking. Returns status, processor, and timestamps. Parameter: `run_id` (str). |
+
+### Monitor API
+
+| Function | Description |
+|----------|-------------|
+| `create_monitor` | Create a monitor for a query. Returns `monitor_id`, status, frequency. Parameter: `query` (str). |
+| `get_monitor` | Retrieve monitor configuration. Parameter: `monitor_id` (str). |
+| `update_monitor` | Update frequency or query. Parameters: `monitor_id` (str), `frequency` (str), `query` (str). |
+| `list_monitors` | List all monitors with optional filters. Parameters: `status` ("active"/"cancelled"), `monitor_type` ("event_stream"/"snapshot"), `limit` (int). |
+| `get_monitor_events` | Get detected changes. Returns events with content and citations. Parameters: `monitor_id` (str), `include_completions` (bool), `limit` (int). |
+| `cancel_monitor` | Permanently stop a monitor. Parameter: `monitor_id` (str). |
 
 ## Developer Resources
 
-- View [Example](https://github.com/agno-agi/agno/tree/main/cookbook/91_models/search/parallel)
-- View [Parallel SDK Documentation](https://docs.parallel.ai)
-- View [Parallel API Reference](https://docs.parallel.ai/api-reference)
+- [Cookbook examples](https://github.com/agno-agi/agno/tree/main/cookbook/91_tools/parallel)
+- [Parallel SDK Documentation](https://docs.parallel.ai)
+- [Parallel API Reference](https://docs.parallel.ai/api-reference)

--- a/tools/toolkits/search/parallel.mdx
+++ b/tools/toolkits/search/parallel.mdx
@@ -1,10 +1,10 @@
 ---
 title: Parallel
-description: "Web search, content extraction, deep research, and continuous monitoring with Parallel."
+description: "Use Parallel with Agno for AI-optimized web search and content extraction."
 keywords: [parallel, web search, extract, task api, monitor api, deep research, web monitoring, citations]
 ---
 
-**ParallelTools** provide AI-optimized web capabilities through four APIs:
+**ParallelTools** enable an Agent to perform AI-optimized web search and content extraction using [Parallel's APIs](https://docs.parallel.ai/home).
 
 | API | Speed | Use Case |
 |-----|-------|----------|


### PR DESCRIPTION
## Summary

Updates ParallelTools documentation to cover the Task API and Monitor API tools added in agno-agi/agno#8071.

**Changes:**
- Expanded `tools/toolkits/search/parallel.mdx` from ~80 lines to ~225 lines
- Added Task API section with processor tiers (lite/base/pro/ultra) and output schema types
- Added Monitor API section with frequency options and two-phase usage pattern
- Updated MCP endpoint from deprecated `search-mcp.parallel.ai` to `search.parallel.ai`
- Made API key optional (keyless access is rate-limited)
- Updated all example pages with current code patterns

## Files Changed

| File | Description |
|------|-------------|
| `tools/toolkits/search/parallel.mdx` | Main toolkit documentation |
| `tools/mcp/usage/parallel.mdx` | MCP server usage |
| `examples/tools/parallel-tools.mdx` | Toolkit examples |
| `examples/tools/mcp/parallel.mdx` | MCP example |

## Related

- agno-agi/agno#8071 (feat: add Task API and Monitor API tools)
- agno-agi/agno#8202 (cookbook: update Parallel MCP to use free endpoint)