### PR TITLE
docs: add AG-UI Channels guide and Slack example (CopilotKit Channels SDK)

### DIFF
--- a/agent-os/interfaces/ag-ui/channels.mdx
+++ b/agent-os/interfaces/ag-ui/channels.mdx
@@ -1,0 +1,161 @@
+---
+title: Channels
+description: Run an AG-UI agent as a bot in Slack and other messaging platforms with the CopilotKit Channels SDK.
+---
+
+The same agent that powers your AG-UI frontend can also run as a bot in messaging platforms. [CopilotKit Channels](https://docs.copilotkit.ai/slack/agno) connects an Agno agent to Slack and other messaging platforms, with threads, tool calls, and rich interactive messages handled natively in the channel.
+
+<Info>
+Full platform setup lives in the [CopilotKit Channels documentation](https://docs.copilotkit.ai/slack/agno). This page shows how Channels fit together with an Agno agent.
+</Info>
+
+## How it fits together
+
+Your AgentOS server stays where it is, exposed over [AG-UI](/agent-os/interfaces/ag-ui/introduction). A channel is a separate long-running Node service built with `@copilotkit/channels`: you point it at your agent and attach one or more platform adapters. `createChannel` takes an array of adapters, so a single process can serve several platforms at once.
+
+```
+Slack / Teams / Discord  ──►  channel process (Node)  ──►  AgentOS (POST /agui)
+```
+
+The channel drives your agent through `AgnoAgent` from [`@ag-ui/agno`](https://www.npmjs.com/package/@ag-ui/agno), the AG-UI client for Agno. The agent receives ordinary AG-UI input and emits ordinary AG-UI events. The platform mechanics stay behind the adapter, so the same Agno agent runs unchanged across every channel and keeps serving your web frontend from the same endpoint. Rich messages are written as JSX and rendered to each platform's native format (Block Kit on Slack, for example), so an interactive card degrades gracefully where a platform has no equivalent.
+
+CopilotKit Intelligence runs the channel (free tier available). The SDK and its adapters are MIT-licensed. To run without Intelligence, build your own channel runner on the SDK's lower-level primitives. Your team then owns lifecycle, state, persistence, concurrency, and retries.
+
+## Slack
+
+Slack runs over Socket Mode, which opens an outbound WebSocket to Slack, so no public URL or tunnel is required during development.
+
+<Steps>
+  <Step title="Serve an agent over AG-UI">
+
+```python basic.py
+from agno.agent.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+
+chat_agent = Agent(model=OpenAIResponses(id="gpt-5.4"))
+
+agent_os = AgentOS(agents=[chat_agent], interfaces=[AGUI(agent=chat_agent)])
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="basic:app", reload=True)
+```
+
+The AG-UI endpoint is served at `http://localhost:7777/agui`.
+
+  </Step>
+  <Step title="Install the channel packages">
+
+In a separate Node project, install the Channels SDK (batteries-included, every adapter), the runtime that runs the channel, and the AG-UI client for Agno:
+
+```bash
+npm init -y
+npm pkg set type=module
+npm install @copilotkit/channels @copilotkit/runtime @ag-ui/agno
+npm install -D tsx
+```
+
+  </Step>
+  <Step title="Create a Slack app and set credentials">
+
+Create an app in the [Slack API dashboard](https://api.slack.com/apps), enable Socket Mode, and grant it the scopes to read and post messages. The full walkthrough is in the [CopilotKit Slack guide](https://docs.copilotkit.ai/slack/agno).
+
+```bash
+export SLACK_BOT_TOKEN="xoxb-..."
+export SLACK_APP_TOKEN="xapp-..."
+export COPILOTKIT_INTELLIGENCE_API_KEY="..."
+```
+
+| Variable | Description |
+|----------|-------------|
+| `SLACK_BOT_TOKEN` | Bot User OAuth token (`xoxb-...`) |
+| `SLACK_APP_TOKEN` | App-level token with the `connections:write` scope (`xapp-...`), used for Socket Mode |
+| `COPILOTKIT_INTELLIGENCE_API_KEY` | Authenticates the runtime that runs the channel. Free tier available. |
+
+  </Step>
+  <Step title="Point the channel at your agent">
+
+Build the agent as a per-thread factory so each conversation gets its own session:
+
+```ts agent.ts
+import { AgnoAgent } from "@ag-ui/agno";
+
+export function makeAgent(threadId: string) {
+  const agent = new AgnoAgent({
+    url: process.env.AGNO_AGUI_URL ?? "http://localhost:7777/agui",
+  });
+  agent.threadId = threadId;
+  return agent;
+}
+```
+
+Then point a channel at it:
+
+```ts channel.ts
+import { createChannel } from "@copilotkit/channels";
+import { slack } from "@copilotkit/channels/slack";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
+
+import { makeAgent } from "./agent"; // your Agno AG-UI agent
+
+const channel = createChannel({
+  name: "agno-slack-bot", // project-unique Intelligence Channel name
+  identifyUser: "platform",
+  agent: makeAgent, // an AbstractAgent, or a per-thread factory
+  adapters: [
+    slack({
+      botToken: process.env.SLACK_BOT_TOKEN!, // xoxb-...
+      appToken: process.env.SLACK_APP_TOKEN!, // xapp-... (Socket Mode)
+    }),
+  ],
+});
+
+// Mentions and DMs both start a turn; runAgent streams the reply into the thread.
+channel.onMessage(async ({ thread }) => {
+  await thread.runAgent();
+});
+
+// The runtime owns the channel lifecycle. Creating the listener connects it.
+const runtime = new CopilotRuntime({
+  agents: {}, // the channel supplies its own agent; no web-facing agents needed
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
+  }),
+  channels: [channel],
+});
+
+const listener = createCopilotNodeListener({ runtime });
+await listener.channels.ready();
+```
+
+  </Step>
+  <Step title="Run both processes">
+
+```bash
+python basic.py    # terminal 1: AgentOS with the AG-UI interface
+npx tsx channel.ts # terminal 2: the Slack channel
+```
+
+Mention or DM the bot in Slack. The channel runs your agent and streams the reply into the thread.
+
+  </Step>
+</Steps>
+
+## Other platforms
+
+Microsoft Teams, Discord, Telegram, and WhatsApp run through the same `@copilotkit/channels` API: add the matching adapter (`@copilotkit/channels/teams`, `/discord`, `/telegram`, `/whatsapp`) to the `adapters` array and the rest of your agent code stays the same. A single process can serve several platforms at once. See the [CopilotKit Channels documentation](https://docs.copilotkit.ai/slack/agno) for the current platform list and per-platform setup.
+
+<Note>
+By default, interactive actions and per-thread state live in memory and reset on restart. Configure a durable state store for production so buttons and per-thread state survive restarts.
+</Note>
+
+## Next steps
+
+| Task | Guide |
+|------|-------|
+| Serve agents and teams over AG-UI | [AG-UI](/agent-os/interfaces/ag-ui/introduction) |
+| Run the full Slack example | [Slack Channel example](/examples/agent-os/interfaces/agui/slack-channel) |
+| Rich messages, approvals, and adapter options | [CopilotKit Channels](https://docs.copilotkit.ai/slack/agno) |

--- a/agent-os/interfaces/ag-ui/channels.mdx
+++ b/agent-os/interfaces/ag-ui/channels.mdx
@@ -11,19 +11,17 @@ Full platform setup lives in the [CopilotKit Channels documentation](https://doc
 
 ## How it fits together
 
-Your AgentOS server stays where it is, exposed over [AG-UI](/agent-os/interfaces/ag-ui/introduction). A channel is a separate long-running Node service built with `@copilotkit/channels`: you point it at your agent and attach one or more platform adapters. `createChannel` takes an array of adapters, so a single process can serve several platforms at once.
+Your AgentOS server stays where it is, exposed over [AG-UI](/agent-os/interfaces/ag-ui/introduction). A channel is a separate long-running Node service built with `@copilotkit/channels`, connected through CopilotKit Intelligence. Intelligence is a required surface for Channels, by design (free tier available): it holds the platform connection and credentials, receives each platform event, and delivers the turn to your channel process.
 
 ```
-Slack / Teams / Discord  ──►  channel process (Node)  ──►  AgentOS (POST /agui)
+Slack  ──►  CopilotKit Intelligence  ──►  channel process (Node)  ──►  AgentOS (POST /agui)
 ```
 
-The channel drives your agent through `AgnoAgent` from [`@ag-ui/agno`](https://www.npmjs.com/package/@ag-ui/agno), the AG-UI client for Agno. The agent receives ordinary AG-UI input and emits ordinary AG-UI events. The platform mechanics stay behind the adapter, so the same Agno agent runs unchanged across every channel and keeps serving your web frontend from the same endpoint. Rich messages are written as JSX and rendered to each platform's native format (Block Kit on Slack, for example), so an interactive card degrades gracefully where a platform has no equivalent.
-
-CopilotKit Intelligence runs the channel (free tier available). The SDK and its adapters are MIT-licensed. To run without Intelligence, build your own channel runner on the SDK's lower-level primitives. Your team then owns lifecycle, state, persistence, concurrency, and retries.
+The channel drives your agent through `AgnoAgent` from [`@ag-ui/agno`](https://www.npmjs.com/package/@ag-ui/agno), the AG-UI client for Agno. The agent receives ordinary AG-UI input and emits ordinary AG-UI events. The platform mechanics stay behind the channel, so the same Agno agent runs unchanged across every platform and keeps serving your web frontend from the same endpoint. Rich messages are written as JSX and rendered to each platform's native format (Block Kit on Slack, for example), so an interactive card degrades gracefully where a platform has no equivalent.
 
 ## Slack
 
-Slack runs over Socket Mode, which opens an outbound WebSocket to Slack, so no public URL or tunnel is required during development.
+The channel process holds a persistent connection to the Intelligence gateway, which delivers each turn to it. It needs a long-running host. A serverless request handler cannot own that connection.
 
 <Steps>
   <Step title="Serve an agent over AG-UI">
@@ -48,7 +46,7 @@ The AG-UI endpoint is served at `http://localhost:7777/agui`.
   </Step>
   <Step title="Install the channel packages">
 
-In a separate Node project, install the Channels SDK (batteries-included, every adapter), the runtime that runs the channel, and the AG-UI client for Agno:
+In a separate Node project, install the Channels SDK, the runtime that runs the channel, and the AG-UI client for Agno:
 
 ```bash
 npm init -y
@@ -58,21 +56,19 @@ npm install -D tsx
 ```
 
   </Step>
-  <Step title="Create a Slack app and set credentials">
+  <Step title="Create the Channel in CopilotKit Intelligence">
 
-Create an app in the [Slack API dashboard](https://api.slack.com/apps), enable Socket Mode, and grant it the scopes to read and post messages. The full walkthrough is in the [CopilotKit Slack guide](https://docs.copilotkit.ai/slack/agno).
+Create a Channel in the Intelligence dashboard and connect Slack there. Intelligence walks you through the Slack app setup and holds its credentials. The full walkthrough is in the [CopilotKit Slack guide](https://docs.copilotkit.ai/slack/agno).
 
 ```bash
-export SLACK_BOT_TOKEN="xoxb-..."
-export SLACK_APP_TOKEN="xapp-..."
-export COPILOTKIT_INTELLIGENCE_API_KEY="..."
+export INTELLIGENCE_API_KEY="..."
+export INTELLIGENCE_CHANNEL_ID="..."
 ```
 
 | Variable | Description |
 |----------|-------------|
-| `SLACK_BOT_TOKEN` | Bot User OAuth token (`xoxb-...`) |
-| `SLACK_APP_TOKEN` | App-level token with the `connections:write` scope (`xapp-...`), used for Socket Mode |
-| `COPILOTKIT_INTELLIGENCE_API_KEY` | Authenticates the runtime that runs the channel. Free tier available. |
+| `INTELLIGENCE_API_KEY` | Authenticates the runtime with Intelligence. Free tier available. |
+| `INTELLIGENCE_CHANNEL_ID` | The ID of the Channel created in Intelligence, matched by `createChannel({ name })`. |
 
   </Step>
   <Step title="Point the channel at your agent">
@@ -95,40 +91,44 @@ Then point a channel at it:
 
 ```ts channel.ts
 import { createChannel } from "@copilotkit/channels";
-import { slack } from "@copilotkit/channels/slack";
 import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
 import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 import { makeAgent } from "./agent"; // your Agno AG-UI agent
 
+const required = (name: string) => {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+};
+
 const channel = createChannel({
-  name: "agno-slack-bot", // project-unique Intelligence Channel name
+  name: required("INTELLIGENCE_CHANNEL_ID"), // the Channel ID from Intelligence
   identifyUser: "platform",
   agent: makeAgent, // an AbstractAgent, or a per-thread factory
-  adapters: [
-    slack({
-      botToken: process.env.SLACK_BOT_TOKEN!, // xoxb-...
-      appToken: process.env.SLACK_APP_TOKEN!, // xapp-... (Socket Mode)
-    }),
-  ],
 });
 
-// Mentions and DMs both start a turn; runAgent streams the reply into the thread.
-channel.onMessage(async ({ thread }) => {
+// A mention subscribes the thread and runs the agent. Afterwards every message
+// in a subscribed thread runs it without another mention.
+channel.onMention(async ({ thread }) => {
+  await thread.subscribe();
   await thread.runAgent();
+});
+channel.onMessage(async ({ thread }) => {
+  if (await thread.isSubscribed()) await thread.runAgent();
 });
 
 // The runtime owns the channel lifecycle. Creating the listener connects it.
 const runtime = new CopilotRuntime({
   agents: {}, // the channel supplies its own agent; no web-facing agents needed
   intelligence: new CopilotKitIntelligence({
-    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
+    apiKey: required("INTELLIGENCE_API_KEY"),
   }),
   channels: [channel],
 });
 
 const listener = createCopilotNodeListener({ runtime });
-await listener.channels.ready();
+await listener.channels?.ready({ timeoutMs: 15_000 });
 ```
 
   </Step>
@@ -139,14 +139,14 @@ python basic.py    # terminal 1: AgentOS with the AG-UI interface
 npx tsx channel.ts # terminal 2: the Slack channel
 ```
 
-Mention or DM the bot in Slack. The channel runs your agent and streams the reply into the thread.
+Mention the bot in Slack. The channel runs your agent and streams the reply into the thread. The thread stays subscribed, so follow-up messages run without another mention.
 
   </Step>
 </Steps>
 
 ## Other platforms
 
-Microsoft Teams, Discord, Telegram, and WhatsApp run through the same `@copilotkit/channels` API: add the matching adapter (`@copilotkit/channels/teams`, `/discord`, `/telegram`, `/whatsapp`) to the `adapters` array and the rest of your agent code stays the same. A single process can serve several platforms at once. See the [CopilotKit Channels documentation](https://docs.copilotkit.ai/slack/agno) for the current platform list and per-platform setup.
+Other messaging platforms connect the same way: a managed connection configured in Intelligence, with your channel code unchanged. See the [CopilotKit Channels documentation](https://docs.copilotkit.ai/slack/agno) for the current platform list and per-platform setup.
 
 <Note>
 By default, interactive actions and per-thread state live in memory and reset on restart. Configure a durable state store for production so buttons and per-thread state survive restarts.
@@ -158,4 +158,4 @@ By default, interactive actions and per-thread state live in memory and reset on
 |------|-------|
 | Serve agents and teams over AG-UI | [AG-UI](/agent-os/interfaces/ag-ui/introduction) |
 | Run the full Slack example | [Slack Channel example](/examples/agent-os/interfaces/agui/slack-channel) |
-| Rich messages, approvals, and adapter options | [CopilotKit Channels](https://docs.copilotkit.ai/slack/agno) |
+| Rich messages, approvals, and platform setup | [CopilotKit Channels](https://docs.copilotkit.ai/slack/agno) |

--- a/agent-os/interfaces/ag-ui/introduction.mdx
+++ b/agent-os/interfaces/ag-ui/introduction.mdx
@@ -57,6 +57,8 @@ With Dojo running, open `http://localhost:3000` and select the Agno agent.
 
 Additional examples are available in the [cookbook](https://github.com/agno-agi/agno/tree/main/cookbook/05_agent_os/16_agui).
 
+The same agent can also run as a bot in Slack and other messaging platforms. See [Channels](/agent-os/interfaces/ag-ui/channels).
+
 ## Custom Events
 
 Custom events created in tools are automatically delivered to AG-UI in the AG-UI custom event format.

--- a/docs.json
+++ b/docs.json
@@ -4827,7 +4827,13 @@
                     ]
                   },
                   "agent-os/interfaces/a2a/introduction",
-                  "agent-os/interfaces/ag-ui/introduction"
+                  {
+                    "group": "AG-UI",
+                    "pages": [
+                      "agent-os/interfaces/ag-ui/introduction",
+                      "agent-os/interfaces/ag-ui/channels"
+                    ]
+                  }
                 ]
               },
               {
@@ -7782,7 +7788,8 @@
                           "examples/agent-os/interfaces/agui/showcase",
                           "examples/agent-os/interfaces/agui/state-events",
                           "examples/agent-os/interfaces/agui/team-state-events",
-                          "examples/agent-os/interfaces/agui/tool-based-generative-ui"
+                          "examples/agent-os/interfaces/agui/tool-based-generative-ui",
+                          "examples/agent-os/interfaces/agui/slack-channel"
                         ]
                       },
                       {

--- a/examples/agent-os/interfaces/agui/overview.mdx
+++ b/examples/agent-os/interfaces/agui/overview.mdx
@@ -20,3 +20,4 @@ description: "Serve Agno agents and teams to AG-UI frontends."
 | [State Events](/examples/agent-os/interfaces/agui/state-events) | Serves a recipe agent over AG-UI at /shared_state, where enable_agentic_state lets the model call update_session_state to sync recipe fields to the UI. |
 | [Team State Events](/examples/agent-os/interfaces/agui/team-state-events) | Serves a recipe-creator plus nutrition-advisor Team over AG-UI at /shared_state, with enable_agentic_state syncing the shared recipe session state to the UI. |
 | [Tool Based Generative UI: Dojo Demo](/examples/agent-os/interfaces/agui/tool-based-generative-ui) | Haiku agent that calls an externally executed generate_haiku tool, passing Japanese and English lines plus an image name and CSS gradient for the frontend to render as a card. |
+| [Slack Channel](/examples/agent-os/interfaces/agui/slack-channel) | Run an AG-UI agent as a Slack bot with the CopilotKit Channels SDK. |

--- a/examples/agent-os/interfaces/agui/slack-channel.mdx
+++ b/examples/agent-os/interfaces/agui/slack-channel.mdx
@@ -3,7 +3,7 @@ title: "Slack Channel"
 description: "Run an AG-UI agent as a Slack bot with the CopilotKit Channels SDK."
 ---
 
-Serve an Agno agent over AG-UI and drive it from Slack with a [CopilotKit Channels](https://docs.copilotkit.ai/slack/agno) process. The AgentOS server is unchanged. The channel is a separate Node process that connects Slack over Socket Mode and runs the agent through `AgnoAgent` from [`@ag-ui/agno`](https://www.npmjs.com/package/@ag-ui/agno).
+Serve an Agno agent over AG-UI and drive it from Slack with a [CopilotKit Channels](https://docs.copilotkit.ai/slack/agno) process. The AgentOS server is unchanged. The channel is a separate Node process, connected to Slack through CopilotKit Intelligence, that runs the agent through `AgnoAgent` from [`@ag-ui/agno`](https://www.npmjs.com/package/@ag-ui/agno).
 
 ```python basic.py
 from agno.agent.agent import Agent
@@ -43,38 +43,41 @@ export function makeAgent(threadId: string) {
 
 ```ts channel.ts
 import { createChannel } from "@copilotkit/channels";
-import { slack } from "@copilotkit/channels/slack";
 import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
 import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 import { makeAgent } from "./agent";
 
+const required = (name: string) => {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+};
+
 const channel = createChannel({
-  name: "agno-slack-bot",
+  name: required("INTELLIGENCE_CHANNEL_ID"),
   identifyUser: "platform",
   agent: makeAgent,
-  adapters: [
-    slack({
-      botToken: process.env.SLACK_BOT_TOKEN!,
-      appToken: process.env.SLACK_APP_TOKEN!,
-    }),
-  ],
 });
 
-channel.onMessage(async ({ thread }) => {
+channel.onMention(async ({ thread }) => {
+  await thread.subscribe();
   await thread.runAgent();
+});
+channel.onMessage(async ({ thread }) => {
+  if (await thread.isSubscribed()) await thread.runAgent();
 });
 
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
+    apiKey: required("INTELLIGENCE_API_KEY"),
   }),
   channels: [channel],
 });
 
 const listener = createCopilotNodeListener({ runtime });
-await listener.channels.ready();
+await listener.channels?.ready({ timeoutMs: 15_000 });
 ```
 
 ## Run the Example
@@ -117,21 +120,20 @@ await listener.channels.ready();
     ```
   </Step>
 
-  <Step title="Export the Slack and CopilotKit credentials">
-    Create a Slack app with Socket Mode enabled, then:
+  <Step title="Export the CopilotKit Intelligence credentials">
+    Create a Channel in the CopilotKit Intelligence dashboard and connect Slack there, then:
     ```bash
-    export SLACK_BOT_TOKEN="xoxb-..."
-    export SLACK_APP_TOKEN="xapp-..."
-    export COPILOTKIT_INTELLIGENCE_API_KEY="..."
+    export INTELLIGENCE_API_KEY="..."
+    export INTELLIGENCE_CHANNEL_ID="..."
     ```
-    Slack app setup and adapter options are covered in the [CopilotKit Slack guide](https://docs.copilotkit.ai/slack/agno).
+    Slack setup is covered in the [CopilotKit Slack guide](https://docs.copilotkit.ai/slack/agno).
   </Step>
 
   <Step title="Run the channel">
     ```bash
     npx tsx channel.ts
     ```
-    Mention or DM the bot in Slack. The channel runs the agent over AG-UI and streams the reply into the thread.
+    Mention the bot in Slack. The channel runs the agent over AG-UI and streams the reply into the thread. The thread stays subscribed, so follow-up messages run without another mention.
   </Step>
 </Steps>
 

--- a/examples/agent-os/interfaces/agui/slack-channel.mdx
+++ b/examples/agent-os/interfaces/agui/slack-channel.mdx
@@ -1,0 +1,138 @@
+---
+title: "Slack Channel"
+description: "Run an AG-UI agent as a Slack bot with the CopilotKit Channels SDK."
+---
+
+Serve an Agno agent over AG-UI and drive it from Slack with a [CopilotKit Channels](https://docs.copilotkit.ai/slack/agno) process. The AgentOS server is unchanged. The channel is a separate Node process that connects Slack over Socket Mode and runs the agent through `AgnoAgent` from [`@ag-ui/agno`](https://www.npmjs.com/package/@ag-ui/agno).
+
+```python basic.py
+from agno.agent.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+
+chat_agent = Agent(
+    name="Assistant",
+    model=OpenAIResponses(id="gpt-5.4"),
+    instructions="You are a helpful AI assistant.",
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+agent_os = AgentOS(
+    agents=[chat_agent],
+    interfaces=[AGUI(agent=chat_agent)],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="basic:app", reload=True)
+```
+
+```ts agent.ts
+import { AgnoAgent } from "@ag-ui/agno";
+
+export function makeAgent(threadId: string) {
+  const agent = new AgnoAgent({
+    url: process.env.AGNO_AGUI_URL ?? "http://localhost:7777/agui",
+  });
+  agent.threadId = threadId;
+  return agent;
+}
+```
+
+```ts channel.ts
+import { createChannel } from "@copilotkit/channels";
+import { slack } from "@copilotkit/channels/slack";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
+
+import { makeAgent } from "./agent";
+
+const channel = createChannel({
+  name: "agno-slack-bot",
+  identifyUser: "platform",
+  agent: makeAgent,
+  adapters: [
+    slack({
+      botToken: process.env.SLACK_BOT_TOKEN!,
+      appToken: process.env.SLACK_APP_TOKEN!,
+    }),
+  ],
+});
+
+channel.onMessage(async ({ thread }) => {
+  await thread.runAgent();
+});
+
+const runtime = new CopilotRuntime({
+  agents: {},
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
+  }),
+  channels: [channel],
+});
+
+const listener = createCopilotNodeListener({ runtime });
+await listener.channels.ready();
+```
+
+## Run the Example
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[agui,os]" openai
+    ```
+  </Step>
+
+  <Step title="Export your OpenAI API key">
+    <CodeGroup>
+    ```bash Mac/Linux
+    export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+    $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the AgentOS server">
+    Save the Python code above as `basic.py`, then run:
+    ```bash
+    python basic.py
+    ```
+  </Step>
+
+  <Step title="Set up the channel project">
+    In a separate directory, save `agent.ts` and `channel.ts` from above and install:
+    ```bash
+    npm init -y
+    npm pkg set type=module
+    npm install @copilotkit/channels @copilotkit/runtime @ag-ui/agno
+    npm install -D tsx
+    ```
+  </Step>
+
+  <Step title="Export the Slack and CopilotKit credentials">
+    Create a Slack app with Socket Mode enabled, then:
+    ```bash
+    export SLACK_BOT_TOKEN="xoxb-..."
+    export SLACK_APP_TOKEN="xapp-..."
+    export COPILOTKIT_INTELLIGENCE_API_KEY="..."
+    ```
+    Slack app setup and adapter options are covered in the [CopilotKit Slack guide](https://docs.copilotkit.ai/slack/agno).
+  </Step>
+
+  <Step title="Run the channel">
+    ```bash
+    npx tsx channel.ts
+    ```
+    Mention or DM the bot in Slack. The channel runs the agent over AG-UI and streams the reply into the thread.
+  </Step>
+</Steps>
+
+See [Channels](/agent-os/interfaces/ag-ui/channels) for how Channels fit together with AG-UI, other platforms, and production notes.


### PR DESCRIPTION
## Description

Adds an AG-UI Channels guide plus a runnable Slack example. The same Agno agent that serves an AG-UI frontend from AgentOS can also run as a bot in Slack and other messaging platforms through the CopilotKit Channels SDK: the AgentOS server stays unchanged, and a separate Node channel process — connected through CopilotKit Intelligence, which holds the platform credentials — drives the agent through `AgnoAgent` from `@ag-ui/agno`.

Changes:

- New `agent-os/interfaces/ag-ui/channels.mdx` guide (how it fits together, Slack steps, other platforms, production note).
- New `examples/agent-os/interfaces/agui/slack-channel.mdx` runnable example.
- `docs.json` navigation entries for both, an AG-UI group, and a row in the AG-UI examples overview table.
- Cross-link from the AG-UI introduction.

## Type of Change

- [x] New content

## Related Issues/PRs (if applicable)

N/A

## Checklist

- [x] Content is accurate and up-to-date
- [x] All links tested and working
- [x] Code examples verified (if applicable)
- [x] Spelling and grammar checked
- [ ] Screenshots updated (if applicable)

Code verification: the TypeScript snippets typecheck against the published `@copilotkit/channels`, `@copilotkit/runtime`, and `@ag-ui/agno` packages; the AgentOS snippet and `/agui` endpoint match the existing AG-UI introduction. `docs.json` validated as JSON.
