### PR TITLE
fix: align agent-platform guide with skills (.agents/skills, /skill invocations)

### DIFF
--- a/agent-platform/create-agent.mdx
+++ b/agent-platform/create-agent.mdx
@@ -5,16 +5,16 @@ description: "Use Claude Code to create a new agent."
 
 Next we're going to create a new agent using Claude Code.
 
-A great side-effect of having a unified platform is that coding agents can manage it end-to-end. The codebase comes with five prompts that cover the full ADLC.
+A great side-effect of having a unified platform is that coding agents can manage it end-to-end. The codebase comes with five skills that cover the full ADLC.
 
-Let's try `docs/create-new-agent.md`
+Let's try the `/create-new-agent` skill.
 
-## Run the prompt
+## Run the skill
 
 Open Claude Code in your `agent-platform` directory and paste:
 
 ```
-Run docs/create-new-agent.md
+/create-new-agent
 ```
 
 Claude will ask a few questions and build your agent out.

--- a/agent-platform/evals.mdx
+++ b/agent-platform/evals.mdx
@@ -7,7 +7,7 @@ Next, let's lock in our agent behavior with evals.
 
 Think of Evals as regression tests for your agents. Same prompts, same agents, run on a schedule. Notify when behavior drifts.
 
-When we run `docs/improve-agent.md`, we're looking for out-of-distribution improvements. Evals make sure in-distribution cases continue to pass. The two work together.
+When we run `/improve-agent`, we're looking for out-of-distribution improvements. Evals make sure in-distribution cases continue to pass. The two work together.
 
 ## Cases
 
@@ -83,7 +83,7 @@ Results write to Postgres via `eval_db`. You can view the Eval history on [os.ag
 Open Claude Code and paste:
 
 ```
-Run docs/eval-and-improve.md
+/eval-and-improve
 ```
 
 Claude runs the full suite, triages every failure (bad criteria, real regression, flaky LLM judge), and proposes in-scope fixes. It edits the agent or the case, re-runs, and shows you the diff.

--- a/agent-platform/improve-agent.mdx
+++ b/agent-platform/improve-agent.mdx
@@ -5,10 +5,10 @@ description: "Use Claude Code to recursively improve your agents."
 
 Next we're going to improve our agents using Claude Code.
 
-The biggest advantage of having a unified agent platform is that coding agents can read logs to iteratively improve our agents. The codebase comes with two prompts:
+The biggest advantage of having a unified agent platform is that coding agents can read logs to iteratively improve our agents. The codebase comes with two skills:
 
-- `docs/improve-agent.md`. Claude derives probes from the agent's instructions, judges responses, and edits until they pass. **Autonomous.**
-- `docs/extend-agent.md`. Add a tool, refine a prompt, fix a bug. **User-driven.**
+- `/improve-agent`. Claude derives probes from the agent's instructions, judges responses, and edits until they pass. **Autonomous.**
+- `/extend-agent`. Add a tool, refine a prompt, fix a bug. **User-driven.**
 
 Both edit `agents/<slug>.py` directly. Hot-reload picks up the change in ~2s, so the test → judge → edit cycle is fairly tight.
 
@@ -17,7 +17,7 @@ Both edit `agents/<slug>.py` directly. Hot-reload picks up the change in ~2s, so
 Open Claude Code in your `agent-platform` directory and paste:
 
 ```
-Run docs/improve-agent.md
+/improve-agent
 ```
 
 Claude reads the target agent's `INSTRUCTIONS` and derives 8–12 probes across four categories: golden path, edge cases, tool selection, and adversarial. For each probe, it cURLs the live container, reads tool calls from the logs, and judges PASS or FAIL against what the instructions promise.
@@ -29,7 +29,7 @@ For every failure, Claude picks a lever and edits: tighten a rule, add a rule, s
 When you have a specific change in mind, paste:
 
 ```
-Run docs/extend-agent.md
+/extend-agent
 ```
 
 Claude asks what to change. You describe a tool to add, a prompt to refine, a bug to fix. The agno-docs MCP is loaded so toolkit research is grounded in the real API. Each iteration is one small, verified change.

--- a/agent-platform/next-steps.mdx
+++ b/agent-platform/next-steps.mdx
@@ -72,10 +72,10 @@ agent_os = AgentOS(
 
 ## Keep the repo coherent
 
-As you ship more agents, configuration drifts, env vars rot, and new agents miss imports. The template ships a fifth Claude Code prompt for the recurring sweep:
+As you ship more agents, configuration drifts, env vars rot, and new agents miss imports. The template ships a fifth Claude Code skill for the recurring sweep:
 
 ```
-Run docs/review-and-improve.md
+/review-and-improve
 ```
 
 It auto-fixes mechanical drift (stale paths, missing `example.env` entries, agents on disk not registered in `app/main.py`) and surfaces the rest as a punch list. Best run before public releases and periodically during active development.

--- a/agent-platform/run-local.mdx
+++ b/agent-platform/run-local.mdx
@@ -87,7 +87,7 @@ We now have a locally running agent platform with:
 
 - Our agent runtime (AgentOS) running on port 8000 with request isolation, session management, scheduling, and 50+ endpoints.
 - A Postgres database for storing sessions, memory, knowledge, and traces.
-- A `docs/` folder of Claude Code prompts for managing the entire agent development lifecycle: create, improve, extend, eval, and review.
+- A `.agents/skills/` folder of Claude Code skills for managing the entire agent development lifecycle: create, improve, extend, eval, and review.
 
 <Tip>
   Hot-reload is on. Edits to `agents/*.py` and `app/*.py` should be live in ~2s.


### PR DESCRIPTION
## Summary

The **`agent-platform/*`** guide targets the newer [`agent-platform-railway`](https://github.com/agno-agi/agent-platform-railway) template, where the five lifecycle prompts ship as **Claude Code skills** under `.agents/skills/<name>/SKILL.md` (invoked as `/create-new-agent`, `/improve-agent`, `/extend-agent`, `/eval-and-improve`, `/review-and-improve`). There is no `docs/` folder in that repo.

Several pages still referenced the old `docs/<name>.md` prompt paths, so following them literally (e.g. `Run docs/create-new-agent.md`) fails. This PR updates all of them to the skill invocations the template actually documents in its README/AGENTS.md.

## Pages fixed (agent-platform/*)

- `run-local.mdx` — Summary bullet: `docs/` folder → `.agents/skills/` folder of skills.
- `create-agent.mdx` — prose + code block → `/create-new-agent`; "five prompts" → "five skills".
- `improve-agent.mdx` — two bullets + two code blocks → `/improve-agent`, `/extend-agent`; "two prompts" → "two skills".
- `evals.mdx` — prose + code block → `/improve-agent`, `/eval-and-improve`.
- `next-steps.mdx` — code block → `/review-and-improve`; "prompt" → "skill".

## Deliberately NOT changed

The **`tutorials/agent-platform/*`** pages clone the *older* [`agentos-railway-template`](https://github.com/agno-agi/agentos-railway-template), which really does ship a `docs/*.md` folder. Their `docs/...md` references are correct for that repo and were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
