### PR TITLE
docs(observability/latitude): point links to console.latitude.so

### DIFF
--- a/observability/latitude.mdx
+++ b/observability/latitude.mdx
@@ -23,7 +23,7 @@ usage, cost, latency, and full input/output captured automatically.
 
 2. **Setup Latitude Account**
 
-   - Sign up for an account at [Latitude](https://app.latitude.so) (or self-host).
+   - Sign up for an account at [Latitude](https://console.latitude.so/login) (or self-host).
    - Create a project and copy its slug.
    - Obtain an API key from the project's settings.
 
@@ -84,7 +84,7 @@ agent.print_response("What is the current price of Tesla?")
 ```
 
 After running the agent, open your project in the
-[Latitude dashboard](https://app.latitude.so) to view the trace, with child
+[Latitude dashboard](https://console.latitude.so/login) to view the trace, with child
 spans for each model and tool call.
 
 <Frame caption="Agno traces in Latitude">


### PR DESCRIPTION
## What

The Latitude observability page links the **signup** step and the **"Latitude dashboard"** reference to `https://app.latitude.so`, which is Latitude V1 and is no longer promoted.

This updates both links to the current console: `https://console.latitude.so/login`.

## Changes

- `observability/latitude.mdx`
  - Signup step: `app.latitude.so` → `console.latitude.so/login`
  - "Latitude dashboard" link: `app.latitude.so` → `console.latitude.so/login`

The marketing homepage link (`https://latitude.so`) is unchanged.