### PR TITLE
fix: repoint stale /agent-os/cli links to /cli

### DIFF
--- a/agent-os/security/authorization/service-accounts.mdx
+++ b/agent-os/security/authorization/service-accounts.mdx
@@ -32,7 +32,7 @@ agno tokens create claude-code
 ```
 </CodeGroup>
 
-The `201` response is the only time you'll see the plaintext `token`, so store it somewhere safe. There's no way to get it back later. [`agno tokens`](/agent-os/cli/tokens) wraps this API for the terminal.
+The `201` response is the only time you'll see the plaintext `token`, so store it somewhere safe. There's no way to get it back later. [`agno tokens`](/cli/tokens) wraps this API for the terminal.
 
 The machine sends the token as a standard bearer header:
 
@@ -187,7 +187,7 @@ On an instance with no auth configured, a token that cannot be verified is ignor
 
 | Task | Guide |
 |------|-------|
-| Mint tokens from the terminal | [agno tokens](/agent-os/cli/tokens) |
+| Mint tokens from the terminal | [agno tokens](/cli/tokens) |
 | See the full scope reference | [Scopes](/agent-os/security/authorization/scopes) |
 | Understand per-user data scoping | [User Isolation](/agent-os/security/authorization/user-isolation) |
 | Run the cookbook example | [agent_os_with_service_accounts.py](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/middleware/agent_os_with_service_accounts.py) |

--- a/cli/connect.mdx
+++ b/cli/connect.mdx
@@ -121,4 +121,4 @@ agno disconnect
 - [agnoctl reference](/reference/cli/agnoctl)
 - [AgentOS as MCP server](/agent-os/mcp/mcp)
 - [Service accounts](/agent-os/security/authorization/service-accounts)
-- [Manage tokens with the CLI](/agent-os/cli/tokens)
+- [Manage tokens with the CLI](/cli/tokens)

--- a/cli/create.mdx
+++ b/cli/create.mdx
@@ -55,6 +55,6 @@ The command fails if the target directory already exists. The CLI doesn't keep a
 
 | Task | Guide |
 |------|-------|
-| Start the project | [agno up](/agent-os/cli/operate) |
-| Connect coding agents | [agno connect](/agent-os/cli/connect) |
+| Start the project | [agno up](/cli/operate) |
+| Connect coding agents | [agno connect](/cli/connect) |
 | Deploy to production | [Templates](/deploy/introduction) |

--- a/cli/operate.mdx
+++ b/cli/operate.mdx
@@ -11,7 +11,7 @@ agno restart   # down, then up
 agno status    # what is running, how it is secured, what is connected
 ```
 
-`up`, `down`, and `restart` shell out to `docker compose` against your project's compose file. Run them from a project directory created with [`agno create`](/agent-os/cli/create), or point them at a compose file with `--file`.
+`up`, `down`, and `restart` shell out to `docker compose` against your project's compose file. Run them from a project directory created with [`agno create`](/cli/create), or point them at a compose file with `--file`.
 
 ## Compose File Detection
 
