### PR TITLE
docs: add ScyllaDB vector store page

### DIFF
--- a/_snippets/vectordb_scylladb_params.mdx
+++ b/_snippets/vectordb_scylladb_params.mdx
@@ -1,0 +1,6 @@
+| Parameter          | Type                 | Default           | Description                                                                       |
+| ------------------ | -------------------- | ----------------- | --------------------------------------------------------------------------------- |
+| `table_name`       | `str`                | `None`            | Name of the table to store vectors and metadata                                   |
+| `keyspace`         | `str`                | `None`            | Keyspace name where the table will be created                                     |
+| `embedder`         | `Optional[Embedder]` | `OpenAIEmbedder()` | Embedder instance to generate embeddings                                         |
+| `session`          | `CassandraSession`   | `None`            | Active ScyllaDB session object for database operations                  |

--- a/docs.json
+++ b/docs.json
@@ -924,6 +924,12 @@
                         ]
                       },
                       {
+                        "group": "ScyllaDB",
+                        "pages": [
+                          "knowledge/vector-stores/scylladb/overview"
+                        ]
+                      },
+                      {
                         "group": "Clickhouse",
                         "pages": [
                           "knowledge/vector-stores/clickhouse/overview",
@@ -4310,6 +4316,12 @@
                           "knowledge/vector-stores/cassandra/usage/async-cassandra-db"
                         ]
                       }
+                    ]
+                  },
+                  {
+                    "group": "ScyllaDB",
+                    "pages": [
+                      "knowledge/vector-stores/scylladb/overview"
                     ]
                   },
                   {

--- a/knowledge/vector-stores/index.mdx
+++ b/knowledge/vector-stores/index.mdx
@@ -132,6 +132,14 @@ Agno supports the following vector database providers organized by category:
   >
     SurrealDB multi-model with vectors.
   </Card>
+  <Card
+    title="ScyllaDB"
+    icon="database"
+    iconType="duotone"
+    href="/knowledge/vector-stores/scylladb/overview"
+  >
+    ScyllaDB high-performance distributed vector search.
+  </Card>
 </CardGroup>
 
 ### Local Vector Databases

--- a/knowledge/vector-stores/scylladb/overview.mdx
+++ b/knowledge/vector-stores/scylladb/overview.mdx
@@ -1,0 +1,158 @@
+---
+title: ScyllaDB Vector Database
+sidebarTitle: Overview
+description: Use ScyllaDB as a vector database for your Knowledge Base.
+---
+
+ScyllaDB is a high-performance, real-time distributed database with low-latency
+reads/writes and vector similarity search. It is compatible with Apache Cassandra,
+so Agno's `Cassandra` integration works with ScyllaDB out of the box.
+
+## Setup
+
+Install the driver
+
+```shell
+uv pip install scylla-driver cassio
+```
+
+Run ScyllaDB
+
+```shell
+docker run -d \
+  --name scylla \
+  -p 9042:9042 \
+  scylladb/scylla:latest \
+  --developer-mode=1 \
+  --enable-cassio-compatibility=1
+```
+
+<Note>
+  `--enable-cassio-compatibility=1` is required for self-hosted ScyllaDB.
+</Note>
+
+## Example
+
+```python agent_with_knowledge.py
+import os
+
+from cassandra.cluster import Cluster
+
+from agno.agent import Agent
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
+from agno.vectordb.cassandra import Cassandra
+
+SCYLLA_HOST = "127.0.0.1"
+SCYLLA_PORT = 9042
+KEYSPACE = "agno_knowledge"
+
+cluster = Cluster([SCYLLA_HOST], port=SCYLLA_PORT)
+session = cluster.connect()
+session.execute(
+    f"""
+    CREATE KEYSPACE IF NOT EXISTS {KEYSPACE};
+    """
+)
+
+embedder = OpenAIEmbedder(id="text-embedding-3-small", dimensions=1024)
+
+knowledge_base = Knowledge(
+    vector_db=Cassandra(
+        table_name="recipes",
+        keyspace=KEYSPACE,
+        session=session,
+        embedder=embedder,
+    ),
+)
+
+knowledge_base.insert(
+    url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"
+)
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-4o"),
+    knowledge=knowledge_base,
+    search_knowledge=True,
+    markdown=True,
+)
+
+agent.print_response("What Thai recipes do you know?", stream=True)
+```
+
+<Card title="Async Support ⚡">
+  <div className="mt-2">
+    <p>
+      ScyllaDB also supports asynchronous operations, enabling concurrency and leading to better performance.
+    </p>
+
+    ```python async_scylladb.py
+    import asyncio
+    import os
+
+    from agno.agent import Agent
+    from agno.knowledge.embedder.openai import OpenAIEmbedder
+    from agno.knowledge.knowledge import Knowledge
+    from agno.models.openai import OpenAIResponses
+    from agno.vectordb.cassandra import Cassandra
+
+    try:
+        from cassandra.cluster import Cluster  # type: ignore
+    except (ImportError, ModuleNotFoundError):
+        raise ImportError(
+            "Could not import scylla-driver. Install it with: uv pip install scylla-driver cassio"
+        )
+
+    SCYLLA_HOST = "127.0.0.1"
+    SCYLLA_PORT = 9042
+    KEYSPACE = "agno_knowledge"
+
+    cluster = Cluster([SCYLLA_HOST], port=SCYLLA_PORT)
+    session = cluster.connect()
+    session.execute(
+        f"""
+        CREATE KEYSPACE IF NOT EXISTS {KEYSPACE}
+        WITH REPLICATION = {{ 'class': 'SimpleStrategy', 'replication_factor': 1 }}
+        AND tablets = {{ 'enabled': false }}
+        """
+    )
+
+    embedder = OpenAIEmbedder(id="text-embedding-3-small", dimensions=1024)
+
+    knowledge_base = Knowledge(
+        vector_db=Cassandra(
+            table_name="recipes",
+            keyspace=KEYSPACE,
+            session=session,
+            embedder=embedder,
+        ),
+    )
+
+    agent = Agent(
+        model=OpenAIResponses(id="gpt-4o"),
+        knowledge=knowledge_base,
+    )
+
+    if __name__ == "__main__":
+        asyncio.run(
+            knowledge_base.ainsert(
+                url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"
+            )
+        )
+
+        asyncio.run(
+            agent.aprint_response("What Thai recipes do you know?", markdown=True)
+        )
+    ```
+
+    <Tip className="mt-4">
+      Use <code>ainsert()</code> and <code>aprint_response()</code> with <code>asyncio.run()</code> for
+      non-blocking operations in high-throughput applications.
+    </Tip>
+  </div>
+</Card>
+
+## ScyllaDB Params
+
+<Snippet file="vectordb_scylladb_params.mdx" />


### PR DESCRIPTION
Adds a new documentation page for using ScyllaDB as a vector store in Agno. ScyllaDB is compatible with Apache Cassandra and reuses the existing `agno.vectordb.cassandra.Cassandra` class. Related issue: https://github.com/agno-agi/agno/issues/8886