### PR TITLE
docs: add TrustedRouter provider guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2087,6 +2087,12 @@
                                 ]
                               }
                             ]
+                          },
+                          {
+                            "group": "TrustedRouter",
+                            "pages": [
+                              "models/providers/gateways/trustedrouter/overview"
+                            ]
                           }
                         ]
                       },
@@ -3996,6 +4002,12 @@
                               "models/providers/gateways/together/usage/tool-use"
                             ]
                           }
+                        ]
+                      },
+                      {
+                        "group": "TrustedRouter",
+                        "pages": [
+                          "models/providers/gateways/trustedrouter/overview"
                         ]
                       }
                     ]

--- a/models/providers/gateways/trustedrouter/overview.mdx
+++ b/models/providers/gateways/trustedrouter/overview.mdx
@@ -1,0 +1,63 @@
+---
+title: TrustedRouter
+sidebarTitle: Overview
+description: Use TrustedRouter models and routing aliases with Agno agents.
+---
+
+TrustedRouter provides an OpenAI-compatible API for models across multiple providers. The Agno integration defaults to `trustedrouter/zdr`, a routing alias for zero-data-retention endpoints.
+
+## Authentication
+
+Create an API key in the [TrustedRouter console](https://trustedrouter.com/console/api-keys), then set the `TRUSTEDROUTER_API_KEY` environment variable.
+
+<CodeGroup>
+
+```bash Mac
+export TRUSTEDROUTER_API_KEY=***
+```
+
+```bash Windows
+setx TRUSTEDROUTER_API_KEY ***
+```
+
+</CodeGroup>
+
+## Example
+
+Install Agno and the OpenAI client:
+
+```shell
+uv pip install -U agno openai
+```
+
+Use `TrustedRouter` with an `Agent`:
+
+<CodeGroup>
+
+```python agent.py
+from agno.agent import Agent
+from agno.models.trustedrouter import TrustedRouter
+
+agent = Agent(
+    model=TrustedRouter(id="trustedrouter/zdr"),
+    markdown=True,
+)
+
+agent.print_response("Share a two-sentence horror story.", stream=True)
+```
+
+</CodeGroup>
+
+Set `id` to a specific model such as `google/gemini-2.5-flash-lite`, or use a TrustedRouter alias such as `trustedrouter/auto`, `trustedrouter/zdr`, or `trustedrouter/e2e`.
+
+## Params
+
+| Parameter  | Type            | Default                              | Description                                                               |
+| ---------- | --------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| `id`       | `str`           | `"trustedrouter/zdr"`                | The model ID or TrustedRouter routing alias                               |
+| `name`     | `str`           | `"TrustedRouter"`                    | The model name                                                            |
+| `provider` | `str`           | `"TrustedRouter"`                    | The provider name                                                         |
+| `api_key`  | `Optional[str]` | `None`                               | The API key, defaulting to `TRUSTEDROUTER_API_KEY`                        |
+| `base_url` | `str`           | `"https://api.trustedrouter.com/v1"` | The TrustedRouter OpenAI-compatible API base URL                          |
+
+`TrustedRouter` extends [OpenAILike](/reference/models/openai-like) and accepts all of its parameters.


### PR DESCRIPTION
## Summary

Adds the provider documentation requested in agno-agi/agno#9100 after the first-class `TrustedRouter` model integration merged.

- documents `TRUSTEDROUTER_API_KEY` authentication
- shows the default `trustedrouter/zdr` alias and a runnable Agno example
- lists the model class defaults and supported routing aliases
- adds the provider page to both model navigation sections

## Validation

- `jq empty docs.json`
- `git diff --check`

Related implementation: agno-agi/agno#9100
