### PR TITLE
[feat] Add Scavio search toolkit docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2176,6 +2176,7 @@
                           "tools/toolkits/search/parallel",
                           "tools/toolkits/search/perplexity",
                           "tools/toolkits/search/pubmed",
+                          "tools/toolkits/search/scavio",
                           "tools/toolkits/search/searxng",
                           "tools/toolkits/search/seltz",
                           "tools/toolkits/search/serpapi",

--- a/tools/toolkits/search/scavio.mdx
+++ b/tools/toolkits/search/scavio.mdx
@@ -1,0 +1,82 @@
+---
+title: Scavio
+---
+
+**ScavioTools** enable an Agent to search across Google, YouTube, Amazon, Walmart, Reddit, TikTok, and Instagram using the [Scavio](https://scavio.dev) unified Search API.
+
+## Prerequisites
+
+The following examples require the `scavio` library and an API key from [Scavio](https://dashboard.scavio.dev).
+
+```shell
+uv pip install -U scavio
+```
+
+```shell
+export SCAVIO_API_KEY=***
+```
+
+## Example
+
+The following agent will search Google via Scavio and print the response.
+
+```python cookbook/91_tools/scavio_tools.py
+from agno.agent import Agent
+from agno.tools.scavio import ScavioTools
+
+agent = Agent(tools=[ScavioTools()], markdown=True)
+agent.print_response("Search for the GitHub repo of the Agno framework")
+```
+
+Every provider is enabled by default. Use the `enable_*` flags to expose only the tools you need:
+
+```python
+# Web-only agent: Google, YouTube, Reddit
+agent = Agent(
+    tools=[
+        ScavioTools(
+            enable_google=True,
+            enable_youtube=True,
+            enable_reddit=True,
+            enable_amazon=False,
+            enable_walmart=False,
+            enable_tiktok=False,
+            enable_instagram=False,
+        )
+    ],
+    markdown=True,
+)
+```
+
+## Toolkit Params
+
+| Parameter           | Type            | Default | Description                                                                  |
+| ------------------- | --------------- | ------- | ---------------------------------------------------------------------------- |
+| `api_key`           | `Optional[str]` | `None`  | Scavio API key. If not provided, uses the `SCAVIO_API_KEY` environment variable. |
+| `enable_google`     | `bool`          | `True`  | Register the Google web search tool.                                         |
+| `enable_amazon`     | `bool`          | `True`  | Register the Amazon search and product tools.                               |
+| `enable_walmart`    | `bool`          | `True`  | Register the Walmart search and product tools.                              |
+| `enable_youtube`    | `bool`          | `True`  | Register the YouTube search and metadata tools.                             |
+| `enable_reddit`     | `bool`          | `True`  | Register the Reddit search and post tools.                                  |
+| `enable_tiktok`     | `bool`          | `True`  | Register the TikTok tools.                                                   |
+| `enable_instagram`  | `bool`          | `True`  | Register the Instagram tools.                                                |
+| `all`               | `bool`          | `False` | Register every available tool, ignoring the individual flags.               |
+
+## Toolkit Functions
+
+Each function returns the Scavio response as a JSON string. Errors are returned as `{"error": "..."}` rather than raised.
+
+| Function                                                                                         | Description                                                  |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `google_search`                                                                                  | Search Google for real-time web results.                    |
+| `amazon_search`, `amazon_product`                                                                | Search Amazon products and fetch a product by ASIN.         |
+| `walmart_search`, `walmart_product`                                                              | Search Walmart products and fetch a product by product ID.  |
+| `youtube_search`, `youtube_metadata`                                                             | Search YouTube videos and fetch video metadata.             |
+| `reddit_search`, `reddit_post`                                                                   | Search Reddit and fetch a post with its comment tree.       |
+| `tiktok_profile`, `tiktok_user_posts`, `tiktok_video`, `tiktok_video_comments`, `tiktok_comment_replies`, `tiktok_search_videos`, `tiktok_search_users`, `tiktok_hashtag`, `tiktok_hashtag_videos`, `tiktok_user_followers`, `tiktok_user_followings` | TikTok profiles, videos, comments, search, hashtags, and social graph. |
+| `instagram_profile`, `instagram_user_posts`, `instagram_user_reels`, `instagram_user_tagged`, `instagram_user_stories`, `instagram_post`, `instagram_post_comments`, `instagram_comment_replies`, `instagram_search_users`, `instagram_search_hashtags`, `instagram_user_followers`, `instagram_user_followings` | Instagram profiles, posts, reels, stories, comments, search, hashtags, and social graph. |
+
+## Developer Resources
+
+- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/scavio.py)
+- View [Cookbook](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/scavio_tools.py)


### PR DESCRIPTION
## Summary

Adds the documentation page for the new `ScavioTools` search toolkit, under **Tools → Toolkits → Search**.

- New page `tools/toolkits/search/scavio.mdx` (modeled on `tavily.mdx` / `exa.mdx`): prerequisites, example, `enable_*` flag usage, toolkit params, and the full function list across all 7 providers.
- Registered in `docs.json` navigation under the search toolkits group.

Companion to the code PR adding the toolkit itself: agno-agi/agno#8508 (closes agno-agi/agno#8512).

## Notes

`ScavioTools` wraps the [Scavio](https://scavio.dev) unified Search API (Google, YouTube, Amazon, Walmart, Reddit, TikTok, Instagram) via the `scavio` Python SDK. Get a key at https://dashboard.scavio.dev.
