### PR TITLE
docs: move Agno CLI under Templates tab, tag Culture as to be deprecated

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4477,7 +4477,7 @@
             "pages": [
               {
                 "group": "Culture",
-                "tag": "experimental",
+                "tag": "to be deprecated",
                 "pages": [
                   "culture/overview"
                 ]
@@ -4587,16 +4587,6 @@
               "agent-os/connect-your-os",
               "agent-os/control-plane",
               "agent-os/security/overview"
-            ]
-          },
-          {
-            "group": "Agno CLI",
-            "pages": [
-              "agent-os/cli/overview",
-              "agent-os/cli/create",
-              "agent-os/cli/connect",
-              "agent-os/cli/operate",
-              "agent-os/cli/tokens"
             ]
           },
           {
@@ -4914,6 +4904,16 @@
             "pages": [
               "deploy/introduction",
               "deploy/templates/improve-agents"
+            ]
+          },
+          {
+            "group": "Agno CLI",
+            "pages": [
+              "agent-os/cli/overview",
+              "agent-os/cli/create",
+              "agent-os/cli/connect",
+              "agent-os/cli/operate",
+              "agent-os/cli/tokens"
             ]
           },
           {


### PR DESCRIPTION
## Summary

- Move the Agno CLI group (overview, create, connect, operate, tokens) from the AgentOS tab to the Templates tab, between Get Started and Starters. Nav-only move: URLs stay `/agent-os/cli/*`, so no redirects or link edits needed. The Reference tab's agnoctl group is untouched.
- Change the Culture group sidebar tag from `experimental` to `to be deprecated`.

`mint broken-links` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)