@@ -43,7 +43,7 @@ agno restart --dry-run    # print the docker compose commands without running th
 agno status
 ```
 
-`status` discovers the AgentOS (see [discovery order](/agent-os/cli/overview#how-the-cli-finds-your-agentos)) and reports:
+`status` discovers the AgentOS (see [discovery order](/cli/overview#how-the-cli-finds-your-agentos)) and reports:
 
 - Base URL and agno version
 - MCP endpoint, or `disabled` when the MCP server is off
@@ -61,6 +61,6 @@ agno status
 
 | Task | Guide |
 |------|-------|
-| Connect coding agents | [agno connect](/agent-os/cli/connect) |
-| Manage tokens | [agno tokens](/agent-os/cli/tokens) |
+| Connect coding agents | [agno connect](/cli/connect) |
+| Manage tokens | [agno tokens](/cli/tokens) |
 | Full flag and JSON reference | [agnoctl reference](/reference/cli/agnoctl) |

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -34,12 +34,12 @@ uvx agnoctl connect
 
 | Command | What it does | Guide |
 |---------|--------------|-------|
-| `agno create <name>` | Scaffold a project from a starter template | [Create a project](/agent-os/cli/create) |
-| `agno connect` | Connect coding agents to a running AgentOS over MCP | [Connect your clients](/agent-os/cli/connect) |
-| `agno disconnect` | Remove AgentOS MCP entries from client configs | [Connect your clients](/agent-os/cli/connect) |
-| `agno up` / `down` / `restart` | Run the project with Docker Compose | [Operate your AgentOS](/agent-os/cli/operate) |
-| `agno status` | Show the discovered AgentOS and connected clients | [Operate your AgentOS](/agent-os/cli/operate) |
-| `agno tokens create` / `list` / `revoke` | Manage service-account tokens | [Manage tokens](/agent-os/cli/tokens) |
+| `agno create <name>` | Scaffold a project from a starter template | [Create a project](/cli/create) |
+| `agno connect` | Connect coding agents to a running AgentOS over MCP | [Connect your clients](/cli/connect) |
+| `agno disconnect` | Remove AgentOS MCP entries from client configs | [Connect your clients](/cli/connect) |
+| `agno up` / `down` / `restart` | Run the project with Docker Compose | [Operate your AgentOS](/cli/operate) |
+| `agno status` | Show the discovered AgentOS and connected clients | [Operate your AgentOS](/cli/operate) |
+| `agno tokens create` / `list` / `revoke` | Manage service-account tokens | [Manage tokens](/cli/tokens) |
 
 ## How the CLI Finds Your AgentOS
 

--- a/docs.json
+++ b/docs.json
@@ -17948,39 +17948,39 @@
     },
     {
       "source": "/templates/cli/ag/auth",
-      "destination": "/agent-os/cli/overview"
+      "destination": "/cli/overview"
     },
     {
       "source": "/templates/cli/ag/config",
-      "destination": "/agent-os/cli/overview"
+      "destination": "/cli/overview"
     },
     {
       "source": "/templates/cli/ag/init",
-      "destination": "/agent-os/cli/overview"
+      "destination": "/cli/overview"
     },
     {
       "source": "/templates/cli/ag/patch",
-      "destination": "/agent-os/cli/overview"
+      "destination": "/cli/overview"
     },
     {
       "source": "/templates/cli/ag/reset",
-      "destination": "/agent-os/cli/overview"
+      "destination": "/cli/overview"
     },
     {
       "source": "/templates/cli/ag/restart",
-      "destination": "/agent-os/cli/overview"
+      "destination": "/cli/overview"
     },
     {
       "source": "/templates/cli/ag/set",
-      "destination": "/agent-os/cli/overview"
+      "destination": "/cli/overview"
     },
     {
       "source": "/templates/cli/ag/start",
-      "destination": "/agent-os/cli/overview"
+      "destination": "/cli/overview"
     },
     {
       "source": "/templates/cli/ag/stop",
-      "destination": "/agent-os/cli/overview"
+      "destination": "/cli/overview"
     },
     {
       "source": "/templates/cli/ws/config",

--- a/faq/agno-cli.mdx
+++ b/faq/agno-cli.mdx
@@ -21,5 +21,5 @@ The CLI scaffolds AgentOS projects (`agno create`), runs them with Docker Compos
 
 ## Next Steps
 
-- [Agno CLI overview](/agent-os/cli/overview)
+- [Agno CLI overview](/cli/overview)
 - [agnoctl reference](/reference/cli/agnoctl)

--- a/faq/environment-variables.mdx
+++ b/faq/environment-variables.mdx
@@ -42,4 +42,4 @@ These last for the current shell session. To persist a variable, add the export 
 
 - [Models overview](/models/overview)
 - [AgentOS security](/agent-os/security/overview)
-- [Agno CLI](/agent-os/cli/overview)
+- [Agno CLI](/cli/overview)

--- a/reference/cli/agnoctl.mdx
+++ b/reference/cli/agnoctl.mdx
@@ -305,6 +305,6 @@ Revoking is irreversible; the account's tokens stop working on their next reques
 
 ## Developer Resources
 
-- [Agno CLI guides](/agent-os/cli/overview)
+- [Agno CLI guides](/cli/overview)
 - [Service accounts](/agent-os/security/authorization/service-accounts)
 - [Scopes](/agent-os/security/authorization/scopes)


### PR DESCRIPTION
## Problem

The CLI docs were moved from `agent-os/cli/` to top-level `cli/` in `cb43e12a`, but the links were never updated. `mintlify broken-links` reports **18 broken links**:

- 18 stale `/agent-os/cli/*` links across 8 pages
- 9 `docs.json` redirects whose *destination* pointed at the now-dead `/agent-os/cli/overview`


## Fix

Pure 1:1 path swap, `/agent-os/cli/` -> `/cli/`. No content changes (27 insertions, 27 deletions).

## Verification the targets are the same pages

Confirmed the move was a clean rename, not a rename into different pages:

| Check | Result |
|-------|--------|
| Git rename detection on `cb43e12a` | `R100` on all 5 files (100% similarity) |
| Content hash, old vs new | byte-identical, all 5 |
| Pages split / merged / dropped in the move? | No, the move touched only those 5 files |
| Anchor `#how-the-cli-finds-your-agentos` | heading exists, slug matches, unchanged |
| `mintlify broken-links` | **18 -> 0** |

All five target pages (`/cli/overview`, `create`, `connect`, `operate`, `tokens`) were also verified to serve live against `mint dev`.