### PR TITLE
docs: add ScyllaDB (Alternator) storage provider

### DIFF
--- a/_snippets/db-scylladb-params.mdx
+++ b/_snippets/db-scylladb-params.mdx
@@ -1,0 +1,15 @@
+| Parameter                    | Type            | Default | Description                                              |
+| ---------------------------- | --------------- | ------- | -------------------------------------------------------- |
+| `id`                         | `Optional[str]` | -       | The ID of the database instance. UUID by default.        |
+| `db_client`                  | `Optional[Any]` | -       | The DynamoDB-compatible client to use (point at Alternator). |
+| `region_name`                | `Optional[str]` | -       | AWS region name. Ignored by Alternator but required by boto3. |
+| `aws_access_key_id`          | `Optional[str]` | -       | Access key ID. Any non-empty value works with Alternator. |
+| `aws_secret_access_key`      | `Optional[str]` | -       | Secret access key. Any non-empty value works with Alternator. |
+| `session_table`              | `Optional[str]` | -       | The name of the session table.                           |
+| `memory_table`               | `Optional[str]` | -       | The name of the memory table.                            |
+| `metrics_table`              | `Optional[str]` | -       | The name of the metrics table.                           |
+| `eval_table`                 | `Optional[str]` | -       | The name of the eval table.                              |
+| `knowledge_table`            | `Optional[str]` | -       | The name of the knowledge table.                         |
+| `culture_table`              | `Optional[str]` | -       | The name of the cultural knowledge table.                |
+| `traces_table`               | `Optional[str]` | -       | The name of the traces table.                            |
+| `spans_table`                | `Optional[str]` | -       | The name of the spans table.                             |

--- a/database/providers/overview.mdx
+++ b/database/providers/overview.mdx
@@ -104,6 +104,14 @@ Agno supports the following database providers organized by category:
     Amazon DynamoDB NoSQL database.
   </Card>
   <Card
+    title="ScyllaDB"
+    icon="database"
+    iconType="duotone"
+    href="/database/providers/scylladb/overview"
+  >
+    ScyllaDB integration (via DynamoDB API).
+  </Card>
+  <Card
     title="Firestore"
     icon="fire"
     iconType="duotone"

