### PR TITLE
docs: AgentOS description update on template deploy pages (backend → platform)

### DIFF
--- a/deploy/templates/aws/deploy.mdx
+++ b/deploy/templates/aws/deploy.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Deploy"
 description: "Run AgentOS locally using Docker and deploy to production on AWS."
 ---
 
-AgentOS is a secure and scalable backend for running agents. The [agentos-aws](https://github.com/agno-agi/agentos-aws) codebase runs AgentOS locally using Docker and deploys to production on AWS. It comes with:
+AgentOS is a secure, scalable platform for running agents. The [agentos-aws](https://github.com/agno-agi/agentos-aws) codebase runs AgentOS locally using Docker and deploys to production on AWS. It comes with:
 
 - **2 platform agents** that build and run the platform for you. **Agent Builder** creates agents, teams, and workflows. **Platform Manager** monitors and manages the platform.
 - **5 [skills](/deploy/templates/improve-agents)** that let coding agents build, test, and improve the platform for you.

--- a/deploy/templates/azure/deploy.mdx
+++ b/deploy/templates/azure/deploy.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Deploy"
 description: "Run AgentOS locally using Docker and deploy to production on Azure Container Apps."
 ---
 
-AgentOS is a secure and scalable backend for running agents. The [agentos-azure](https://github.com/agno-agi/agentos-azure) codebase runs AgentOS locally using Docker and deploys to production on Azure Container Apps. It comes with:
+AgentOS is a secure, scalable platform for running agents. The [agentos-azure](https://github.com/agno-agi/agentos-azure) codebase runs AgentOS locally using Docker and deploys to production on Azure Container Apps. It comes with:
 
 - **2 platform agents** that build and run the platform for you. **Agent Builder** creates agents, teams, and workflows. **Platform Manager** monitors and manages the platform.
 - **5 [skills](/deploy/templates/improve-agents)** that let coding agents build, test, and improve the platform for you.

--- a/deploy/templates/docker/deploy.mdx
+++ b/deploy/templates/docker/deploy.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Deploy"
 description: "Run AgentOS locally using Docker and deploy to production on self-hosted Docker."
 ---
 
-AgentOS is a secure and scalable backend for running agents. The [agentos-docker](https://github.com/agno-agi/agentos-docker) codebase runs AgentOS locally using Docker and deploys to production on self-hosted Docker. It comes with:
+AgentOS is a secure, scalable platform for running agents. The [agentos-docker](https://github.com/agno-agi/agentos-docker) codebase runs AgentOS locally using Docker and deploys to production on self-hosted Docker. It comes with:
 
 - **2 platform agents** that build and run the platform for you. **Agent Builder** creates agents, teams, and workflows. **Platform Manager** monitors and manages the platform.
 - **5 [skills](/deploy/templates/improve-agents)** that let coding agents build, test, and improve the platform for you.

--- a/deploy/templates/fly/deploy.mdx
+++ b/deploy/templates/fly/deploy.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Deploy"
 description: "Run AgentOS locally using Docker and deploy to production on Fly.io."
 ---
 
-AgentOS is a secure and scalable backend for running agents. The [agentos-fly](https://github.com/agno-agi/agentos-fly) codebase runs AgentOS locally using Docker and deploys to production on Fly.io. It comes with:
+AgentOS is a secure, scalable platform for running agents. The [agentos-fly](https://github.com/agno-agi/agentos-fly) codebase runs AgentOS locally using Docker and deploys to production on Fly.io. It comes with:
 
 - **2 platform agents** that build and run the platform for you. **Agent Builder** creates agents, teams, and workflows. **Platform Manager** monitors and manages the platform.
 - **5 [skills](/deploy/templates/improve-agents)** that let coding agents build, test, and improve the platform for you.

--- a/deploy/templates/gcp/deploy.mdx
+++ b/deploy/templates/gcp/deploy.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Deploy"
 description: "Run AgentOS locally using Docker and deploy to production on Google Cloud Run."
 ---
 
-AgentOS is a secure and scalable backend for running agents. The [agentos-gcp](https://github.com/agno-agi/agentos-gcp) codebase runs AgentOS locally using Docker and deploys to production on Google Cloud Run. It comes with:
+AgentOS is a secure, scalable platform for running agents. The [agentos-gcp](https://github.com/agno-agi/agentos-gcp) codebase runs AgentOS locally using Docker and deploys to production on Google Cloud Run. It comes with:
 
 - **2 platform agents** that build and run the platform for you. **Agent Builder** creates agents, teams, and workflows. **Platform Manager** monitors and manages the platform.
 - **5 [skills](/deploy/templates/improve-agents)** that let coding agents build, test, and improve the platform for you.

--- a/deploy/templates/helm/deploy.mdx
+++ b/deploy/templates/helm/deploy.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Deploy"
 description: "Run AgentOS locally using Docker and deploy to production on Kubernetes."
 ---
 
-AgentOS is a secure and scalable backend for running agents. The [agentos-helm](https://github.com/agno-agi/agentos-helm) codebase runs AgentOS locally using Docker and deploys to production on Kubernetes. It comes with:
+AgentOS is a secure, scalable platform for running agents. The [agentos-helm](https://github.com/agno-agi/agentos-helm) codebase runs AgentOS locally using Docker and deploys to production on Kubernetes. It comes with:
 
 - **2 platform agents** that build and run the platform for you. **Agent Builder** creates agents, teams, and workflows. **Platform Manager** monitors and manages the platform.
 - **5 [skills](/deploy/templates/improve-agents)** that let coding agents build, test, and improve the platform for you.

--- a/deploy/templates/modal/deploy.mdx
+++ b/deploy/templates/modal/deploy.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Deploy"
 description: "Run AgentOS locally using Docker and deploy to production on Modal."
 ---
 
-AgentOS is a secure and scalable backend for running agents. The [agentos-modal](https://github.com/agno-agi/agentos-modal) codebase runs AgentOS locally using Docker and deploys to production on Modal. It comes with:
+AgentOS is a secure, scalable platform for running agents. The [agentos-modal](https://github.com/agno-agi/agentos-modal) codebase runs AgentOS locally using Docker and deploys to production on Modal. It comes with:
 
 - **2 platform agents** that build and run the platform for you. **Agent Builder** creates agents, teams, and workflows. **Platform Manager** monitors and manages the platform.
 - **5 [skills](/deploy/templates/improve-agents)** that let coding agents build, test, and improve the platform for you.

--- a/deploy/templates/railway/deploy.mdx
+++ b/deploy/templates/railway/deploy.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Deploy"
 description: "Run AgentOS locally using Docker and deploy to production on Railway."
 ---
 
-AgentOS is a secure and scalable backend for running agents. The [agentos-railway](https://github.com/agno-agi/agentos-railway) codebase runs AgentOS locally using Docker and deploys to production on Railway. It comes with:
+AgentOS is a secure, scalable platform for running agents. The [agentos-railway](https://github.com/agno-agi/agentos-railway) codebase runs AgentOS locally using Docker and deploys to production on Railway. It comes with:
 
 - **2 platform agents** that build and run the platform for you. **Agent Builder** creates agents, teams, and workflows. **Platform Manager** monitors and manages the platform.
 - **5 [skills](/deploy/templates/improve-agents)** that let coding agents build, test, and improve the platform for you.

--- a/deploy/templates/render/deploy.mdx
+++ b/deploy/templates/render/deploy.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Deploy"
 description: "Run AgentOS locally using Docker and deploy to production on Render."
 ---
 
-AgentOS is a secure and scalable backend for running agents. The [agentos-render](https://github.com/agno-agi/agentos-render) codebase runs AgentOS locally using Docker and deploys to production on Render. It comes with:
+AgentOS is a secure, scalable platform for running agents. The [agentos-render](https://github.com/agno-agi/agentos-render) codebase runs AgentOS locally using Docker and deploys to production on Render. It comes with:
 
 - **2 platform agents** that build and run the platform for you. **Agent Builder** creates agents, teams, and workflows. **Platform Manager** monitors and manages the platform.
 - **5 [skills](/deploy/templates/improve-agents)** that let coding agents build, test, and improve the platform for you.


### PR DESCRIPTION
The template README description changed to "AgentOS is a secure, scalable platform for running agents." (agentos-railway@5db5682, already ported and pushed to main on all 9 template repos). This updates the matching sentence on the 9 `deploy/templates/*/deploy.mdx` pages.

Swept the rest of the docs for the old tagline ("the agent backend for every frontend") and description variants ("scalable backend", "agent backend", "backend for running agents"): these 9 pages were the only occurrences. `/agent-platform/*` has no backend phrasing. The `v2.7-docs-sweep` branch has a different `deploy/templates` tree with no old phrasing, so no follow-up needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)