### PR TITLE
docs: add the VectorDB step to the v1 to v2 migration guide

### DIFF
--- a/other/v2-migration.mdx
+++ b/other/v2-migration.mdx
@@ -39,6 +39,20 @@ Notice:
 - The script is idempotent. If something goes wrong or if you stop it mid-run, you can run it again.
 - Metrics are automatically converted from v1 to v2 format.
 
+## Migrating your VectorDB
+
+If you used a VectorDB in v1, your vector tables need the two new columns introduced in v2: `content_hash` and `content_id`.
+
+Use our migration script: [`libs/agno/migrations/v1_to_v2/migrate_vectordbs_to_v2.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/migrations/v1_to_v2/migrate_vectordbs_to_v2.py)
+
+The script supports PgVector and SingleStore. Set the database URL and the config listing the schema and the tables to migrate at the top of the script and run it.
+
+Notice:
+
+- The script is idempotent. It skips tables that already have both columns.
+- Creating a `PgVector` instance won't migrate existing tables. `create()` only creates tables that don't exist.
+- Until the migration runs, writes to a v1 table fail with `column "content_id" of relation "..." does not exist`.
+
 ## Migrating your Agno code
 
 Each section here covers a specific framework domain, with before and after examples and detailed explanations where needed.
@@ -248,7 +262,7 @@ from any sources. For a full example of the usage, see the [Content Types](/know
 Furthermore, we now support deletion of individual vectors using the `remove_vector_by_id()`, `remove_vectors_by_name()` and `remove_vectors_by_metadata()` methods.
 You can also delete all vectors created by a specific piece of content using `remove_content_by_id()`.
 
-4.4 To support the deletion mentioned above, VectorDB tables have been updated. Two new columns, `content_hash` and `content_id`, have been added.
+4.4 To support the deletion mentioned above, VectorDB tables have been updated. Two new columns, `content_hash` and `content_id`, have been added. See [Migrating your VectorDB](#migrating-your-vectordb) to update existing tables.
 
 4.5. The `retriever` field has been renamed to `knowledge_retriever`.
 


### PR DESCRIPTION
## Description

Upgrade an existing v1 deployment, follow this guide exactly, and every vector write fails at runtime with `UndefinedColumn` (`column "content_id" of relation "..." does not exist`). Agno v2 added two required columns, `content_hash` and `content_id`, to VectorDB tables, but the guide never mentions the migration script that applies them. The "Migrating your Agno DB" section covers only Storage and Memory, and item 4.4 announces the two new columns without saying how to apply them. `PgVector.create()` does not help: it only creates tables that do not exist, and never alters one that does.

This PR adds:

- A `## Migrating your VectorDB` section after "Migrating your Agno DB", mirroring its shape: the script link, what to configure (the database URL and a config listing the schema and the tables to migrate), and notes on idempotency, `create()` behavior, and the error seen until the migration runs.
- A sentence at item 4.4 routing readers from the column change to the new section.

The migration script (`libs/agno/migrations/v1_to_v2/migrate_vectordbs_to_v2.py`) has existed since agno-agi/agno#5421 and is currently unreferenced by the guide.

Addresses item 1 of agno-agi/agno#9343.

The remaining two items of that issue (the wrong paths in `libs/agno/migrations/README.md`, and drift detection in `PgVector`) are a separate PR against `agno-agi/agno`.

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

- Related issue: agno-agi/agno#9343 (item 1)
- Related SDK PR: agno-agi/agno#5421

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [ ] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
