### PR TITLE
Add Tuning Engines model provider docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1978,6 +1978,12 @@
                             ]
                           },
                           {
+                            "group": "Tuning Engines",
+                            "pages": [
+                              "models/providers/gateways/tuning-engines/overview"
+                            ]
+                          },
+                          {
                             "group": "Requesty",
                             "pages": [
                               "models/providers/gateways/requesty/overview",
@@ -3847,6 +3853,12 @@
                               "models/providers/gateways/portkey/usage/structured-output"
                             ]
                           }
+                        ]
+                      },
+                      {
+                        "group": "Tuning Engines",
+                        "pages": [
+                          "models/providers/gateways/tuning-engines/overview"
                         ]
                       },
                       {

--- a/models/providers/gateways/tuning-engines/overview.mdx
+++ b/models/providers/gateways/tuning-engines/overview.mdx
@@ -1,0 +1,65 @@
+---
+title: Tuning Engines
+sidebarTitle: Overview
+description: Use Tuning Engines with Agno through an OpenAI-compatible governed endpoint.
+---
+
+Tuning Engines exposes an OpenAI-compatible endpoint for teams that want Agno agents to run through a governed AI control plane. Agno owns the agent behavior, tools, memory, and orchestration, while Tuning Engines centralizes model access, policy checks, audit logs, traces, and usage/cost reporting.
+
+## Authentication
+
+Create a Tuning Engines inference key and enable the model alias you want the agent to use.
+
+<CodeGroup>
+
+```bash Mac
+export TUNING_ENGINES_API_KEY=sk-te-your-inference-key
+export TUNING_ENGINES_MODEL=your-model-alias
+```
+
+```bash Windows
+setx TUNING_ENGINES_API_KEY sk-te-your-inference-key
+setx TUNING_ENGINES_MODEL your-model-alias
+```
+
+</CodeGroup>
+
+## Example
+
+Use Agno's `OpenAILike` model with the Tuning Engines base URL:
+
+<CodeGroup>
+
+```python agent.py
+from os import getenv
+
+from agno.agent import Agent
+from agno.models.openai import OpenAILike
+
+agent = Agent(
+    model=OpenAILike(
+        id=getenv("TUNING_ENGINES_MODEL", "your-model-alias"),
+        api_key=getenv("TUNING_ENGINES_API_KEY"),
+        base_url="https://api.tuningengines.com/v1",
+    ),
+    markdown=True,
+)
+
+agent.print_response("Share a short checklist for running production AI agents.", stream=True)
+```
+
+</CodeGroup>
+
+## Params
+
+| Parameter | Type | Description | Default |
+| --- | --- | --- | --- |
+| `id` | `str` | Model alias enabled in Tuning Engines | `"your-model-alias"` |
+| `api_key` | `str` | Tuning Engines inference key, usually from `TUNING_ENGINES_API_KEY` | `None` |
+| `base_url` | `str` | Tuning Engines OpenAI-compatible API endpoint | `"https://api.tuningengines.com/v1"` |
+
+`OpenAILike` supports the same parameters documented in [OpenAI Like](/models/providers/openai-like).
+
+<Note>
+For a runnable example, see the Tuning Engines cookbook in the Agno repository.
+</Note>

--- a/models/providers/gateways/tuning-engines/overview.mdx
+++ b/models/providers/gateways/tuning-engines/overview.mdx
@@ -15,18 +15,22 @@ Create a Tuning Engines inference key and enable the model alias you want the ag
 ```bash Mac
 export TUNING_ENGINES_API_KEY=sk-te-your-inference-key
 export TUNING_ENGINES_MODEL=your-model-alias
+# Optional, only when using a custom host:
+export TUNING_ENGINES_BASE_URL=https://api.tuningengines.com/v1
 ```
 
 ```bash Windows
 setx TUNING_ENGINES_API_KEY sk-te-your-inference-key
 setx TUNING_ENGINES_MODEL your-model-alias
+:: Optional, only when using a custom host:
+setx TUNING_ENGINES_BASE_URL https://api.tuningengines.com/v1
 ```
 
 </CodeGroup>
 
 ## Example
 
-Use Agno's `OpenAILike` model with the Tuning Engines base URL:
+Use Agno's `TuningEngines` model provider:
 
 <CodeGroup>
 
@@ -34,13 +38,11 @@ Use Agno's `OpenAILike` model with the Tuning Engines base URL:
 from os import getenv
 
 from agno.agent import Agent
-from agno.models.openai import OpenAILike
+from agno.models.tuning_engines import TuningEngines
 
 agent = Agent(
-    model=OpenAILike(
+    model=TuningEngines(
         id=getenv("TUNING_ENGINES_MODEL", "your-model-alias"),
-        api_key=getenv("TUNING_ENGINES_API_KEY"),
-        base_url="https://api.tuningengines.com/v1",
     ),
     markdown=True,
 )
@@ -55,10 +57,10 @@ agent.print_response("Share a short checklist for running production AI agents."
 | Parameter | Type | Description | Default |
 | --- | --- | --- | --- |
 | `id` | `str` | Model alias enabled in Tuning Engines | `"your-model-alias"` |
-| `api_key` | `str` | Tuning Engines inference key, usually from `TUNING_ENGINES_API_KEY` | `None` |
-| `base_url` | `str` | Tuning Engines OpenAI-compatible API endpoint | `"https://api.tuningengines.com/v1"` |
+| `api_key` | `str` | Tuning Engines inference key, usually from `TUNING_ENGINES_API_KEY` | `TUNING_ENGINES_API_KEY` |
+| `base_url` | `str` | Tuning Engines OpenAI-compatible API endpoint | `TUNING_ENGINES_BASE_URL` or `"https://api.tuningengines.com/v1"` |
 
-`OpenAILike` supports the same parameters documented in [OpenAI Like](/models/providers/openai-like).
+`TuningEngines` extends `OpenAILike`, so it supports the same OpenAI-compatible model parameters documented in [OpenAI Like](/models/providers/openai-like).
 
 <Note>
 For a runnable example, see the Tuning Engines cookbook in the Agno repository.


### PR DESCRIPTION
## Summary
- add a Tuning Engines gateway docs page under model providers
- document the dedicated `TuningEngines` model provider added in agno-agi/agno#8175
- add the page to the model gateway navigation

## Context
Companion docs for agno-agi/agno#8175, requested in review.

## Validation
- `jq empty docs.json`