### PR TITLE
docs: add Adanos toolkit documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2310,6 +2310,7 @@
                       {
                         "group": "Additional Toolkits",
                         "pages": [
+                          "tools/toolkits/others/adanos",
                           "tools/toolkits/others/airflow",
                           "tools/toolkits/others/antigravity",
                           "tools/toolkits/others/apify",
@@ -7289,6 +7290,7 @@
               {
                 "group": "Data & Analytics",
                 "pages": [
+                  "examples/tools/adanos-tools",
                   "examples/tools/arxiv-tools",
                   "examples/tools/csv-tools",
                   "examples/tools/custom-api-tools",

--- a/examples/tools/adanos-tools.mdx
+++ b/examples/tools/adanos-tools.mdx
@@ -1,0 +1,62 @@
+---
+title: "Adanos Market Sentiment"
+description: "Research stock sentiment across Reddit, X, financial news, and Polymarket with AdanosTools."
+---
+
+`AdanosTools` gives an agent market sentiment functions for stocks and cryptocurrencies.
+
+```python adanos_tools.py
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.adanos import AdanosTools
+
+agent = Agent(
+    name="Market Sentiment Research Agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[AdanosTools()],
+    instructions=[
+        "Compare sentiment across available sources before drawing conclusions.",
+        "Treat sentiment as research context, not as trading advice.",
+    ],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Compare AAPL sentiment on Reddit, X, financial news, and Polymarket over the last seven UTC days."
+    )
+```
+
+## Run the Example
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U agno openai
+    ```
+  </Step>
+
+  <Step title="Export your API keys">
+    <CodeGroup>
+    ```bash Mac/Linux
+    export OPENAI_API_KEY="***"
+    export ADANOS_API_KEY="***"
+    ```
+
+    ```bash Windows
+    $Env:OPENAI_API_KEY="***"
+    $Env:ADANOS_API_KEY="***"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the example">
+    ```bash
+    python adanos_tools.py
+    ```
+  </Step>
+</Steps>
+
+Full source: [cookbook/91_tools/adanos_tools.py](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/adanos_tools.py)

--- a/examples/tools/overview.mdx
+++ b/examples/tools/overview.mdx
@@ -7,6 +7,7 @@ description: "Examples for using and creating tools in Agno."
 
 | Example | Description |
 |---------|-------------|
+| [Adanos Market Sentiment](/examples/tools/adanos-tools) | Research stock and cryptocurrency sentiment with AdanosTools. |
 | [AgentQL](/examples/tools/agentql-tools) | Web Automation: Resilient semantic queries for interaction beyond fragile scraping. |
 | [Airflow](/examples/tools/airflow-tools) | Manage Apache Airflow DAGs. |
 | [Apify](/examples/tools/apify-tools) | Demonstrates apify tools. |

--- a/tools/toolkits/others/adanos.mdx
+++ b/tools/toolkits/others/adanos.mdx
@@ -1,0 +1,82 @@
+---
+title: Adanos Market Sentiment
+description: AdanosTools gives agents multi-source stock sentiment and Reddit cryptocurrency sentiment.
+---
+
+**AdanosTools** gives an Agent access to multi-source stock sentiment and Reddit cryptocurrency sentiment from [Adanos](https://adanos.org/).
+
+## Prerequisites
+
+Create an API key through the [Adanos registration page](https://adanos.org/register).
+
+```shell
+uv pip install -U agno openai
+```
+
+Set the API key as an environment variable:
+
+```shell
+export ADANOS_API_KEY="***"
+```
+
+## Example
+
+```python cookbook/91_tools/adanos_tools.py
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.adanos import AdanosTools
+
+agent = Agent(
+    name="Market Sentiment Research Agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[AdanosTools()],
+    instructions=[
+        "Compare sentiment across available sources before drawing conclusions.",
+        "Treat sentiment as research context, not as trading advice.",
+    ],
+    markdown=True,
+)
+
+agent.print_response(
+    "Compare AAPL sentiment on Reddit, X, financial news, and Polymarket over the last seven UTC days."
+)
+```
+
+## Supported Data
+
+| Asset type | Sources |
+| --- | --- |
+| Stocks | Reddit, X, financial news, and Polymarket |
+| Cryptocurrency | Reddit |
+
+All functions accept optional inclusive UTC date windows through `start_date` and `end_date` in `YYYY-MM-DD` format.
+
+## Toolkit Params
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `api_key` | `Optional[str]` | `None` | Adanos API key. Uses `ADANOS_API_KEY` when omitted. |
+| `base_url` | `str` | `"https://api.adanos.org"` | Adanos API base URL. |
+| `timeout` | `float` | `20.0` | Per-request timeout in seconds. |
+| `enable_stock_sentiment` | `bool` | `True` | Enable the stock sentiment function. |
+| `enable_crypto_sentiment` | `bool` | `True` | Enable the cryptocurrency sentiment function. |
+| `enable_trending` | `bool` | `True` | Enable the trending assets function. |
+| `enable_market_sentiment` | `bool` | `True` | Enable the aggregate market sentiment function. |
+| `all` | `bool` | `False` | Enable all functions regardless of individual flags. |
+
+## Toolkit Functions
+
+| Function | Description |
+| --- | --- |
+| `get_stock_sentiment` | Get sentiment for a stock from Reddit, X, financial news, or Polymarket. |
+| `get_crypto_sentiment` | Get Reddit sentiment for a cryptocurrency. |
+| `get_trending` | Get trending stocks or cryptocurrencies ranked by buzz score with sentiment data. |
+| `get_market_sentiment` | Get aggregate market sentiment for stocks or cryptocurrencies. |
+
+The toolkit maps these functions to asynchronous implementations when used by an asynchronous Agent.
+
+## Developer Resources
+
+- [Adanos API documentation](https://api.adanos.org/docs)
+- [Tools](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/adanos.py)
+- [Cookbook example](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/adanos_tools.py)

--- a/tools/toolkits/overview.mdx
+++ b/tools/toolkits/overview.mdx
@@ -646,6 +646,14 @@ The following **Toolkits** are available to use
 
 <CardGroup cols={3}>
   <Card
+    title="Adanos Market Sentiment"
+    icon="chart-line"
+    iconType="duotone"
+    href="/tools/toolkits/others/adanos"
+  >
+    Stock and cryptocurrency market sentiment from Adanos.
+  </Card>
+  <Card
     title="Airflow"
     icon="wind"
     iconType="duotone"


### PR DESCRIPTION
## Description

Adds documentation for `AdanosTools`, the optional market sentiment toolkit introduced in agno-agi/agno#9060.

- documents authentication, supported asset/source combinations, constructor parameters, and toolkit functions
- adds a runnable stock sentiment research example based on the companion Agno cookbook
- registers both pages in the toolkit and example navigation and overview indexes

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [x] New content
- [ ] Content improvement
- [ ] Other: ___

## Related Issues/PRs

- Related SDK PR: agno-agi/agno#9060
- Related wording follow-up: agno-agi/agno#9061
- Related SDK issue: agno-agi/agno#9058

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified
- [x] Spelling and grammar checked
- [x] Screenshots updated (not applicable)

## Validation

- `npx -y -p node@20 -p mintlify mintlify broken-links`
- `npx -y -p node@20 -p mintlify mintlify validate`
- Python compilation of both embedded examples
- `python3 -m json.tool docs.json`
- `git diff --check`
- structured autoreview: clean
