### PR TITLE
docs: add The Context Company observability integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4562,6 +4562,7 @@
                   "observability/maxim",
                   "observability/mlflow",
                   "observability/openlit",
+                  "observability/the-context-company",
                   "observability/traceloop",
                   "observability/weave"
                 ]
@@ -8241,6 +8242,7 @@
                       "examples/integrations/observability/logfire-via-openinference",
                       "examples/integrations/observability/maxim-ops",
                       "examples/integrations/observability/opik-via-openinference",
+                      "examples/integrations/observability/the-context-company",
                       "examples/integrations/observability/teams/langfuse-via-openinference-team",
                       "examples/integrations/observability/trace-to-database",
                       "examples/integrations/observability/traceloop-op",

--- a/examples/integrations/observability/overview.mdx
+++ b/examples/integrations/observability/overview.mdx
@@ -20,6 +20,7 @@ description: "Observability examples for tracing and monitoring Agno agents, tea
 | [Logfire Via OpenInference](/examples/integrations/observability/logfire-via-openinference) | Demonstrates instrumenting an Agno agent with OpenInference and sending traces to Logfire. |
 | [Maxim Integration](/examples/integrations/observability/maxim-ops) | Demonstrates using Maxim to trace and log Agno agent and team calls. |
 | [Opik Via OpenInference](/examples/integrations/observability/opik-via-openinference) | Demonstrates instrumenting Agno with OpenTelemetry and exporting traces to Opik. |
+| [The Context Company](/examples/integrations/observability/the-context-company) | Demonstrates instrumenting an Agno agent with The Context Company. |
 | [Trace To Database](/examples/integrations/observability/trace-to-database) | Demonstrates Agno's two-table trace design and how to inspect traces and spans. |
 | [Traceloop Integration](/examples/integrations/observability/traceloop-op) | Demonstrates wrapping Agno calls in Traceloop workflow spans. |
 | [Weave Integration](/examples/integrations/observability/weave-op) | Demonstrates logging Agno model calls with Weave. |

