### PR TITLE
docs: add CoinGeckoTools toolkit documentation

### DIFF
--- a/tools/toolkits/others/coingecko.mdx
+++ b/tools/toolkits/others/coingecko.mdx
@@ -1,0 +1,50 @@
+---
+title: CoinGecko
+---
+
+**CoinGeckoTools** enable an Agent to access cryptocurrency market data, prices, trending coins, and more from the free CoinGecko API.
+
+## Prerequisites
+
+No additional dependencies are required. CoinGeckoTools uses the free CoinGecko API which does not require an API key.
+
+## Example
+
+The following agent will provide information about cryptocurrency prices and trending coins.
+
+```python cookbook/14_tools/coingecko_tools.py
+from agno.agent import Agent
+from agno.tools.coingecko import CoinGeckoTools
+
+agent = Agent(
+    tools=[CoinGeckoTools()],
+    description="You are a crypto market analyst that researches cryptocurrency prices, market data, and trending coins.",
+    instructions=["Format your response using markdown and use tables to display data where possible."],
+)
+agent.print_response("What is the current price of Bitcoin and Ethereum? Also show me trending coins.", markdown=True)
+```
+
+## Toolkit Params
+
+| Parameter          | Type  | Default | Description                                        |
+| ------------------ | ----- | ------- | -------------------------------------------------- |
+| `enable_price`     | bool  | True    | Enable the get_coin_price function.                |
+| `enable_search`    | bool  | True    | Enable the search_coins function.                  |
+| `enable_trending`  | bool  | True    | Enable the get_trending function.                  |
+| `enable_market`    | bool  | True    | Enable the get_coin_market_data function.          |
+| `timeout`          | int   | 30      | Request timeout in seconds.                        |
+
+## Toolkit Functions
+
+| Function              | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `get_coin_price`      | Get the current price of a cryptocurrency in a specified currency (USD, EUR, etc.). |
+| `search_coins`        | Search for coins by name or symbol and return matching results.             |
+| `get_trending`        | Get the top trending cryptocurrencies on CoinGecko.                         |
+| `get_coin_market_data`| Get detailed market data for a coin including market cap, volume, and price changes. |
+
+You can use `include_tools` or `exclude_tools` to modify the list of tools the agent has access to. Learn more about [selecting tools](/tools/selecting-tools).
+
+## Developer Resources
+
+- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/coingecko.py)


### PR DESCRIPTION
## Summary

Adds documentation for the **CoinGeckoTools** toolkit, as requested in [agno-agi/agno#8523](https://github.com/agno-agi/agno/pull/8523#issuecomment-4809568690).

Follows the same format as existing toolkit docs (yfinance, etc.):
- Usage example with Agent
- Toolkit params table (enable flags + timeout)
- Functions table with descriptions
- Developer resources link

Related PR: https://github.com/agno-agi/agno/pull/8523