### PR TITLE
fix: migration manager using outdated table names

### DIFF
--- a/other/database-migrations.mdx
+++ b/other/database-migrations.mdx
@@ -86,19 +86,19 @@ db = AsyncPostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 
 async def run_migrate_table():
     # This will migrate the memories table to the latest version
-    await MigrationManager(db).up(table_type="memory")
+    await MigrationManager(db).up(table_type="memories")
 
     # Or if you want to upgrade to a specific version
-    await MigrationManager(db).up(table_type="memory", target_version="2.0.0")
+    await MigrationManager(db).up(table_type="memories", target_version="2.0.0")
 
     # Or if you want to force the migration
-    await MigrationManager(db).up(table_type="memory", force=True)
+    await MigrationManager(db).up(table_type="memories", force=True)
 
 if __name__ == "__main__":
     asyncio.run(run_migrate_table())
 ```
 
-The supported table types are: `session`, `memory`, `metrics`, `eval`, `knowledge`, `culture`.
+The supported table types are: `sessions`, `memories`, `metrics`, `evals`, `knowledge`, `culture`, `approvals`.
 
 
 ### Reverting Migrations
@@ -132,7 +132,7 @@ if __name__ == "__main__":
   ```python
     await MigrationManager(db).up(
         target_version="2.3.0",
-        table_type="memory",
+        table_type="memories",
         force=True,
     )
     ```

--- a/reference/storage/migrations.mdx
+++ b/reference/storage/migrations.mdx
@@ -55,7 +55,7 @@ async def up(
 <ResponseField name="table_type" type="str" optional>
   The specific table type to migrate. If not provided, all tables will be migrated.
   
-  Valid values: `"memory"`, `"session"`, `"metrics"`, `"eval"`, `"knowledge"`, `"culture"`
+  Valid values: `"memories"`, `"sessions"`, `"metrics"`, `"evals"`, `"knowledge"`, `"culture"`, `"approvals"`
 </ResponseField>
 
 <ResponseField name="force" type="bool" default="False">
@@ -78,12 +78,12 @@ async def run_migrations():
     # Migrate specific table to specific version
     await MigrationManager(db).up(
         target_version="2.3.0",
-        table_type="memory"
+        table_type="memories"
     )
     
     # Force migration
     await MigrationManager(db).up(
-        table_type="session",
+        table_type="sessions",
         force=True
     )
 
@@ -112,7 +112,7 @@ async def down(
 <ResponseField name="table_type" type="str" optional>
   The specific table type to migrate. If not provided, all tables will be migrated.
   
-  Valid values: `"memory"`, `"session"`, `"metrics"`, `"eval"`, `"knowledge"`, `"culture"`
+  Valid values: `"memories"`, `"sessions"`, `"metrics"`, `"evals"`, `"knowledge"`, `"culture"`, `"approvals"`
 </ResponseField>
 
 <ResponseField name="force" type="bool" default="False">
@@ -135,7 +135,7 @@ async def revert_migrations():
     # Revert specific table
     await MigrationManager(db).down(
         target_version="2.0.0",
-        table_type="memory"
+        table_type="memories"
     )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

fix for: https://github.com/agno-agi/agno/issues/8595

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [ ] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

<!-- Link any related issues or PRs -->

- Closes #\_\_\_\_
- Related SDK PR: agno-agi/agno#\_\_\_\_

## Checklist

- [ ] Content is accurate and up-to-date
- [ ] All links tested and working
- [ ] Code examples verified (if applicable)
- [ ] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
