### PR TITLE
docs: add emem MCP example

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -7270,7 +7270,8 @@
                   "examples/tools/mcp/stripe",
                   "examples/tools/mcp/supabase",
                   "examples/tools/mcp/tool-name-prefix",
-                  "examples/tools/mcp/bgpt"
+                  "examples/tools/mcp/bgpt",
+                  "examples/tools/mcp/emem"
                 ]
               },
               {

--- a/examples/tools/mcp/emem.mdx
+++ b/examples/tools/mcp/emem.mdx
@@ -1,0 +1,88 @@
+---
+title: "MCP emem Agent - Shared Memory for AI Agents Working in the Real World"
+description: "Query the hosted emem MCP server over Streamable HTTP for shared, signed memory of the physical world. No API key or account required for reads."
+source: cookbook/91_tools/mcp/emem.py
+---
+
+```python emem.py
+"""MCP emem Agent - Shared Memory for AI Agents Working in the Real World
+
+emem is shared memory for AI agents working together in the real world. One
+agent writes down what it observed. Another agent reads the same bytes, not a
+summary of them. Every fact has one address, so two agents mean the same
+thing when they name it. Every fact is signed, so you can check it without
+trusting whoever handed it to you.
+
+No API key or account is required for reads.
+
+Example prompts to try:
+- "Has this place flooded historically?"
+- "What's the air quality at this place right now?"
+- "Is this neighbourhood hot for an urban area?"
+- "How similar are two places?"
+- "Has this place lost forest?"
+
+Run: `uv pip install agno mcp openai` to install the dependencies
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.tools.mcp import MCPTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+server_url = "https://emem.dev/mcp"
+
+
+async def run_agent(message: str) -> None:
+    async with MCPTools(transport="streamable-http", url=server_url) as mcp_tools:
+        agent = Agent(
+            tools=[mcp_tools],
+            markdown=True,
+        )
+        await agent.aprint_response(input=message, stream=True, markdown=True)
+
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    asyncio.run(run_agent("Has this place flooded historically? Mumbai, India."))
+```
+
+## Run the Example
+
+<Steps>
+  <Snippet file="create-venv-step.mdx" />
+
+  <Step title="Install dependencies">
+    ```bash
+    uv pip install -U "agno[mcp]" openai
+    ```
+  </Step>
+
+  <Step title="Export your OpenAI API key">
+    <CodeGroup>
+    ```bash Mac/Linux
+    export OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+
+    ```bash Windows
+    $Env:OPENAI_API_KEY="your_openai_api_key_here"
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Run the example">
+    Save the code above as `emem.py`, then run:
+    ```bash
+    python emem.py
+    ```
+  </Step>
+</Steps>
+
+Full source: [cookbook/91_tools/mcp/emem.py](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/mcp/emem.py)

--- a/examples/tools/mcp/overview.mdx
+++ b/examples/tools/mcp/overview.mdx
@@ -38,3 +38,4 @@ description: "Enable Agno agents to interact with external systems via MCP inter
 | [Sse Transport](/examples/tools/mcp/sse-transport/overview) | Connect agents to an MCP server over SSE transport using MCPTools and MultiMCPTools. |
 | [Streamable Http Transport](/examples/tools/mcp/streamable-http-transport/overview) | Connect an Agno agent to a Streamable HTTP MCP server using MCPTools and MultiMCPTools. |
 | [MCP BGPT Agent - Evidence-grounded scientific paper search](/examples/tools/mcp/bgpt) | Query the hosted BGPT MCP server over Streamable HTTP to search papers and surface methods, sample sizes, limitations, and conflicts of interest. |
+| [MCP emem Agent - Shared Memory for AI Agents Working in the Real World](/examples/tools/mcp/emem) | Query the hosted emem MCP server over Streamable HTTP for shared, signed memory of the physical world. No API key or account required for reads. |


### PR DESCRIPTION
## Summary

Adds a docs page for the emem MCP example, matching the existing pattern used for other hosted, public, no-API-key MCP servers (e.g. the BGPT example).

- New page: `examples/tools/mcp/emem.mdx`
- Registered in `docs.json` navigation, alongside the other MCP examples
- Added a row to the MCP examples overview index (`examples/tools/mcp/overview.mdx`)

The embedded script matches the runnable example already merged in the main Agno repo at `cookbook/91_tools/mcp/emem.py`.

## Test plan

- [x] Validated `docs.json` is well-formed JSON
- [x] New page frontmatter and structure follow the same format as the existing `bgpt.mdx` page
- [ ] `mint build` not run locally (mintlify CLI install did not complete in this environment); please run it as part of review if that's part of your standard check