### PR TITLE
docs(minimax): update default model to MiniMax-M3

### DIFF
--- a/examples/models/minimax/basic.mdx
+++ b/examples/models/minimax/basic.mdx
@@ -19,7 +19,7 @@ from agno.models.minimax import MiniMax
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=MiniMax(id="MiniMax-M2.7"), markdown=True)
+agent = Agent(model=MiniMax(id="MiniMax-M3"), markdown=True)
 
 # ---------------------------------------------------------------------------
 # Run Agent

--- a/examples/models/minimax/structured-output.mdx
+++ b/examples/models/minimax/structured-output.mdx
@@ -44,7 +44,7 @@ class MovieScript(BaseModel):
 # MiniMax does not implement OpenAI-style native `response_format` /
 # `json_schema`, so we drive structured output through JSON mode.
 agent = Agent(
-    model=MiniMax(id="MiniMax-M2.7"),
+    model=MiniMax(id="MiniMax-M3"),
     description="You write movie scripts.",
     output_schema=MovieScript,
     use_json_mode=True,

--- a/examples/models/minimax/tool-use.mdx
+++ b/examples/models/minimax/tool-use.mdx
@@ -19,7 +19,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=MiniMax(id="MiniMax-M2.7"),
+    model=MiniMax(id="MiniMax-M3"),
     markdown=True,
     tools=[WebSearchTools()],
 )

--- a/models/providers/native/minimax/overview.mdx
+++ b/models/providers/native/minimax/overview.mdx
@@ -6,7 +6,7 @@ description: Use MiniMax models with Agno agents.
 
 [MiniMax](https://www.minimax.io/) serves its text models through an OpenAI-compatible API, so you drive them through Agno like any other OpenAI-compatible provider.
 
-The `MiniMax` class defaults to `MiniMax-M2.7` and points at the international endpoint `https://api.minimax.io/v1`.
+The `MiniMax` class defaults to `MiniMax-M3` and points at the international endpoint `https://api.minimax.io/v1`.
 
 ## Authentication
 
@@ -36,7 +36,7 @@ Use `MiniMax` with your `Agent`:
 from agno.agent import Agent
 from agno.models.minimax import MiniMax
 
-agent = Agent(model=MiniMax(id="MiniMax-M2.7"), markdown=True)
+agent = Agent(model=MiniMax(id="MiniMax-M3"), markdown=True)
 
 # Print the response in the terminal
 agent.print_response("Share a 2 sentence horror story.")
@@ -50,7 +50,7 @@ agent.print_response("Share a 2 sentence horror story.")
 
 | Parameter  | Type            | Default                       | Description                                                       |
 | ---------- | --------------- | ----------------------------- | --------------------------------------------------------------- |
-| `id`       | `str`           | `"MiniMax-M2.7"`              | The id of the MiniMax model to use                              |
+| `id`       | `str`           | `"MiniMax-M3"`               | The id of the MiniMax model to use                              |
 | `name`     | `str`           | `"MiniMax"`                   | The name of the model                                           |
 | `provider` | `str`           | `"MiniMax"`                   | The provider of the model                                       |
 | `api_key`  | `Optional[str]` | `None`                        | The API key for MiniMax (defaults to `MINIMAX_API_KEY` env var) |
@@ -63,16 +63,17 @@ agent.print_response("Share a 2 sentence horror story.")
 To hit a different host (private deployment, regional endpoint), pass `base_url`:
 
 ```python
-MiniMax(id="MiniMax-M2.7", base_url="https://your-host.example.com/v1")
+MiniMax(id="MiniMax-M3", base_url="https://your-host.example.com/v1")
 ```
 
 ## Available Models
 
-The OpenAI-compatible endpoint exposes the M2 family. See the [models intro](https://platform.minimax.io/docs/guides/models-intro) for the current catalog.
+The OpenAI-compatible endpoint exposes the M3 and M2 families. See the [models intro](https://platform.minimax.io/docs/guides/models-intro) for the current catalog.
 
 | Model id                  | Notes                                                       |
 | ------------------------- | ---------------------------------------------------------- |
-| `MiniMax-M2.7`            | Flagship MoE (230B total / 10B active), 205k context       |
+| `MiniMax-M3`              | Latest flagship, long-context multimodal reasoning (default) |
+| `MiniMax-M2.7`            | MoE (230B total / 10B active), 205k context                |
 | `MiniMax-M2.7-highspeed`  | Same weights as M2.7, ~1.6-1.7x throughput                 |
 | `MiniMax-M2.5`            | Previous flagship                                          |
 | `MiniMax-M2.5-highspeed`  | Higher-throughput variant of M2.5                          |

--- a/models/providers/native/minimax/usage/basic.mdx
+++ b/models/providers/native/minimax/usage/basic.mdx
@@ -10,7 +10,7 @@ import asyncio
 from agno.agent import Agent
 from agno.models.minimax import MiniMax
 
-agent = Agent(model=MiniMax(id="MiniMax-M2.7"), markdown=True)
+agent = Agent(model=MiniMax(id="MiniMax-M3"), markdown=True)
 
 if __name__ == "__main__":
     # --- Sync ---

--- a/models/providers/native/minimax/usage/structured-output.mdx
+++ b/models/providers/native/minimax/usage/structured-output.mdx
@@ -35,7 +35,7 @@ class MovieScript(BaseModel):
 # MiniMax does not implement OpenAI-style native `response_format` /
 # `json_schema`, so drive structured output through JSON mode.
 agent = Agent(
-    model=MiniMax(id="MiniMax-M2.7"),
+    model=MiniMax(id="MiniMax-M3"),
     description="You write movie scripts.",
     output_schema=MovieScript,
     use_json_mode=True,

--- a/models/providers/native/minimax/usage/tool-use.mdx
+++ b/models/providers/native/minimax/usage/tool-use.mdx
@@ -10,7 +10,7 @@ from agno.models.minimax import MiniMax
 from agno.tools.websearch import WebSearchTools
 
 agent = Agent(
-    model=MiniMax(id="MiniMax-M2.7"),
+    model=MiniMax(id="MiniMax-M3"),
     markdown=True,
     tools=[WebSearchTools()],
 )


### PR DESCRIPTION
Follow-up to agno-agi/agno#8215 (now merged), which switched the `MiniMax` class default from `MiniMax-M2.7` to `MiniMax-M3`. @kausmeows asked for the matching docs update.

Changes:
- Update the default model in the overview prose and parameter table to `MiniMax-M3`
- Update the code examples (basic / tool-use / structured-output, both `examples/` and `usage/`) to use `MiniMax-M3`
- Add `MiniMax-M3` to the available-models table as the new flagship/default; existing M2.x rows are unchanged

Docs-only, no behavior change.