### PR TITLE
docs: add pagination and max_results to Gmail and Calendar toolkits

### DIFF
--- a/tools/toolkits/others/google-drive.mdx
+++ b/tools/toolkits/others/google-drive.mdx
@@ -75,10 +75,15 @@ GoogleDriveTools(
 )
 ```
 
+<Tip>
+Results are capped at 20 per call by default to prevent context overflow. Increase `max_results` if your model has a larger context window.
+</Tip>
+
 ## Toolkit Params
 
 | Parameter              | Type                  | Default        | Description                                                       |
 | ---------------------- | --------------------- | -------------- | ----------------------------------------------------------------- |
+| `max_results`          | `int`                 | `20`           | Maximum results per API request to prevent context overflow.      |
 | `list_files`           | `bool`                | `True`         | Enable the `list_files` tool.                                     |
 | `search_files`         | `bool`                | `True`         | Enable the `search_files` tool.                                   |
 | `read_file`            | `bool`                | `True`         | Enable the `read_file` tool.                                      |

--- a/tools/toolkits/others/google-slides.mdx
+++ b/tools/toolkits/others/google-slides.mdx
@@ -99,10 +99,15 @@ description: "GoogleSlidesTools create, edit, and read Google Slides presentatio
   </Step>
 </Steps>
 
+<Tip>
+Results are capped at 20 per call by default to prevent context overflow. Increase `max_results` if your model has a larger context window.
+</Tip>
+
 ## Toolkit Params
 
 | Parameter                          | Type                          | Default        | Description                                                |
 | ---------------------------------- | ----------------------------- | -------------- | ---------------------------------------------------------- |
+| `max_results`                      | `int`                         | `20`           | Maximum results per API request to prevent context overflow |
 | `creds`                            | `Credentials`                 | `None`         | Pre-fetched OAuth credentials to skip auth flow           |
 | `credentials_path`                 | `str`                         | `None`         | Path to OAuth credentials JSON file                        |
 | `token_path`                       | `str`                         | `None`         | Path to token file for storing access/refresh tokens       |

--- a/tools/toolkits/others/googlecalendar.mdx
+++ b/tools/toolkits/others/googlecalendar.mdx
@@ -120,6 +120,10 @@ agent = Agent(
 )
 ```
 
+<Tip>
+Results are capped at 20 per call by default to prevent context overflow. Increase `max_results` if your model has a larger context window.
+</Tip>
+
 ## Toolkit Params
 
 | Parameter               | Type                          | Default        | Description                                                                   |
@@ -132,6 +136,7 @@ agent = Agent(
 | `scopes`                | `List[str]`                   | `None`         | List of OAuth scopes for Google Calendar API access                           |
 | `oauth_port`            | `int`                         | `8080`         | Port number for OAuth callback server                                         |
 | `login_hint`            | `str`                         | `None`         | Email to pre-select in the OAuth consent screen                              |
+| `max_results`           | `int`                         | `20`           | Maximum results per API request to prevent context overflow                   |
 | `calendar_id`           | `str`                         | `"primary"`    | The calendar ID to use for operations                                         |
 | `allow_update`          | `bool`                        | `None`         | When `True`, enables `create_event`, `update_event`, and `delete_event`       |
 | `list_events`           | `bool`                        | `True`         | Enable list_events tool                                                       |
@@ -157,7 +162,7 @@ agent = Agent(
 
 | Function               | Description                                                                             |
 | ---------------------- | --------------------------------------------------------------------------------------- |
-| `list_events`          | List upcoming events from the calendar. Parameters: `limit` (int), `start_date` (str)   |
+| `list_events`          | List upcoming events from the calendar. Parameters: `limit` (int), `start_date` (str) |
 | `get_event`            | Get full details of a single event by ID. Parameters: `event_id` (str)                  |
 | `fetch_all_events`     | Fetch all events in a date range with pagination. Parameters: `max_results` (int), `start_date` (str), `end_date` (str) |
 | `search_events`        | Search events by text across all fields. Parameters: `query` (str), `start_date` (str), `end_date` (str), `max_results` (int) |
@@ -169,7 +174,7 @@ agent = Agent(
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `find_available_slots` | Find free time slots based on working hours and existing events. Parameters: `start_date` (str), `end_date` (str), `duration_minutes` (int) |
 | `check_availability`   | Check busy/free status for multiple people using FreeBusy API. Parameters: `start_date` (str), `end_date` (str), `attendee_emails` (List[str]), `timezone` (str) |
-| `list_calendars`       | List all available calendars with access roles. No parameters required                  |
+| `list_calendars`       | List all available calendars with access roles. No parameters required |
 
 ### Creating & Managing Events
 

--- a/tools/toolkits/social/gmail.mdx
+++ b/tools/toolkits/social/gmail.mdx
@@ -118,6 +118,10 @@ agent = Agent(
 )
 ```
 
+<Tip>
+Results are capped at 20 per call by default to prevent context overflow. Increase `max_results` if your model has a larger context window.
+</Tip>
+
 ## Toolkit Params
 
 | Parameter               | Type          | Default        | Description                                                |
@@ -133,6 +137,7 @@ agent = Agent(
 | `include_html`          | `bool`        | `False`        | Return raw HTML body instead of stripping tags             |
 | `max_body_length`       | `int`         | `None`         | Truncate message bodies to this length                     |
 | `attachment_dir`        | `str`         | `None`         | Directory to save downloaded attachments                   |
+| `max_results`           | `int`         | `20`           | Maximum results per API request to prevent context overflow |
 | `max_batch_size`        | `int`         | `10`           | Max items per Gmail API batch request (max 100)            |
 | `get_latest_emails`     | `bool`        | `True`         | Enable get_latest_emails tool                              |
 | `get_emails_from_user`  | `bool`        | `True`         | Enable get_emails_from_user tool                           |


### PR DESCRIPTION
## Summary

Documents new `max_results` parameter (default: 20) from agno-agi/agno#9030.

This parameter caps results per API request to prevent context overflow in LLM agents. Increase it if your model has a larger context window.

## Updated Toolkits

- **Gmail** — `tools/toolkits/social/gmail.mdx`
- **Google Calendar** — `tools/toolkits/others/googlecalendar.mdx`
- **Google Drive** — `tools/toolkits/others/google-drive.mdx`
- **Google Slides** — `tools/toolkits/others/google-slides.mdx`

## Changes

- Added `<Tip>` explaining the 20-result default and when to increase it
- Added `max_results` parameter to each toolkit's params table