### PR TITLE
Clarify Arize Phoenix observability positioning

### DIFF
--- a/observability/arize.mdx
+++ b/observability/arize.mdx
@@ -1,11 +1,13 @@
 ---
-title: Arize
-description: Integrate Agno with Arize Phoenix to send traces and gain insights into your agent's performance.
+title: Arize Phoenix
+description: Integrate Agno with Arize Phoenix to send traces and evaluate your agent's performance.
 ---
 
 ## Integrating Agno with Arize Phoenix
 
-[Arize Phoenix](https://arize.com/phoenix/) is a platform for monitoring and analyzing AI models. By integrating Agno with Arize Phoenix, you can use OpenInference to send traces and gain insights into your agent's performance.
+[Arize Phoenix](https://arize.com/phoenix/) is the open-source observability and evaluation platform from [Arize AI](https://arize.com/?utm_source=agno-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=observability-arize) for tracing, evaluating, and debugging LLM applications and AI agents. By integrating Agno with Arize Phoenix, you can use OpenInference to send traces and understand your agent's runtime behavior.
+
+Phoenix is a good fit for local development, OSS workflows, and self-hosted experimentation. Teams that need the full-featured platform for production AI observability and evaluation can use [Arize AX](https://arize.com/products/ax/), available as managed cloud or enterprise self-hosted deployment. For examples of how traces turn into evaluation workflows, see Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/).
 
 ## Prerequisites
 
@@ -67,7 +69,7 @@ agent = Agent(
 agent.print_response("What is the current price of Tesla?")
 ```
 
-Now go to the [Phoenix Cloud](https://app.phoenix.arize.com) and view the traces created by your agent. You can visualize the execution flow, monitor performance, and debug issues directly from the Arize Phoenix dashboard.
+Now open your Phoenix instance and view the traces created by your agent. You can visualize the execution flow, monitor performance, and debug issues directly from the Arize Phoenix dashboard.
 <Frame caption="Arize Phoenix Trace">
   <img
     src="/images/arize-phoenix-trace.png"


### PR DESCRIPTION
## Summary
- Clarifies that the Agno integration sends traces to Arize Phoenix
- Notes when teams may prefer the full-featured Arize AX platform
- Adds concise evaluation context for teams using traces to understand agent behavior

## Why
The setup steps already cover sending Agno traces to Phoenix. This update improves the product context before readers start configuration: Phoenix for open-source local and self-hosted workflows, AX for production teams using managed cloud or enterprise self-hosted deployment.

## Testing
- Docs-only change; not run.
