### PR TITLE
Redirect old agent-platform tutorial overview to canonical path

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -8222,6 +8222,10 @@
       "destination": "/tutorials/agent-platform/next-steps"
     },
     {
+      "source": "/tutorials/agent-platform/overview",
+      "destination": "/agent-platform/overview"
+    },
+    {
       "source": "/home",
       "destination": "/"
     },


### PR DESCRIPTION
## What

Adds a redirect from the old (Google-indexed) tutorial path to the canonical Agent Platform path:

```json
{
  "source": "/tutorials/agent-platform/overview",
  "destination": "/agent-platform/overview"
}
```

## Why

Searching "agno agent platform template" on Google surfaces the old `/tutorials/agent-platform/overview` URL. That section is being wound down in favor of the canonical `/agent-platform/*` pages. This redirect lands visitors on the correct page.

Scope is intentionally limited to `overview` only. The other old tutorial pages (`setup`, `deploy-to-railway`, etc.) don't map 1:1 by filename to the new structure and were left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)