--- a/database/providers/scylladb/overview.mdx
+++ b/database/providers/scylladb/overview.mdx
@@ -1,0 +1,66 @@
+---
+title: ScyllaDB
+description: Use ScyllaDB for agent session storage and persistence.
+sidebarTitle: Overview
+---
+
+[ScyllaDB](https://www.scylladb.com/) exposes a DynamoDB-compatible API called
+[Alternator](https://docs.scylladb.com/manual/stable/alternator/alternator.html). 
+Because of this, Agno's `DynamoDb` class works with ScyllaDB out of the box.
+
+## Setup
+
+Install the `boto3` and `openai` packages:
+
+```shell
+uv pip install boto3 openai
+```
+
+Run ScyllaDB with Alternator enabled:
+
+```shell
+docker run -d --name scylla \
+  -p 9042:9042 -p 8000:8000 \
+  scylladb/scylla:latest \
+  --alternator-port 8000 \
+  --alternator-write-isolation=only_rmw_uses_lwt \
+  --smp 1
+```
+
+<Warning>
+  Run Alternator with a safe write-isolation mode. Use
+  `--alternator-write-isolation=only_rmw_uses_lwt` (used throughout these docs) or
+  `always`.
+</Warning>
+
+## Usage
+
+Build a `boto3` client whose `endpoint_url` points at the Alternator port, then pass it to
+`DynamoDb`. Alternator ignores credentials by default, but `boto3` requires some non-empty
+values, so any region and keys work.
+
+```python scylladb_for_agent.py
+import boto3
+
+from agno.agent import Agent
+from agno.db.dynamo import DynamoDb
+
+# boto3 client pointed at ScyllaDB Alternator (instead of AWS DynamoDB)
+client = boto3.client(
+    "dynamodb",
+    endpoint_url="http://localhost:8000",
+    region_name="us-east-1",
+    aws_access_key_id="alternator",
+    aws_secret_access_key="alternator",
+)
+
+# Setup your Database using the ScyllaDB Alternator client
+db = DynamoDb(db_client=client)
+
+# Setup your Agent with the Database
+agent = Agent(db=db)
+```
+
+## Params
+
+<Snippet file="db-scylladb-params.mdx" />

--- a/database/providers/scylladb/usage/scylladb-for-agent.mdx
+++ b/database/providers/scylladb/usage/scylladb-for-agent.mdx
@@ -1,0 +1,51 @@
+---
+title: ScyllaDB for Agent
+sidebarTitle: Agent
+---
+
+Agno supports using ScyllaDB as a storage backend for Agents using the `DynamoDb` class
+through ScyllaDB's DynamoDB-compatible [Alternator](https://docs.scylladb.com/manual/stable/alternator/alternator.html)
+API.
+
+## Usage
+
+Install dependencies:
+
+```shell
+uv pip install agno boto3 openai
+```
+
+Run ScyllaDB with Alternator enabled (`--alternator-port 8000 --alternator-write-isolation=only_rmw_uses_lwt`),
+then build a `boto3` client pointed at the Alternator endpoint and pass it to `DynamoDb` via
+`db_client`.
+
+<Warning>
+  Run Alternator with a safe write-isolation mode. Use
+  `--alternator-write-isolation=only_rmw_uses_lwt` (used throughout these docs) or
+  `always`.
+</Warning>
+
+```python scylladb_for_agent.py
+import boto3
+
+from agno.agent import Agent
+from agno.db.dynamo import DynamoDb
+
+# boto3 client pointed at ScyllaDB Alternator
+client = boto3.client(
+    "dynamodb",
+    endpoint_url="http://localhost:8000",
+    region_name="us-east-1",
+    aws_access_key_id="alternator",
+    aws_secret_access_key="alternator",
+)
+
+db = DynamoDb(db_client=client)
+
+# Add storage to the Agent
+agent = Agent(db=db)
+```
+
+## Params
+
+<Snippet file="db-scylladb-params.mdx" />

--- a/database/providers/scylladb/usage/scylladb-for-team.mdx
+++ b/database/providers/scylladb/usage/scylladb-for-team.mdx
@@ -1,0 +1,93 @@
+---
+title: ScyllaDB for Team
+sidebarTitle: Team
+---
+
+Agno supports using ScyllaDB as a storage backend for Teams using the `DynamoDb` class
+through ScyllaDB's DynamoDB-compatible [Alternator](https://docs.scylladb.com/manual/stable/alternator/alternator.html)
+API.
+
+## Usage
+
+Run ScyllaDB with Alternator enabled (`--alternator-port 8000 --alternator-write-isolation=only_rmw_uses_lwt`),
+then build a `boto3` client pointed at the Alternator endpoint and pass it to `DynamoDb` via
+`db_client`.
+
+<Warning>
+  Run Alternator with a safe write-isolation mode. Use
+  `--alternator-write-isolation=only_rmw_uses_lwt` (used throughout these docs) or
+  `always`.
+</Warning>
+
+Install dependencies:
+
+```shell
+uv pip install agno boto3 openai ddgs
+```
+
+```python scylladb_for_team.py
+from typing import List
+
+import boto3
+
+from agno.agent import Agent
+from agno.db.dynamo import DynamoDb
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+from agno.tools.hackernews import HackerNewsTools
+from agno.tools.websearch import WebSearchTools
+from pydantic import BaseModel
+
+# boto3 client pointed at ScyllaDB Alternator
+client = boto3.client(
+    "dynamodb",
+    endpoint_url="http://localhost:8000",
+    region_name="us-east-1",
+    aws_access_key_id="alternator",
+    aws_secret_access_key="alternator",
+)
+
+# Setup the ScyllaDB database
+db = DynamoDb(db_client=client)
+
+class Article(BaseModel):
+    title: str
+    summary: str
+    reference_links: List[str]
+
+hn_researcher = Agent(
+    name="HackerNews Researcher",
+    model=OpenAIResponses(id="gpt-5.2"),
+    role="Gets top stories from hackernews.",
+    tools=[HackerNewsTools()],
+)
+
+web_searcher = Agent(
+    name="Web Searcher",
+    model=OpenAIResponses(id="gpt-5.2"),
+    role="Searches the web for information on a topic",
+    tools=[WebSearchTools()],
+    add_datetime_to_context=True,
+)
+
+hn_team = Team(
+    name="HackerNews Team",
+    model=OpenAIResponses(id="gpt-5.2"),
+    members=[hn_researcher, web_searcher],
+    db=db,
+    instructions=[
+        "First, search hackernews for what the user is asking about.",
+        "Then, ask the web searcher to search for each story to get more information.",
+        "Finally, provide a thoughtful and engaging summary.",
+    ],
+    output_schema=Article,
+    markdown=True,
+    show_members_responses=True,
+)
+
+hn_team.print_response("Write an article about the top 2 stories on hackernews")
+```
+
+## Params
+
+<Snippet file="db-scylladb-params.mdx" />

--- a/database/providers/scylladb/usage/scylladb-for-workflow.mdx
+++ b/database/providers/scylladb/usage/scylladb-for-workflow.mdx
@@ -1,0 +1,108 @@
+---
+title: ScyllaDB for Workflow
+sidebarTitle: Workflow
+---
+
+Agno supports using ScyllaDB as a storage backend for Workflows using the `DynamoDb` class
+through ScyllaDB's DynamoDB-compatible [Alternator](https://docs.scylladb.com/manual/stable/alternator/alternator.html)
+API.
+
+## Usage
+
+Run ScyllaDB with Alternator enabled (`--alternator-port 8000 --alternator-write-isolation=only_rmw_uses_lwt`),
+then build a `boto3` client pointed at the Alternator endpoint and pass it to `DynamoDb` via
+`db_client`.
+
+<Warning>
+  Run Alternator with a safe write-isolation mode. Use
+  `--alternator-write-isolation=only_rmw_uses_lwt` (used throughout these docs) or
+  `always`.
+</Warning>
+
+Install dependencies:
+
+```shell
+uv pip install agno boto3 openai ddgs
+```
+
+```python scylladb_for_workflow.py
+import boto3
+
+from agno.agent import Agent
+from agno.db.dynamo import DynamoDb
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+from agno.tools.hackernews import HackerNewsTools
+from agno.tools.websearch import WebSearchTools
+from agno.workflow.step import Step
+from agno.workflow.workflow import Workflow
+
+# boto3 client pointed at ScyllaDB Alternator
+client = boto3.client(
+    "dynamodb",
+    endpoint_url="http://localhost:8000",
+    region_name="us-east-1",
+    aws_access_key_id="alternator",
+    aws_secret_access_key="alternator",
+)
+
+db = DynamoDb(db_client=client)
+
+# Define agents
+hackernews_agent = Agent(
+    name="HackerNews Agent",
+    model=OpenAIResponses(id="gpt-5.2"),
+    tools=[HackerNewsTools()],
+    role="Extract key insights and content from HackerNews posts",
+)
+web_agent = Agent(
+    name="Web Agent",
+    model=OpenAIResponses(id="gpt-5.2"),
+    tools=[WebSearchTools()],
+    role="Search the web for the latest news and trends",
+)
+
+# Define research team for complex analysis
+research_team = Team(
+    name="Research Team",
+    members=[hackernews_agent, web_agent],
+    instructions="Research tech topics from HackerNews and the web",
+)
+
+content_planner = Agent(
+    name="Content Planner",
+    model=OpenAIResponses(id="gpt-5.2"),
+    instructions=[
+        "Plan a content schedule over 4 weeks for the provided topic and research content",
+        "Ensure there are 3 posts per week",
+    ],
+)
+
+# Define steps
+research_step = Step(
+    name="Research Step",
+    team=research_team,
+)
+
+content_planning_step = Step(
+    name="Content Planning Step",
+    agent=content_planner,
+)
+
+# Create and use workflow
+if __name__ == "__main__":
+    content_creation_workflow = Workflow(
+        name="Content Creation Workflow",
+        description="Automated content creation from blog posts to social media",
+        db=db,
+        steps=[research_step, content_planning_step],
+    )
+    content_creation_workflow.print_response(
+        input="AI trends in 2024",
+        markdown=True,
+    )
+```
+
+## Params
+
+<Snippet file="db-scylladb-params.mdx" />

--- a/docs.json
+++ b/docs.json
@@ -479,6 +479,20 @@
                         ]
                       },
                       {
+                        "group": "ScyllaDB",
+                        "pages": [
+                          "database/providers/scylladb/overview",
+                          {
+                            "group": "Usage",
+                            "pages": [
+                              "database/providers/scylladb/usage/scylladb-for-agent",
+                              "database/providers/scylladb/usage/scylladb-for-team",
+                              "database/providers/scylladb/usage/scylladb-for-workflow"
+                            ]
+                          }
+                        ]
+                      },
+                      {
                         "group": "MongoDB",
                         "pages": [
                           "database/providers/mongo/overview",
@@ -4103,6 +4117,20 @@
                     ]
                   },
                   {
+                    "group": "ScyllaDB",
+                    "pages": [
+                      "database/providers/scylladb/overview",
+                      {
+                        "group": "Usage",
+                        "pages": [
+                          "database/providers/scylladb/usage/scylladb-for-agent",
+                          "database/providers/scylladb/usage/scylladb-for-team",
+                          "database/providers/scylladb/usage/scylladb-for-workflow"
+                        ]
+                      }
+                    ]
+                  },
+                  {
                     "group": "MongoDB",
                     "pages": [
                       "database/providers/mongo/overview",
@@ -5849,6 +5877,14 @@
                     ]
                   },
                   {
+                    "group": "ScyllaDB",
+                    "pages": [
+                      "examples/storage/scylladb/overview",
+                      "examples/storage/scylladb/scylladb-for-agent",
+                      "examples/storage/scylladb/scylladb-for-team"
+                    ]
+                  },
+                  {
                     "group": "Examples",
                     "pages": [
                       "examples/storage/examples/overview",
@@ -7587,6 +7623,7 @@
                       "examples/agent-os/dbs/surreal-db/overview",
                       "examples/agent-os/dbs/agentos-default-db",
                       "examples/agent-os/dbs/dynamo",
+                      "examples/agent-os/dbs/scylladb",
                       "examples/agent-os/dbs/firestore",
                       "examples/agent-os/dbs/gcs-json",
                       "examples/agent-os/dbs/json-db",
@@ -8423,6 +8460,7 @@
                   "reference/storage/redis",
                   "reference/storage/valkey",
                   "reference/storage/dynamodb",
+                  "reference/storage/scylladb",
                   "reference/storage/singlestore",
                   "reference/storage/surrealdb",
                   "reference/storage/firestore",

--- a/examples/agent-os/dbs/overview.mdx
+++ b/examples/agent-os/dbs/overview.mdx
@@ -7,6 +7,7 @@ description: "Examples for `dbs` in AgentOS."
 |---------|-------------|
 | [AgentOS Demo](/examples/agent-os/dbs/agentos-default-db) | Set the OS_SECURITY_KEY environment variable to your OS security key to enable authentication. |
 | [Dynamo](/examples/agent-os/dbs/dynamo) | Set the following environment variables to connect to your DynamoDb instance: - AWS_REGION - AWS_ACCESS_KEY_ID - AWS_SECRET_ACCESS_KEY. |
+| [Scylla](/examples/agent-os/dbs/scylladb) | Use ScyllaDB as the database backend for AgentOS via its DynamoDB-compatible Alternator API. |
 | [Firestore](/examples/agent-os/dbs/firestore) | Setup the Firestore database. |
 | [Gcs Json](/examples/agent-os/dbs/gcs-json) | Use Google Cloud Storage JSON as the database backend for AgentOS. |
 | [Json Db](/examples/agent-os/dbs/json-db) | Setup the JSON database. |

--- a/examples/agent-os/dbs/scylladb.mdx
+++ b/examples/agent-os/dbs/scylladb.mdx
@@ -1,0 +1,140 @@
+---
+title: "Scylla"
+description: "Example showing how to use AgentOS with a ScyllaDB (Alternator) database."
+source: cookbook/05_agent_os/dbs/scylladb.py
+---
+
+```python scylla.py
+"""Example showing how to use AgentOS with a ScyllaDB database (via Alternator)
+
+ScyllaDB exposes a DynamoDB-compatible API (Alternator), so Agno's DynamoDb class
+works with it by pointing a boto3 client at the Alternator endpoint.
+
+Run ScyllaDB with Alternator enabled:
+    docker run -d --name scylla \
+        -p 9042:9042 -p 8000:8000 \
+        scylladb/scylla:latest \
+        --alternator-port 8000 \
+        --alternator-write-isolation=only_rmw_uses_lwt \
+        --smp 1
+
+Run `uv pip install boto3` to install dependencies.
+"""
+
+import boto3
+
+from agno.agent import Agent
+from agno.db.dynamo import DynamoDb
+from agno.eval.accuracy import AccuracyEval
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.team.team import Team
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# boto3 client pointed at ScyllaDB Alternator instead of AWS DynamoDB
+client = boto3.client(
+    "dynamodb",
+    endpoint_url="http://localhost:8000",
+    region_name="us-east-1",
+    aws_access_key_id="alternator",
+    aws_secret_access_key="alternator",
+)
+
+# Setup the ScyllaDB database
+db = DynamoDb(db_client=client)
+
+# Setup a basic agent and a basic team
+basic_agent = Agent(
+    name="Basic Agent",
+    id="basic-agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+    update_memory_on_run=True,
+    enable_session_summaries=True,
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    markdown=True,
+)
+basic_team = Team(
+    id="basic-team",
+    name="Team Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+    members=[basic_agent],
+    debug_mode=True,
+)
+
+# Evals
+evaluation = AccuracyEval(
+    db=db,
+    name="Calculator Evaluation",
+    model=OpenAIChat(id="gpt-4o"),
+    agent=basic_agent,
+    input="Should I post my password online? Answer yes or no.",
+    expected_output="No",
+    num_iterations=1,
+)
+# evaluation.run(print_results=True)
+
+agent_os = AgentOS(
+    description="Example OS setup",
+    agents=[basic_agent],
+    teams=[basic_team],
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app="scylladb:app", reload=True)
+```
+
+## Run the Example
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Start ScyllaDB with Alternator">
+    ```bash
+    docker run -d --name scylla \
+      -p 9042:9042 -p 8000:8000 \
+      scylladb/scylla:latest \
+      --alternator-port 8000 \
+      --alternator-write-isolation=only_rmw_uses_lwt \
+      --smp 1
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[os]" boto3 openai
+    ```
+  </Step>
+
+  <Step title="Export environment variables">
+    <CodeGroup>
+    ```bash Mac/Linux
+    export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+    $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the example">
+    Save the code above as `scylla.py`, then run:
+    ```bash
+    python scylla.py
+    ```
+  </Step>
+</Steps>
+
+Full source: [cookbook/05_agent_os/dbs/scylladb.py](https://github.com/agno-agi/agno/blob/main/cookbook/05_agent_os/dbs/scylladb.py)

--- a/examples/storage/overview.mdx
+++ b/examples/storage/overview.mdx
@@ -13,6 +13,7 @@ description: "This directory contains examples demonstrating how to integrate va
 | [SingleStore](/examples/storage/singlestore/overview) | Examples demonstrating SingleStore database integration with Agno agents and teams. |
 | [Firestore](/examples/storage/firestore/overview) | Examples demonstrating Google Cloud Firestore integration with Agno agents. |
 | [Dynamodb](/examples/storage/dynamodb/overview) | Examples demonstrating AWS DynamoDB integration with Agno agents. |
+| [ScyllaDB](/examples/storage/scylladb/overview) | Examples demonstrating ScyllaDB (Alternator) integration with Agno agents. |
 | [Gcs](/examples/storage/gcs/overview) | Examples demonstrating Google Cloud Storage (GCS) integration with Agno agents using JSON blob storage. |
 | [In Memory](/examples/storage/in-memory/overview) | This directory contains examples demonstrating how to use `InMemoryDb` with Agno agents, workflows, and teams. |
 | [Persistent Session Storage](/examples/storage/persistent-session-storage) | Demonstrates using PostgresDb for persistent session storage with a team. |

--- a/examples/storage/scylladb/overview.mdx
+++ b/examples/storage/scylladb/overview.mdx
@@ -1,0 +1,9 @@
+---
+title: "ScyllaDB"
+sidebarTitle: "Overview"
+description: "Examples demonstrating ScyllaDB integration with Agno agents."
+---
+| Example | Description |
+|---------|-------------|
+| [ScyllaDB For Agent](/examples/storage/scylladb/scylladb-for-agent) | Store agent sessions and runs in ScyllaDB using its DynamoDB-compatible Alternator API. |
+| [Use ScyllaDB as the database for a team](/examples/storage/scylladb/scylladb-for-team) | Store team sessions and runs in ScyllaDB by pointing a boto3 client at the Alternator endpoint. |

--- a/examples/storage/scylladb/scylladb-for-agent.mdx
+++ b/examples/storage/scylladb/scylladb-for-agent.mdx
@@ -1,0 +1,103 @@
+---
+title: "Use ScyllaDB as the database for an agent"
+description: "Store agent sessions and runs in ScyllaDB."
+source: cookbook/06_storage/scylladb/scylladb_for_agent.py
+---
+
+```python scylladb_for_agent.py
+"""Use ScyllaDB as the database for an agent.
+
+ScyllaDB exposes a DynamoDB-compatible API (Alternator), so Agno's DynamoDb class
+works with it by pointing a boto3 client at the Alternator endpoint.
+
+Run ScyllaDB with Alternator enabled:
+    docker run -d --name scylla \
+        -p 9042:9042 -p 8000:8000 \
+        scylladb/scylla:latest \
+        --alternator-port 8000 \
+        --alternator-write-isolation=only_rmw_uses_lwt \
+        --smp 1
+
+Run `uv pip install boto3` to install dependencies."""
+
+import boto3
+
+from agno.agent import Agent
+from agno.db.dynamo import DynamoDb
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+# boto3 client pointed at ScyllaDB Alternator instead of AWS DynamoDB
+client = boto3.client(
+    "dynamodb",
+    endpoint_url="http://localhost:8000",
+    region_name="us-east-1",
+    aws_access_key_id="alternator",
+    aws_secret_access_key="alternator",
+)
+
+db = DynamoDb(db_client=client)
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    db=db,
+    name="ScyllaDB Agent",
+    description="An agent that uses ScyllaDB (Alternator) as a database",
+    add_history_to_context=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # The Agent sessions and runs will now be stored in ScyllaDB
+    agent.print_response("How many people live in Canada?")
+    agent.print_response("What is their national anthem called?")
+```
+
+## Run the Example
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Start ScyllaDB with Alternator">
+    ```bash
+    docker run -d --name scylla \
+      -p 9042:9042 -p 8000:8000 \
+      scylladb/scylla:latest \
+      --alternator-port 8000 \
+      --alternator-write-isolation=only_rmw_uses_lwt \
+      --smp 1
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U agno boto3 openai
+    ```
+  </Step>
+
+  <Step title="Export your OpenAI API key">
+    <CodeGroup>
+    ```bash Mac/Linux
+    export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+    $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the example">
+    Save the code above as `scylladb_for_agent.py`, then run:
+    ```bash
+    python scylladb_for_agent.py
+    ```
+  </Step>
+</Steps>
+
+Full source: [cookbook/06_storage/scylladb/scylladb_for_agent.py](https://github.com/agno-agi/agno/blob/main/cookbook/06_storage/scylladb/scylladb_for_agent.py)

--- a/examples/storage/scylladb/scylladb-for-team.mdx
+++ b/examples/storage/scylladb/scylladb-for-team.mdx
@@ -1,0 +1,140 @@
+---
+title: "Use ScyllaDB as the database for a team"
+description: "Store team sessions and runs in ScyllaDB."
+source: cookbook/06_storage/scylladb/scylladb_for_team.py
+---
+
+```python scylladb_for_team.py
+"""Use ScyllaDB as the database for a team.
+
+ScyllaDB exposes a DynamoDB-compatible API (Alternator), so Agno's DynamoDb class
+works with it by pointing a boto3 client at the Alternator endpoint.
+
+Run ScyllaDB with Alternator enabled:
+    docker run -d --name scylla \
+        -p 9042:9042 -p 8000:8000 \
+        scylladb/scylla:latest \
+        --alternator-port 8000 \
+        --alternator-write-isolation=only_rmw_uses_lwt \
+        --smp 1
+
+Run `uv pip install openai ddgs newspaper4k lxml_html_clean agno boto3` to install the
+dependencies
+"""
+
+from typing import List
+
+import boto3
+
+from agno.agent import Agent
+from agno.db.dynamo import DynamoDb
+from agno.models.openai import OpenAIChat
+from agno.team import Team
+from agno.tools.hackernews import HackerNewsTools
+from agno.tools.websearch import WebSearchTools
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+# boto3 client pointed at ScyllaDB Alternator instead of AWS DynamoDB
+client = boto3.client(
+    "dynamodb",
+    endpoint_url="http://localhost:8000",
+    region_name="us-east-1",
+    aws_access_key_id="alternator",
+    aws_secret_access_key="alternator",
+)
+
+db = DynamoDb(db_client=client)
+
+
+# ---------------------------------------------------------------------------
+# Create Team
+# ---------------------------------------------------------------------------
+class Article(BaseModel):
+    title: str
+    summary: str
+    reference_links: List[str]
+
+
+hn_researcher = Agent(
+    name="HackerNews Researcher",
+    model=OpenAIChat("gpt-4o"),
+    role="Gets top stories from hackernews.",
+    tools=[HackerNewsTools()],
+)
+
+web_searcher = Agent(
+    name="Web Searcher",
+    model=OpenAIChat("gpt-4o"),
+    role="Searches the web for information on a topic",
+    tools=[WebSearchTools()],
+    add_datetime_to_context=True,
+)
+
+hn_team = Team(
+    name="HackerNews Team",
+    model=OpenAIChat("gpt-4o"),
+    members=[hn_researcher, web_searcher],
+    db=db,
+    instructions=[
+        "First, search hackernews for what the user is asking about.",
+        "Then, ask the web searcher to search for each story to get more information.",
+        "Finally, provide a thoughtful and engaging summary.",
+    ],
+    output_schema=Article,
+    markdown=True,
+    show_members_responses=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Team
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    hn_team.print_response("Write an article about the top 2 stories on hackernews")
+```
+
+## Run the Example
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Start ScyllaDB with Alternator">
+    ```bash
+    docker run -d --name scylla \
+      -p 9042:9042 -p 8000:8000 \
+      scylladb/scylla:latest \
+      --alternator-port 8000 \
+      --alternator-write-isolation=only_rmw_uses_lwt \
+      --smp 1
+    ```
+  </Step>
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U agno boto3 ddgs openai
+    ```
+  </Step>
+
+  <Step title="Export environment variables">
+    <CodeGroup>
+    ```bash Mac/Linux
+    export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+    $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the example">
+    Save the code above as `scylladb_for_team.py`, then run:
+    ```bash
+    python scylladb_for_team.py
+    ```
+  </Step>
+</Steps>
+
+Full source: [cookbook/06_storage/scylladb/scylladb_for_team.py](https://github.com/agno-agi/agno/blob/main/cookbook/06_storage/scylladb/scylladb_for_team.py)

--- a/features/storage.mdx
+++ b/features/storage.mdx
@@ -47,6 +47,7 @@ When we set the `db` param, AgentOS creates the tables and indexes on first boot
 | [`RedisDb`](/database/providers/redis/overview) | Cache-friendly, ephemeral sessions |
 | [`ValkeyDb`](/database/providers/valkey/overview) | Cache-friendly, ephemeral sessions |
 | [`DynamoDb`](/database/providers/dynamodb/overview) | AWS-native, serverless |
+| [`DynamoDb` (ScyllaDB)](/database/providers/scylladb/overview) | DynamoDB-compatible (Alternator), self-hosted or ScyllaDB Cloud |
 | [`FirestoreDb`](/database/providers/firestore/overview) | GCP-native, serverless |
 | [`GcsJsonDb`](/database/providers/gcs/overview) | Cheap cold storage, knowledge as JSON in Cloud Storage |
 | [`InMemoryDb`](/database/providers/in-memory/overview) | Tests, ephemeral demos |

--- a/knowledge/concepts/contents-db.mdx
+++ b/knowledge/concepts/contents-db.mdx
@@ -73,7 +73,7 @@ Agno supports multiple database backends:
   </Tab>
 </Tabs>
 
-Other supported backends: [PostgreSQL](/database/providers/postgres/overview) (recommended for production), [SQLite](/database/providers/sqlite/overview) (development), [MySQL](/database/providers/mysql/overview), [MongoDB](/database/providers/mongo/overview), [Redis](/database/providers/redis/overview), [Valkey](/database/providers/valkey/overview), [DynamoDB](/database/providers/dynamodb/overview), [Firestore](/database/providers/firestore/overview).
+Other supported backends: [PostgreSQL](/database/providers/postgres/overview) (recommended for production), [SQLite](/database/providers/sqlite/overview) (development), [MySQL](/database/providers/mysql/overview), [MongoDB](/database/providers/mongo/overview), [Redis](/database/providers/redis/overview), [Valkey](/database/providers/valkey/overview), [DynamoDB](/database/providers/dynamodb/overview), [ScyllaDB](/database/providers/scylladb/overview), [Firestore](/database/providers/firestore/overview).
 
 ## Managing Content
 

--- a/reference/storage/scylladb.mdx
+++ b/reference/storage/scylladb.mdx
@@ -1,0 +1,10 @@
+---
+title: ScyllaDB
+---
+
+ScyllaDB is a high-performance NoSQL database that provides a DynamoDB-compatible API. 
+Agno's `DynamoDb` class works with ScyllaDB through the [Alternator](https://docs.scylladb.com/manual/stable/alternator/alternator.html)
+API. This provides low-latency, distributed storage for agent sessions.
+
+<Snippet file="db-scylladb-params.mdx" />
+<Snippet file="db-new-bulk-methods.mdx" />


### PR DESCRIPTION
## Description
ScyllaDB exposes a DynamoDB-compatible API (Alternator), so Agno's existing `DynamoDb`
class works against it by pointing a boto3 client at the Alternator endpoint.

Every page mentions the mandatory Alternator write-isolation that's needed so
concurrent counter and conditional writes aren't silently dropped
(`--alternator-write-isolation=always` or `only_rmw_uses_lwt`).

## Type of Change
- [x] New content (docs for a new provider)

## Related Issues/PRs
Closes agno-agi/agno#8965
Related PR: agno-agi/agno#8964 (ScyllaDB storage cookbook)

## Checklist
- [x] Content is accurate and verified against a working integration
- [x] Internal links tested — `mint broken-links` clean
- [x] Code examples verified (storage layer 13/13 against a live Alternator container)
- [x] Spelling/grammar reviewed
- [x] AI-assisted, human reviewed and validated