### PR TITLE
docs: update agno create for v2.7.4

### DIFF
--- a/cli/create.mdx
+++ b/cli/create.mdx
@@ -8,7 +8,7 @@ description: "Scaffold an AgentOS project from a starter template: Docker by def
 agno create my-os
 ```
 
-`agno create` clones a starter template into a new directory, strips its git history, seeds `.env` from the template's `example.env`, and prints the next steps:
+`agno create` clones a starter template into a new directory, strips its git history, seeds `.env` from the template's `example.env` when it ships one, and prints the next steps:
 
 ```bash
 cd my-os
@@ -19,7 +19,7 @@ agno connect          # make it available in your coding agents
 
 ## Interactive Mode
 
-Run it bare and the CLI walks you through both choices:
+Run `agno create` with no arguments and the CLI walks you through both choices:
 
 ```bash
 agno create
@@ -66,7 +66,7 @@ agno create my-os --url https://github.com/acme/agentos-internal
 1. Validates the name. It becomes a directory under the current directory, so it must be a single path segment of letters, digits, `-`, and `_`.
 2. Runs `git clone --depth 1` on the template repository (git must be installed).
 3. Removes the cloned `.git` directory, giving you a clean tree to init your own repo in.
-4. Copies `example.env` to `.env` with owner-only permissions, when the template ships one. An existing `.env` is never overwritten, and if seeding fails the cloned directory is removed so a retry starts clean.
+4. Copies `example.env` to `.env` with owner-only permissions when the template ships one. An existing `.env` is never overwritten. If seeding fails, the cloned directory is removed so a retry starts clean.
 
 The command fails if the target directory already exists. The CLI doesn't keep a registry of projects; `up`, `down`, and `restart` operate on whatever directory you run them from.
 

--- a/cli/create.mdx
+++ b/cli/create.mdx
@@ -8,13 +8,14 @@ description: "Scaffold an AgentOS project from a starter template: Docker by def
 agno create my-os
 ```
 
-`agno create` clones a starter template into a new directory, strips its git history, seeds `.env` from the template's `example.env` when it ships one, and prints the next steps:
+`agno create` clones a starter template into a new directory, strips its git history, and seeds `.env` from the template's `example.env` when it ships one.
+
+Add your secrets to `my-os/.env`, then:
 
 ```bash
 cd my-os
-# add your secrets to .env, then:
-agno up               # start it with docker compose
-agno connect          # make it available in your coding agents
+agno up       # start it with docker compose
+agno connect  # make it available in your coding agents
 ```
 
 ## Interactive Mode

--- a/cli/create.mdx
+++ b/cli/create.mdx
@@ -1,21 +1,35 @@
 ---
 title: "Create a Project"
 sidebarTitle: "agno create"
-description: "Scaffold an AgentOS project from a starter template: Docker by default, or AWS, Fly.io, GCP, and Railway."
+description: "Scaffold an AgentOS project from a starter template: Docker by default, or AWS, Azure, Fly.io, GCP, Kubernetes, Modal, Railway, and Render."
 ---
 
 ```bash
 agno create my-os
 ```
 
-`agno create` clones a starter template into a new directory, strips its git history, and prints the next steps:
+`agno create` clones a starter template into a new directory, strips its git history, seeds `.env` from the template's `example.env`, and prints the next steps:
 
 ```bash
 cd my-os
-cp example.env .env   # then fill in your secrets
+# add your secrets to .env, then:
 agno up               # start it with docker compose
 agno connect          # make it available in your coding agents
 ```
+
+## Interactive Mode
+
+Run it bare and the CLI walks you through both choices:
+
+```bash
+agno create
+```
+
+It shows a numbered menu of starter templates. Answer with a number or a template name, or press Enter for `agentos-docker`. It then asks for a project name (default `agentos`) and re-prompts until the name is valid and the directory is free.
+
+Passing `--template` or `--url` skips the template question. An unknown `--template` fails before the first prompt appears.
+
+With `--json`, or in any run where stdin is not a TTY, nothing prompts and the name argument is required.
 
 ## Starter Templates
 
