### PR TITLE
docs: add TwelveLabs tools page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2335,6 +2335,7 @@
                           "tools/toolkits/others/shopify",
                           "tools/toolkits/others/todoist",
                           "tools/toolkits/others/trello",
+                          "tools/toolkits/others/twelvelabs",
                           "tools/toolkits/others/user-control-flow",
                           "tools/toolkits/others/user-feedback",
                           "tools/toolkits/others/visualization",

--- a/tools/toolkits/others/twelvelabs.mdx
+++ b/tools/toolkits/others/twelvelabs.mdx
@@ -1,0 +1,78 @@
+---
+title: TwelveLabs
+---
+
+**TwelveLabsTools** enable an Agent to understand and search video using [TwelveLabs](https://twelvelabs.io). The toolkit exposes two capabilities: `analyze_video`, which answers a natural-language question about a video using the Pegasus video understanding model, and `embed_text`, which generates a multimodal embedding with the Marengo model that lives in the same latent space as TwelveLabs video, audio and image embeddings (useful for searching a video corpus by text).
+
+## Prerequisites
+
+You need to install the `twelvelabs` library and an API key which can be obtained from the [TwelveLabs dashboard](https://twelvelabs.io).
+
+```bash
+uv pip install twelvelabs
+```
+
+Set the `TWELVELABS_API_KEY` environment variable.
+
+```bash
+export TWELVELABS_API_KEY=****
+```
+
+## Example
+
+The following agent will use TwelveLabs to answer a question about a video and to generate a text embedding.
+
+```python cookbook/91_tools/twelvelabs_tools.py
+from agno.agent import Agent
+from agno.tools.twelvelabs import TwelveLabsTools
+
+# Example 1: Enable all tools
+agent = Agent(
+    tools=[TwelveLabsTools(all=True)],
+    markdown=True,
+)
+
+agent.print_response(
+    "What is happening in this video? https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4",
+)
+
+# Example 2: Enable only text embedding (useful for embedding search queries
+# against a TwelveLabs video index)
+embedding_agent = Agent(
+    tools=[
+        TwelveLabsTools(
+            enable_analyze_video=False,
+            enable_embed_text=True,
+        )
+    ],
+    markdown=True,
+)
+
+embedding_agent.print_response(
+    "Embed the text 'a cat playing piano' and tell me how many dimensions it has."
+)
+```
+
+## Toolkit Params
+
+| Parameter              | Type            | Default        | Description                                                                                     |
+| ---------------------- | --------------- | -------------- | ----------------------------------------------------------------------------------------------- |
+| `api_key`              | `Optional[str]` | `None`         | The TwelveLabs API key. Read from the `TWELVELABS_API_KEY` environment variable if not provided. |
+| `analyze_model`        | `str`           | `pegasus1.5`   | The Pegasus model used for `analyze_video`.                                                     |
+| `embed_model`          | `str`           | `marengo3.0`   | The Marengo model used for `embed_text`.                                                        |
+| `max_tokens`           | `int`           | `2048`         | Maximum number of tokens for `analyze_video` responses.                                         |
+| `enable_analyze_video` | `bool`          | `True`         | Enable the `analyze_video` functionality.                                                       |
+| `enable_embed_text`    | `bool`          | `True`         | Enable the `embed_text` functionality.                                                          |
+| `all`                  | `bool`          | `False`        | Enable all functionality.                                                                       |
+
+## Toolkit Functions
+
+| Function        | Description                                                                                                                        |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `analyze_video` | Analyze a video and answer a natural-language question about it using the Pegasus model.                                           |
+| `embed_text`    | Generate a multimodal (Marengo) embedding for a piece of text, which can be used to search a video corpus by text.                 |
+
+## Developer Resources
+
+- View [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/twelvelabs.py)
+- View [Cookbook](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/twelvelabs_tools.py)


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds a documentation page for the **TwelveLabs** toolkit that was added to the framework in agno-agi/agno#8562 (recently merged). During that review, @kausmeows kindly asked if I'd also add docs for it here, so this is the follow-up.

### What this covers

The new page (`tools/toolkits/others/twelvelabs.mdx`) documents `TwelveLabsTools`, which lets an Agent understand and search video via [TwelveLabs](https://twelvelabs.io):

- `analyze_video` — answer a natural-language question about a video using the Pegasus model.
- `embed_text` — generate a multimodal (Marengo) embedding that lives in the same latent space as TwelveLabs video/audio/image embeddings.

The page includes the intro, Prerequisites (`uv pip install twelvelabs` + `TWELVELABS_API_KEY`), a runnable Example adapted from the cookbook (`cookbook/91_tools/twelvelabs_tools.py`), a Toolkit Params table, a Toolkit Functions table, and Developer Resources links to the toolkit source and cookbook.

It follows the existing toolkit-docs format (mirrors the sibling pages under `tools/toolkits/others/`, e.g. Eleven Labs and Replicate), and I added the page to the Toolkits nav in `docs.json` alongside the other `others/` toolkits.