--- a/examples/integrations/observability/the-context-company.mdx
+++ b/examples/integrations/observability/the-context-company.mdx
@@ -1,0 +1,93 @@
+---
+title: "The Context Company"
+description: "Demonstrates instrumenting an Agno agent with The Context Company."
+source: cookbook/observability/the_context_company.py
+---
+
+```python the_context_company.py
+"""
+The Context Company
+===================
+
+Demonstrates instrumenting an Agno agent with The Context Company.
+
+Setup:
+    pip install "contextcompany[agno]>=1.9.1" agno openai yfinance
+
+Set TCC_API_KEY and OPENAI_API_KEY before running this example.
+See https://docs.thecontextcompany.com/frameworks/agno for the complete setup guide.
+"""
+
+import asyncio
+
+from contextcompany.agno import instrument_agno
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+# Initialize instrumentation before importing Agno.
+instrument_agno()
+
+from agno.agent import Agent  # noqa: E402
+from agno.models.openai import OpenAIChat  # noqa: E402
+from agno.tools.yfinance import YFinanceTools  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    name="Stock Price Agent",
+    model=OpenAIChat(id="gpt-5.2"),
+    tools=[YFinanceTools()],
+    instructions="You are a stock price agent. Answer questions in the style of a stock analyst.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+async def main() -> None:
+    await agent.aprint_response(
+        "What is the current price of Tesla? Then find the current price of NVIDIA.",
+        stream=True,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## Run the Example
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "contextcompany[agno]>=1.9.1" agno openai yfinance
+    ```
+  </Step>
+
+  <Step title="Export your API keys">
+    <CodeGroup>
+    ```bash Mac/Linux
+    export TCC_API_KEY="your_tcc_api_key_here"
+    export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+    $Env:TCC_API_KEY="your_tcc_api_key_here"
+    $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the example">
+    Save the code above as `the_context_company.py`, then run:
+    ```bash
+    python the_context_company.py
+    ```
+  </Step>
+</Steps>
+
+Full source: [cookbook/observability/the_context_company.py](https://github.com/agno-agi/agno/blob/main/cookbook/observability/the_context_company.py)

--- a/features/observability.mdx
+++ b/features/observability.mdx
@@ -97,9 +97,9 @@ See [Multi-DB tracing](/agent-os/tracing/usage/tracing-with-multi-db-scenario) f
 
 ## External providers
 
-If you already run an observability platform, AgentOS can export to it instead of (or alongside) your database. Add an OpenTelemetry exporter to send traces to Langfuse, Langsmith, Arize, Logfire, MLflow, or any OTel endpoint.
+If you already run an observability platform, AgentOS can export to it instead of (or alongside) your database. Add an OpenTelemetry exporter to send traces to Langfuse, Langsmith, Arize, Logfire, MLflow, The Context Company, or any OTel endpoint.
 
-See the [Observability section](/observability/overview): [Langfuse](/observability/langfuse), [Langsmith](/observability/langsmith), [Arize](/observability/arize), [Logfire](/examples/integrations/observability/logfire-via-openinference), [MLflow](/observability/mlflow).
+See the [Observability section](/observability/overview): [Langfuse](/observability/langfuse), [Langsmith](/observability/langsmith), [Arize](/observability/arize), [Logfire](/examples/integrations/observability/logfire-via-openinference), [MLflow](/observability/mlflow), [The Context Company](/observability/the-context-company).
 
 ## Developer Resources
 

--- a/features/sdk.mdx
+++ b/features/sdk.mdx
@@ -52,7 +52,7 @@ Agno is a Python SDK for building multi-agent systems. It comes with three primi
 |------------|--------------|
 | [Background execution](/background-execution/overview) | Long-running runs that don't block your API |
 | [Evals](/evals/overview) | Measure accuracy, performance, and reliability; agent-as-judge |
-| [Observability](/observability/overview) | Tracing with Langfuse, Logfire, Arize, and 12+ providers |
+| [Observability](/observability/overview) | Tracing with Langfuse, Logfire, Arize, The Context Company, and 12+ providers |
 | [Scheduler](/scheduler/overview) | Run agents on a recurring schedule |
 
 ## Components

--- a/observability/overview.mdx
+++ b/observability/overview.mdx
@@ -19,6 +19,5 @@ Agno offers first-class support for OpenTelemetry, the industry standard for dis
 - **Custom Tracing**: Extend or customize tracing as needed.
 
 <Note>
-OpenTelemetry-compatible backends including Arize Phoenix, Langfuse, Langsmith, Langtrace, Latitude, Logfire, Maxim, MLflow, OpenLIT, Traceloop, and Weave are supported by Agno out of the box.
+OpenTelemetry-compatible backends including Arize Phoenix, Langfuse, Langsmith, Langtrace, Latitude, Logfire, Maxim, MLflow, OpenLIT, The Context Company, Traceloop, and Weave are supported by Agno out of the box.
 </Note>
-

--- a/observability/the-context-company.mdx
+++ b/observability/the-context-company.mdx
@@ -1,0 +1,90 @@
+---
+title: The Context Company
+description: Send Agno traces to The Context Company for agent observability and production interaction analysis.
+---
+
+[The Context Company](https://www.thecontextcompany.com) is an AI agent observability and customer analytics platform that helps teams understand and improve agents in production. The Agno integration captures agent runs through OpenTelemetry and sends them to The Context Company.
+
+## Setup
+
+<Steps>
+  <Step title="Install the integration">
+    ```bash
+    uv pip install -U "contextcompany[agno]" agno openai yfinance
+    ```
+  </Step>
+
+  <Step title="Export your API keys">
+    <CodeGroup>
+    ```bash Mac/Linux
+    export TCC_API_KEY="your_tcc_api_key_here"
+    export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+    $Env:TCC_API_KEY="your_tcc_api_key_here"
+    $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Initialize instrumentation">
+    Call `instrument_agno()` before importing Agno.
+
+    ```python
+    from contextcompany.agno import instrument_agno
+
+    instrument_agno()
+
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIChat
+    from agno.tools.yfinance import YFinanceTools
+
+    agent = Agent(
+        name="Stock Price Agent",
+        model=OpenAIChat(id="gpt-5.2"),
+        tools=[YFinanceTools()],
+    )
+
+    agent.print_response("What is the current price of NVIDIA?")
+    ```
+  </Step>
+</Steps>
+
+## Captured data
+
+The integration records:
+
+- Agent runs and model calls
+- Tool arguments, results, and errors
+- Prompts and responses
+- Token usage and latency
+- Session, user, organization, and custom metadata
+
+The Context Company analyzes production conversations and traces to surface recurring patterns and account-level insights. Teams can inspect the supporting runs and use that context to improve agent behavior.
+
+## Run metadata
+
+Use OpenInference's `using_attributes` context manager to associate a run with a session, user, organization, or named agent:
+
+```python
+from openinference.instrumentation import using_attributes
+
+with using_attributes(
+    metadata={
+        "tcc.sessionId": "session-123",
+        "tcc.conversational": "true",
+        "tcc.agent": "stock-price-agent",
+        "tcc.userId": "user-123",
+        "tcc.orgId": "org-456",
+        "environment": "production",
+    },
+):
+    agent.print_response("What is the current price of NVIDIA?")
+```
+
+## Developer resources
+
+- [Complete Agno integration guide](https://docs.thecontextcompany.com/frameworks/agno)
+- [Runnable Agno example](/examples/integrations/observability/the-context-company)
+- [The Context Company Python SDK](https://pypi.org/project/contextcompany/)

--- a/tracing/overview.mdx
+++ b/tracing/overview.mdx
@@ -83,7 +83,7 @@ Agno automatically captures:
 - **Zero-Code Instrumentation**: No need to modify your agent code
 - **Database Storage**: Traces stored in your Agno database (SQLite, PostgreSQL, etc.)
 - **Flexible Querying**: Filter by agent, session, run, or time range
-- **OpenTelemetry Standard**: Export to external tools like Arize Phoenix, Langfuse
+- **OpenTelemetry Standard**: Export to external tools like Arize Phoenix, Langfuse, and The Context Company
 - **Low Overhead**: Traces are batched and exported in the background
 - **Configurable**: Adjust batch sizes and processing for your needs
 


### PR DESCRIPTION
## What this changes

- Adds a dedicated The Context Company observability guide.
- Adds The Context Company to the observability overview and AgentOS external-provider list.
- Publishes the merged cookbook example in the examples section.
- Adds the provider and example pages to navigation.

The runnable example was added to `agno-agi/agno` in https://github.com/agno-agi/agno/pull/8955. This PR makes that integration discoverable in the public documentation.

## Verification

- `mint broken-links`
- Parsed `docs.json` with `jq`
- Previewed the provider guide, example, observability overview, and Agent Observability page locally