@@ -29,9 +43,13 @@ agno create my-os --template agentos-aws
 |----------|--------|------------|
 | `agentos-docker` (default) | Local dev and any Docker host | [agno-agi/agentos-docker](https://github.com/agno-agi/agentos-docker) |
 | `agentos-aws` | AWS | [agno-agi/agentos-aws](https://github.com/agno-agi/agentos-aws) |
+| `agentos-azure` | Azure | [agno-agi/agentos-azure](https://github.com/agno-agi/agentos-azure) |
 | `agentos-fly` | Fly.io | [agno-agi/agentos-fly](https://github.com/agno-agi/agentos-fly) |
 | `agentos-gcp` | Google Cloud | [agno-agi/agentos-gcp](https://github.com/agno-agi/agentos-gcp) |
+| `agentos-helm` | Kubernetes (Helm chart) | [agno-agi/agentos-helm](https://github.com/agno-agi/agentos-helm) |
+| `agentos-modal` | Modal | [agno-agi/agentos-modal](https://github.com/agno-agi/agentos-modal) |
 | `agentos-railway` | Railway | [agno-agi/agentos-railway](https://github.com/agno-agi/agentos-railway) |
+| `agentos-render` | Render | [agno-agi/agentos-render](https://github.com/agno-agi/agentos-render) |
 
 Every starter ships an AgentOS application, an `example.env`, and a compose file that `agno up` picks up. See [Templates](/deploy/introduction) for the full catalog, including pre-built agent systems.
 
@@ -48,6 +66,7 @@ agno create my-os --url https://github.com/acme/agentos-internal
 1. Validates the name. It becomes a directory under the current directory, so it must be a single path segment of letters, digits, `-`, and `_`.
 2. Runs `git clone --depth 1` on the template repository (git must be installed).
 3. Removes the cloned `.git` directory, giving you a clean tree to init your own repo in.
+4. Copies `example.env` to `.env` with owner-only permissions, when the template ships one. An existing `.env` is never overwritten, and if seeding fails the cloned directory is removed so a retry starts clean.
 
 The command fails if the target directory already exists. The CLI doesn't keep a registry of projects; `up`, `down`, and `restart` operate on whatever directory you run them from.
 

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -7,7 +7,7 @@ description: "Scaffold, run, and connect an AgentOS from the terminal with the a
 ```bash
 agno create my-os
 cd my-os
-cp example.env .env   # fill in your secrets
+# add your secrets to .env
 agno up
 agno connect
 ```
@@ -34,7 +34,7 @@ uvx agnoctl connect
 
 | Command | What it does | Guide |
 |---------|--------------|-------|
-| `agno create <name>` | Scaffold a project from a starter template | [Create a project](/cli/create) |
+| `agno create [name]` | Scaffold a project from a starter template, prompting when the name is omitted | [Create a project](/cli/create) |
 | `agno connect` | Connect coding agents to a running AgentOS over MCP | [Connect your clients](/cli/connect) |
 | `agno disconnect` | Remove AgentOS MCP entries from client configs | [Connect your clients](/cli/connect) |
 | `agno up` / `down` / `restart` | Run the project with Docker Compose | [Operate your AgentOS](/cli/operate) |

--- a/reference/cli/agnoctl.mdx
+++ b/reference/cli/agnoctl.mdx
@@ -89,14 +89,14 @@ Service-account object (the plaintext token is excluded):
 ## agno create
 
 ```bash
-agno create <name> [--template <starter>] [--url <repo>] [--json]
+agno create [name] [--template <starter>] [--url <repo>] [--json]
 ```
 
-Scaffolds a project by shallow-cloning a template repository (`git clone --depth 1`, 300s timeout) into `./<name>` and removing its `.git` directory. It requires `git` and fails if the directory already exists. `<name>` must be a single path segment of letters, digits, `-`, and `_`.
+Scaffolds a project by shallow-cloning a template repository (`git clone --depth 1`, 300s timeout) into `./<name>`, removing its `.git` directory, and copying `example.env` to `.env` when the template ships one (created with owner-only permissions; an existing `.env` is never overwritten, and symlinked `example.env` or `.env` files are refused). It requires `git` and fails if the directory already exists. `<name>` must be a single path segment of letters, digits, `-`, and `_`. A run with no `name` argument prompts for the template and the project name; with `--json` or a non-TTY stdin, prompts are disabled and `<name>` is required.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--template`, `-t` | `agentos-docker` | Starter template: `agentos-aws`, `agentos-docker`, `agentos-fly`, `agentos-gcp`, `agentos-railway` |
+| `--template`, `-t` | `agentos-docker` | Starter template: `agentos-aws`, `agentos-azure`, `agentos-docker`, `agentos-fly`, `agentos-gcp`, `agentos-helm`, `agentos-modal`, `agentos-railway`, `agentos-render` |
 | `--url`, `-u` | none | Clone from a custom template repository URL instead |
 | `--json` | off | Emit a single JSON document |
 

--- a/reference/cli/agnoctl.mdx
+++ b/reference/cli/agnoctl.mdx
@@ -92,7 +92,7 @@ Service-account object (the plaintext token is excluded):
 agno create [name] [--template <starter>] [--url <repo>] [--json]
 ```
 
-Scaffolds a project by shallow-cloning a template repository (`git clone --depth 1`, 300s timeout) into `./<name>`, removing its `.git` directory, and copying `example.env` to `.env` when the template ships one (created with owner-only permissions; an existing `.env` is never overwritten, and symlinked `example.env` or `.env` files are refused). It requires `git` and fails if the directory already exists. `<name>` must be a single path segment of letters, digits, `-`, and `_`. A run with no `name` argument prompts for the template and the project name; with `--json` or a non-TTY stdin, prompts are disabled and `<name>` is required.
+Scaffolds a project by shallow-cloning a template repository (`git clone --depth 1`, 300s timeout) into `./<name>`, removing its `.git` directory, and copying `example.env` to `.env` when the template ships one (created with owner-only permissions; an existing `.env` is never overwritten, and symlinked `example.env` or `.env` files are refused). It requires `git` and fails if the directory already exists. `<name>` must be a single path segment of letters, digits, `-`, and `_`. A run with no `name` argument prompts for the project name, and for the template unless `--template` or `--url` is passed; with `--json` or a non-TTY stdin, prompts are disabled and `<name>` is required.
 
 | Flag | Default | Description |
 |------|---------|-------------|


### PR DESCRIPTION
## Description

Updates the `agno create` docs for the v2.7.4 onboarding changes: interactive template and project-name prompts, four new starters (`agentos-azure`, `agentos-helm`, `agentos-modal`, `agentos-render`), and automatic `.env` seeding from `example.env` (which removes the manual `cp example.env .env` step from the quickstarts).

Pages updated:

- `cli/create.mdx`: new Interactive Mode section, expanded starter table (9 templates), `.env` seeding step in How It Works
- `cli/overview.mdx`: quickstart drops the obsolete `cp example.env .env` step
- `reference/cli/agnoctl.mdx`: optional `[name]`, seeding and prompt behavior in the mechanism line, full 9-template flag list

## Type of Change

- [ ] Bug fix (errors, broken links, outdated info)
- [ ] New content
- [x] Content improvement
- [ ] Other: \_\_\_\_

## Related Issues/PRs (if applicable)

- Related SDK PR: agno-agi/agno#8959 (shipped in [v2.7.4](https://github.com/agno-agi/agno/releases/tag/v2.7.4))

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)
