### PR TITLE
Add DOCX/HTML support to file-generation docs

### DIFF
--- a/tools/toolkits/file-generation/file-generation.mdx
+++ b/tools/toolkits/file-generation/file-generation.mdx
@@ -13,15 +13,18 @@ Supported file types:
 - JSON 
 - CSV 
 - PDF
+- DOCX
 - TXT
+- HTML
 </Tip>
 
 ## Prerequisites
 
 1. **Install dependencies:**
    ```bash
-   uv pip install reportlab openai
+   uv pip install reportlab python-docx openai
    ```
+   `reportlab` is required for PDF generation and `python-docx` for DOCX generation. JSON, CSV, TXT, and HTML generation have no external dependencies.
 
 2. **Set your credentials:**
     For OpenAI API:
@@ -35,13 +38,14 @@ The following agent will generate files in different formats based on user reque
 
 ```python file_generation_tools.py
 from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.tools.file_generation import FileGenerationTools
 
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.2"),
     db=SqliteDb(db_file="tmp/test.db"),
-    tools=[FileGenerationTools(output_directory="tmp")],  
+    tools=[FileGenerationTools(output_directory="tmp")],
     description="You are a helpful assistant that can generate files in various formats.",
     instructions=[
         "When asked to create files, use the appropriate file generation tools.",
@@ -51,16 +55,16 @@ agent = Agent(
     markdown=True,
 )
 
-response =agent.run(
-        "Create a PDF report about renewable energy trends in 2024. Include sections on solar, wind, and hydroelectric power."
-    )
+response = agent.run(
+    "Create a PDF report about renewable energy trends in 2024. Include sections on solar, wind, and hydroelectric power."
+)
 print(response.content)
-    if response.files:
-        for file in response.files:
-            print(f"Generated file: {file.filename} ({file.size} bytes)")
-            if file.url:
-                print(f"File location: {file.url}")
-    print()
+
+if response.files:
+    for file in response.files:
+        print(f"Generated file: {file.filename} ({file.size} bytes)")
+        if file.url:
+            print(f"File location: {file.url}")
 ```
 
 <Note>
@@ -72,12 +76,15 @@ If not specified, the files will be available in the `RunOutput` object.
 
 | Parameter                 | Type   | Default | Description                                     |
 | ------------------------- | ------ | ------- | ----------------------------------------------- |
-| `enable_json_generation`  | `bool` | `True`  | Enables JSON file generation                    |
-| `enable_csv_generation`   | `bool` | `True`  | Enables CSV file generation                     |
-| `enable_pdf_generation`   | `bool` | `True`  | Enables PDF file generation (requires reportlab)|
-| `enable_txt_generation`   | `bool` | `True`  | Enables text file generation                    |
-| `output_directory`        | `str`  | `None`  | Custom output directory path                    |
-| `all`                     | `bool` | `False` | Enables all file generation types when True     |
+| `enable_json_generation`  | `bool` | `True`  | Enables JSON file generation                       |
+| `enable_csv_generation`   | `bool` | `True`  | Enables CSV file generation                        |
+| `enable_pdf_generation`   | `bool` | `True`  | Enables PDF file generation (requires reportlab)   |
+| `enable_docx_generation`  | `bool` | `True`  | Enables DOCX file generation (requires python-docx)|
+| `enable_txt_generation`   | `bool` | `True`  | Enables text file generation                       |
+| `enable_html_generation`  | `bool` | `True`  | Enables HTML file generation                       |
+| `output_directory`        | `str`  | `None`  | Custom output directory path                       |
+| `save_files`              | `bool` | `False` | Saves generated files to disk when True            |
+| `all`                     | `bool` | `False` | Enables all file generation types when True        |
 
 ## Toolkit Functions
 
@@ -86,7 +93,9 @@ If not specified, the files will be available in the `RunOutput` object.
 | `generate_json_file`  | Generates a JSON file from data (dict, list, or JSON string)  |
 | `generate_csv_file`   | Generates a CSV file from tabular data                        |
 | `generate_pdf_file`   | Generates a PDF document from text content                    |
-| `generate_text_file`  | Generates a plain text file from string content              |
+| `generate_docx_file`  | Generates a Word (DOCX) document from text content            |
+| `generate_text_file`  | Generates a plain text file from string content               |
+| `generate_html_file`  | Generates an HTML file from a complete HTML5 document         |
 
 ## Developer Resources
 


### PR DESCRIPTION


## Description

Document new DOCX and HTML file generation: add DOCX/HTML to supported types, list python-docx as a dependency (keep reportlab note for PDFs), and update the toolkit parameter table to include enable_docx_generation, enable_html_generation, and save_files. Also update example code: import SqliteDb and use it for Agent db, reformat agent.run call and the response.files printing block. Finally, add generate_docx_file and generate_html_file to the toolkit function list.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#8241 agno-agi/agno#7768

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
