### PR TITLE
docs: AgentOS durable background execution (job queue)

### DIFF
--- a/agent-os/background-execution/durable-queue.mdx
+++ b/agent-os/background-execution/durable-queue.mdx
@@ -46,6 +46,27 @@ Failures that retrying cannot cure (schema violations, guardrail refusals, a `Ty
 
 Each claim increments the ticket's `attempt` counter. That number is stamped onto every write the attempt makes: the ticket itself, the run row, and the event stream. A write carrying an older attempt than the one currently recorded is refused. This is what makes `max_attempts > 1` safe: a worker that was swept while still alive cannot corrupt the retry's output. You do not need to reason about this beyond choosing `max_attempts`.
 
+## Queue retries and model retries
+
+Two retry layers exist, and they compose:
+
+| Layer | Setting | What is retried | Default |
+|-------|---------|-----------------|---------|
+| Model | `Model(retries=..., delay_between_retries=..., exponential_backoff=...)` | One model call, inside the running attempt. Only retryable `ModelProviderError`s (not 400, 401, 403, 404, 413, 422). Run context and prior tool results are kept. | `retries=0` |
+| Queue | `QueueConfig(max_attempts=..., retry_delay_seconds=...)` | The whole run, from the start, as a new attempt under the same `run_id`. Applies to crashes, timeouts, and runs that ended in `ERROR`. | `max_attempts=1` |
+
+When model retries are exhausted, the run finishes with status `ERROR`. The worker then consults the queue budget: with attempts remaining it requeues the ticket after a jittered delay, otherwise the ticket is `failed`. At the defaults, a model outage fails the run on the first error with no re-execution at either layer.
+
+```python
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5", retries=3, delay_between_retries=2, exponential_backoff=True),
+    db=db,
+)
+agent_os = AgentOS(agents=[agent], db=db, queue=QueueConfig(durable=True, max_attempts=2))
+```
+
+Use model retries for transient provider errors: they are cheap and keep the run's context. Use queue attempts for worker loss. A queue attempt repeats every tool call the previous attempt already made, so keep `max_attempts=1` for runs with side effects. Budgets multiply: at most `max_attempts * (retries + 1)` model calls per step.
+
 ## Queue stores
 
 The queue store defaults to the AgentOS `db`. A dedicated store isolates queue polling from your session data.

--- a/agent-os/background-execution/durable-queue.mdx
+++ b/agent-os/background-execution/durable-queue.mdx
@@ -139,8 +139,6 @@ A submission accepted on a replica wakes that replica's worker as soon as the ro
 
 ## Configuration
 
-All fields on `QueueConfig`:
-
 | Field | Default | Description |
 |-------|---------|-------------|
 | `durable` | `False` | Write accepted runs to the queue table. |

--- a/agent-os/background-execution/durable-queue.mdx
+++ b/agent-os/background-execution/durable-queue.mdx
@@ -4,8 +4,7 @@ description: "QueueConfig(durable=True): accepted background runs become committ
 ---
 
 ```python
-from agno.job_queue.config import QueueConfig
-from agno.os import AgentOS
+from agno.os import AgentOS, QueueConfig
 
 agent_os = AgentOS(
     agents=[agent],

--- a/agent-os/background-execution/durable-queue.mdx
+++ b/agent-os/background-execution/durable-queue.mdx
@@ -22,16 +22,16 @@ With `durable=True`, a `background=true` submission is written to the `agno_jobs
 
 ## The guarantee
 
-Every accepted run reaches a terminal, visible outcome. Poll it and you will eventually see `COMPLETED`, `ERROR`, or `CANCELLED`. Never `RUNNING` forever, never a run that vanished.
+Every accepted run reaches a terminal, visible outcome. Poll it and you will eventually see `COMPLETED`, `ERROR`, or `CANCELLED`. A run never stays `RUNNING` indefinitely and never disappears.
 
-This is a different promise from "every run executes". What happens to a run whose worker dies mid-execution depends on `max_attempts`:
+This is not the same as a promise that every run executes. What happens to a run whose worker dies mid-execution depends on `max_attempts`:
 
 | `max_attempts` | Crash behavior | Use when |
 |----------------|----------------|----------|
 | `1` (default) | After `lock_grace_seconds` without a heartbeat, another replica's sweep marks the run `ERROR` with the reason on `content`, and the ticket `failed`. Nothing re-executes. | Tools have side effects (emails, payments, writes). A killed run may already have acted. |
 | `2` or more | Another live replica reclaims the stale ticket and re-executes the run, with jittered backoff. A worker that turns out to be alive after being presumed dead has its late writes discarded on the ticket, the run row, and the event stream. | Runs are safe to repeat, or at-least-once beats a manual requeue. |
 
-At the default, a crashed run is failed loudly and an operator grants one more attempt through [requeue](/agent-os/background-execution/operations#requeue). The failed run's `content` says exactly that:
+At the default, a crashed run is marked failed and an operator grants one more attempt through [requeue](/agent-os/background-execution/operations#requeue). The run's `content` carries the reason:
 
 ```
 Worker lost and attempt budget exhausted; run was not re-executed. Crashed runs
@@ -44,11 +44,11 @@ Failures that retrying cannot cure (schema violations, guardrail refusals, a `Ty
 
 ### How it stays correct
 
-Each claim increments the ticket's `attempt` counter. That number is stamped onto every write the attempt makes: the ticket itself, the run row, and the event stream. A write carrying an older attempt than the one currently recorded is refused. This is what makes `max_attempts > 1` safe: a worker that was swept while still alive cannot corrupt the retry's output. You do not need to reason about this beyond choosing `max_attempts`.
+Each claim increments the ticket's `attempt` counter. That number is stamped onto every write the attempt makes: the ticket itself, the run row, and the event stream. A write carrying an older attempt than the one currently recorded is refused. This is what makes `max_attempts > 1` safe: a worker that was swept while still alive cannot corrupt the retry's output.
 
 ## Queue retries and model retries
 
-Two retry layers exist, and they compose:
+Model retries and queue retries are independent layers:
 
 | Layer | Setting | What is retried | Default |
 |-------|---------|-----------------|---------|
@@ -65,7 +65,7 @@ agent = Agent(
 agent_os = AgentOS(agents=[agent], db=db, queue=QueueConfig(durable=True, max_attempts=2))
 ```
 
-Use model retries for transient provider errors: they are cheap and keep the run's context. Use queue attempts for worker loss. A queue attempt repeats every tool call the previous attempt already made, so keep `max_attempts=1` for runs with side effects. Budgets multiply: at most `max_attempts * (retries + 1)` model calls per step.
+Use model retries for transient provider errors. They are cheap and keep the run's context. Use queue attempts for worker loss. A queue attempt repeats every tool call the previous attempt already made, so keep `max_attempts=1` for runs with side effects. The two budgets multiply: at most `max_attempts * (retries + 1)` model calls per step.
 
 ## Queue stores
 
@@ -76,7 +76,7 @@ The queue store defaults to the AgentOS `db`. A dedicated store isolates queue p
 | `PostgresDb` / `AsyncPostgresDb` | Yes | Claims use `SELECT ... FOR UPDATE SKIP LOCKED`. Recommended for production. |
 | `RedisDb` | Yes | Ticket durability depends on Redis persistence. Configure AOF with `appendfsync everysec` or `always`. Default RDB snapshotting can lose recently accepted jobs on a Redis crash. A warning is logged at startup. |
 | `RedisCluster` client | Rejected | The store's transactions need `WATCH`/`MULTI`, which cluster pipelines do not support. Use a standalone Redis or Valkey instance. |
-| Any other `db` | Rejected at startup | `durable=True` over a store without the queue contract raises a `ValueError` during lifespan startup. Silently degrading to non-durable is not an option. |
+| Any other `db` | Rejected at startup | `durable=True` over a store without the queue contract raises a `ValueError` during lifespan startup. |
 
 ```python
 from agno.db.redis import RedisDb
@@ -114,7 +114,7 @@ curl -X POST localhost:7777/agents/durable-agent/runs \
 
 Keys are scoped per user: the same key from two different `user_id` values is two runs. Anonymous submissions share one namespace.
 
-Asking is idempotent. Executing is not. A run that reached a tool with side effects has acted, and a retry acts again. Agno does not keep a side-effect ledger. If a tool must not run twice, make the tool idempotent.
+Asking is idempotent. Executing is not. A run that reached a tool with side effects has already acted, and a retry acts again. Agno does not keep a side-effect ledger. If a tool must not run twice, make the tool itself idempotent.
 
 ## Session serialization
 

--- a/agent-os/background-execution/durable-queue.mdx
+++ b/agent-os/background-execution/durable-queue.mdx
@@ -1,0 +1,149 @@
+---
+title: Durable Queue
+description: "QueueConfig(durable=True): accepted background runs become committed rows that survive crashes and deploys."
+---
+
+```python
+from agno.job_queue.config import QueueConfig
+from agno.os import AgentOS
+
+agent_os = AgentOS(
+    agents=[agent],
+    db=db,  # Postgres. The queue table lives here too.
+    queue=QueueConfig(
+        durable=True,
+        max_concurrency=8,  # per replica
+        max_queue_depth=1000,  # 429 beyond this
+        max_attempts=1,  # a crashed run fails visibly, never re-executes
+    ),
+)
+```
+
+With `durable=True`, a `background=true` submission is written to the `agno_jobs` table before the `202` is returned. The row is the acceptance. A worker on every replica polls the table, claims rows, and executes them under a lease that it refreshes with heartbeats. The client contract is unchanged: `202` with `run_id`, then poll or stream.
+
+## The guarantee
+
+Every accepted run reaches a terminal, visible outcome. Poll it and you will eventually see `COMPLETED`, `ERROR`, or `CANCELLED`. Never `RUNNING` forever, never a run that vanished.
+
+This is a different promise from "every run executes". What happens to a run whose worker dies mid-execution depends on `max_attempts`:
+
+| `max_attempts` | Crash behavior | Use when |
+|----------------|----------------|----------|
+| `1` (default) | After `lock_grace_seconds` without a heartbeat, another replica's sweep marks the run `ERROR` with the reason on `content`, and the ticket `failed`. Nothing re-executes. | Tools have side effects (emails, payments, writes). A killed run may already have acted. |
+| `2` or more | Another live replica reclaims the stale ticket and re-executes the run, with jittered backoff. A worker that turns out to be alive after being presumed dead has its late writes discarded on the ticket, the run row, and the event stream. | Runs are safe to repeat, or at-least-once beats a manual requeue. |
+
+At the default, a crashed run is failed loudly and an operator grants one more attempt through [requeue](/agent-os/background-execution/operations#requeue). The failed run's `content` says exactly that:
+
+```
+Worker lost and attempt budget exhausted; run was not re-executed. Crashed runs
+fail visibly instead of silently re-executing (at-most-once, max_attempts=1 by
+default): set QueueConfig(max_attempts=2) or higher to allow automatic
+re-execution, or grant one attempt via POST /queue/jobs/{id}/requeue.
+```
+
+Failures that retrying cannot cure (schema violations, guardrail refusals, a `TypeError` in the call) go straight to `failed` regardless of remaining budget.
+
+### How it stays correct
+
+Each claim increments the ticket's `attempt` counter. That number is stamped onto every write the attempt makes: the ticket itself, the run row, and the event stream. A write carrying an older attempt than the one currently recorded is refused. This is what makes `max_attempts > 1` safe: a worker that was swept while still alive cannot corrupt the retry's output. You do not need to reason about this beyond choosing `max_attempts`.
+
+## Queue stores
+
+The queue store defaults to the AgentOS `db`. A dedicated store isolates queue polling from your session data.
+
+| Store | Support | Notes |
+|-------|---------|-------|
+| `PostgresDb` / `AsyncPostgresDb` | Yes | Claims use `SELECT ... FOR UPDATE SKIP LOCKED`. Recommended for production. |
+| `RedisDb` | Yes | Ticket durability depends on Redis persistence. Configure AOF with `appendfsync everysec` or `always`. Default RDB snapshotting can lose recently accepted jobs on a Redis crash. A warning is logged at startup. |
+| `RedisCluster` client | Rejected | The store's transactions need `WATCH`/`MULTI`, which cluster pipelines do not support. Use a standalone Redis or Valkey instance. |
+| Any other `db` | Rejected at startup | `durable=True` over a store without the queue contract raises a `ValueError` during lifespan startup. Silently degrading to non-durable is not an option. |
+
+```python
+from agno.db.redis import RedisDb
+
+queue=QueueConfig(
+    durable=True,
+    db=RedisDb(db_url="redis://localhost:6379"),  # queue tickets only
+)
+```
+
+`db=` requires `durable=True`. Passing a queue store without durability raises at construction.
+
+<Warning>
+The queue store and the session store are separate concerns. Sessions and run rows on a non-Postgres store lose the attempt fencing described above and the worker's `RUNNING` stamp (queued runs poll `PENDING` while executing). Acceptance and terminal error persistence still work. A warning is logged at startup. Use Postgres for sessions in production.
+</Warning>
+
+## Idempotency keys
+
+Send an `Idempotency-Key` header to make a resubmission return the original run instead of enqueueing a second one:
+
+```bash
+curl -X POST localhost:7777/agents/durable-agent/runs \
+  -H "Idempotency-Key: order-42" \
+  -F "message=Process order 42" \
+  -F "background=true" -F "stream=false"
+```
+
+| Situation | Response |
+|-----------|----------|
+| First submission | `202` with a new `run_id`. |
+| Same key, same user, same component | `202` with the original `run_id` and its current status (`PENDING`, `RUNNING`, `COMPLETED`, `ERROR`, ...). |
+| Same key on a different agent, team, or workflow | `409`. Keys retry the same submission, never alias a different one. |
+| Same key, original was `stream=false`, replay asks for `stream=true` | `409`. The original never published events, so there is nothing to tail. Poll it instead. |
+| Key longer than 512 characters | `422`. |
+
+Keys are scoped per user: the same key from two different `user_id` values is two runs. Anonymous submissions share one namespace.
+
+Asking is idempotent. Executing is not. A run that reached a tool with side effects has acted, and a retry acts again. Agno does not keep a side-effect ledger. If a tool must not run twice, make the tool idempotent.
+
+## Session serialization
+
+`serialize_sessions=True` (the default) allows at most one live run per session, executed in submission order. Two `background=true` submissions to the same session run one after the other instead of racing each other's context reads and session-state writes. Different sessions still run concurrently under `max_concurrency`.
+
+| Situation | Behavior |
+|-----------|----------|
+| Runs A, B, C submitted to one session | A executes. B waits until A is terminal, then C. |
+| Runs in different sessions | Claimed concurrently. |
+| A crashes with retries left | A is reclaimed, not bypassed. FIFO holds across recovery. |
+| A pauses for human input | **B and C wait until A is continued or cancelled.** |
+
+<Warning>
+A `PAUSED` run holds its session's line. Runs queued behind a human-in-the-loop pause wait for the approval, because their input likely refers to its outcome. Continue or cancel the paused run to release them. Watch `paused` in `/queue/stats` if a session looks stuck.
+</Warning>
+
+Set `serialize_sessions=False` to restore fully concurrent claiming. Serialization applies at durable-queue claim time only. The non-durable in-process path is not session-gated.
+
+## Latency
+
+A submission accepted on a replica wakes that replica's worker as soon as the row commits, so execution starts in milliseconds. `poll_interval` (default `1.0` seconds) bounds three other things: how quickly a replica picks up jobs enqueued by other replicas, when a retry becomes claimable, and how often the sweep runs. Lowering it below the default rarely helps a single-replica deployment.
+
+## Configuration
+
+All fields on `QueueConfig`:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `durable` | `False` | Write accepted runs to the queue table. |
+| `db` | `None` | Queue store override. `None` uses the AgentOS `db`. Requires `durable=True`. |
+| `max_concurrency` | `None` | Background runs executing at once per replica, shared across agents, teams, and workflows. `None` keeps the process setting (`AGNO_BACKGROUND_MAX_CONCURRENCY` or 32). `0` or below disables the cap. |
+| `redis` | `None` | Cross-replica coordination. See [Multi-replica deployments](/agent-os/background-execution/multi-replica). |
+| `max_queue_depth` | `1000` | Accepted-but-unstarted jobs across the fleet. Submissions beyond it get `429`. `0` is unbounded. |
+| `max_attempts` | `1` | Executions per run under any failure mode. Must be at least 1. |
+| `retry_delay_seconds` | `30` | Base retry delay. Attempt N waits a random time up to `base * 2**(N-1)`, capped at 10 times the base. `0` disables backoff. |
+| `timeout_seconds` | `3600` | Per-run execution timeout enforced by the worker. `None` disables. |
+| `deployment_id` | `None` | Claim affinity for mixed fleets. See [Operations](/agent-os/background-execution/operations#deployment-affinity). |
+| `lock_grace_seconds` | `60` | Seconds without a heartbeat before a claimed job counts as abandoned. Minimum 3. Heartbeats fire every third of this. |
+| `poll_interval` | `1.0` | Seconds an idle worker waits between claim passes. |
+| `retention_seconds` | `86400` | Terminal jobs older than this are deleted hourly. Paused tickets are exempt. |
+| `stop_timeout_seconds` | `None` | Graceful-shutdown drain window. `None` means 30 seconds, clamped below `lock_grace_seconds`. Must be strictly below `lock_grace_seconds` when set. |
+| `serialize_sessions` | `True` | One live run per session, FIFO. `False` restores concurrent claiming. |
+
+The timing fields (`lock_grace_seconds`, `stop_timeout_seconds`, `retention_seconds`, `max_attempts`, `timeout_seconds`) must be identical on every replica sharing a queue table. See [Fleet-wide settings](/agent-os/background-execution/operations#fleet-wide-settings).
+
+## Next Steps
+
+| Task | Guide |
+|------|-------|
+| Run more than one replica | [Multi-replica deployments](/agent-os/background-execution/multi-replica) |
+| Continue a paused run durably | [Human-in-the-loop continuations](/agent-os/background-execution/hitl-continuations) |
+| Requeue failed jobs, watch depth | [Operations and monitoring](/agent-os/background-execution/operations) |

--- a/agent-os/background-execution/durable-queue.mdx
+++ b/agent-os/background-execution/durable-queue.mdx
@@ -18,7 +18,7 @@ agent_os = AgentOS(
 )
 ```
 
-With `durable=True`, a `background=true` submission is written to the `agno_jobs` table before the `202` is returned. The row is the acceptance. A worker on every replica polls the table, claims rows, and executes them under a lease that it refreshes with heartbeats. The client contract is unchanged: `202` with `run_id`, then poll or stream.
+With `durable=True`, a `background=true` submission is written to the `agno_jobs` table before the `202` is returned. That job row is the acceptance. The run itself is stored in your sessions database as usual (the run row). A worker on every replica polls the jobs table, claims jobs, and executes them under a lease that it refreshes with heartbeats. The client contract is unchanged: `202` with `run_id`, then poll or stream.
 
 ## The guarantee
 
@@ -28,8 +28,8 @@ This is not the same as a promise that every run executes. What happens to a run
 
 | `max_attempts` | Crash behavior | Use when |
 |----------------|----------------|----------|
-| `1` (default) | After `lock_grace_seconds` without a heartbeat, another replica's sweep marks the run `ERROR` with the reason on `content`, and the ticket `failed`. Nothing re-executes. | Tools have side effects (emails, payments, writes). A killed run may already have acted. |
-| `2` or more | Another live replica reclaims the stale ticket and re-executes the run, with jittered backoff. A worker that turns out to be alive after being presumed dead has its late writes discarded on the ticket, the run row, and the event stream. | Runs are safe to repeat, or at-least-once beats a manual requeue. |
+| `1` (default) | After `lock_grace_seconds` without a heartbeat, another replica's sweep (the periodic check for abandoned jobs) marks the run `ERROR` with the reason on `content`, and the job `failed`. Nothing re-executes. | Tools have side effects (emails, payments, writes). A killed run may already have acted. |
+| `2` or more | Another live replica reclaims the stale job and re-executes the run, with jittered backoff. A worker that turns out to be alive after being presumed dead has its late writes discarded on the job, the run row, and the event stream. | Runs are safe to repeat, or at-least-once beats a manual requeue. |
 
 At the default, a crashed run is marked failed and an operator grants one more attempt through [requeue](/agent-os/background-execution/operations#requeue). The run's `content` carries the reason:
 
@@ -44,7 +44,7 @@ Failures that retrying cannot cure (schema violations, guardrail refusals, a `Ty
 
 ### How it stays correct
 
-Each claim increments the ticket's `attempt` counter. That number is stamped onto every write the attempt makes: the ticket itself, the run row, and the event stream. A write carrying an older attempt than the one currently recorded is refused. This is what makes `max_attempts > 1` safe: a worker that was swept while still alive cannot corrupt the retry's output.
+Each claim increments the job's `attempt` counter. That number is recorded on every write the attempt makes: the job row, the run row, and the event stream. A write carrying an older attempt than the one currently recorded is refused. This is what makes `max_attempts > 1` safe: a worker that was swept while still alive cannot corrupt the retry's output.
 
 ## Queue retries and model retries
 
@@ -55,7 +55,7 @@ Model retries and queue retries are independent layers:
 | Model | `Model(retries=..., delay_between_retries=..., exponential_backoff=...)` | One model call, inside the running attempt. Only retryable `ModelProviderError`s (not 400, 401, 403, 404, 413, 422). Run context and prior tool results are kept. | `retries=0` |
 | Queue | `QueueConfig(max_attempts=..., retry_delay_seconds=...)` | The whole run, from the start, as a new attempt under the same `run_id`. Applies to crashes, timeouts, and runs that ended in `ERROR`. | `max_attempts=1` |
 
-When model retries are exhausted, the run finishes with status `ERROR`. The worker then consults the queue budget: with attempts remaining it requeues the ticket after a jittered delay, otherwise the ticket is `failed`. At the defaults, a model outage fails the run on the first error with no re-execution at either layer.
+When model retries are exhausted, the run finishes with status `ERROR`. The worker then consults the queue budget: with attempts remaining it requeues the job after a jittered delay, otherwise the job is `failed`. At the defaults, a model outage fails the run on the first error with no re-execution at either layer.
 
 ```python
 agent = Agent(
@@ -74,7 +74,7 @@ The queue store defaults to the AgentOS `db`. A dedicated store isolates queue p
 | Store | Support | Notes |
 |-------|---------|-------|
 | `PostgresDb` / `AsyncPostgresDb` | Yes | Claims use `SELECT ... FOR UPDATE SKIP LOCKED`. Recommended for production. |
-| `RedisDb` | Yes | Ticket durability depends on Redis persistence. Configure AOF with `appendfsync everysec` or `always`. Default RDB snapshotting can lose recently accepted jobs on a Redis crash. A warning is logged at startup. |
+| `RedisDb` | Yes | Job durability depends on Redis persistence. Configure AOF with `appendfsync everysec` or `always`. Default RDB snapshotting can lose recently accepted jobs on a Redis crash. A warning is logged at startup. |
 | `RedisCluster` client | Rejected | The store's transactions need `WATCH`/`MULTI`, which cluster pipelines do not support. Use a standalone Redis or Valkey instance. |
 | Any other `db` | Rejected at startup | `durable=True` over a store without the queue contract raises a `ValueError` during lifespan startup. |
 
@@ -83,14 +83,14 @@ from agno.db.redis import RedisDb
 
 queue=QueueConfig(
     durable=True,
-    db=RedisDb(db_url="redis://localhost:6379"),  # queue tickets only
+    db=RedisDb(db_url="redis://localhost:6379"),  # queue jobs only
 )
 ```
 
 `db=` requires `durable=True`. Passing a queue store without durability raises at construction.
 
 <Warning>
-The queue store and the session store are separate concerns. Sessions and run rows on a non-Postgres store lose the attempt fencing described above and the worker's `RUNNING` stamp (queued runs poll `PENDING` while executing). Acceptance and terminal error persistence still work. A warning is logged at startup. Use Postgres for sessions in production.
+The queue store and the session store are separate concerns. Sessions and run rows on a non-Postgres store lose the attempt fencing described above, and the worker cannot update the run to `RUNNING` (queued runs poll `PENDING` while executing). Acceptance and terminal error persistence still work. A warning is logged at startup. Use Postgres for sessions in production.
 </Warning>
 
 ## Idempotency keys
@@ -154,7 +154,7 @@ All fields on `QueueConfig`:
 | `deployment_id` | `None` | Claim affinity for mixed fleets. See [Operations](/agent-os/background-execution/operations#deployment-affinity). |
 | `lock_grace_seconds` | `60` | Seconds without a heartbeat before a claimed job counts as abandoned. Minimum 3. Heartbeats fire every third of this. |
 | `poll_interval` | `1.0` | Seconds an idle worker waits between claim passes. |
-| `retention_seconds` | `86400` | Terminal jobs older than this are deleted hourly. Paused tickets are exempt. |
+| `retention_seconds` | `86400` | Terminal jobs older than this are deleted hourly. Paused jobs are exempt. |
 | `stop_timeout_seconds` | `None` | Graceful-shutdown drain window. `None` means 30 seconds, clamped below `lock_grace_seconds`. Must be strictly below `lock_grace_seconds` when set. |
 | `serialize_sessions` | `True` | One live run per session, FIFO. `False` restores concurrent claiming. |
 

--- a/agent-os/background-execution/hitl-continuations.mdx
+++ b/agent-os/background-execution/hitl-continuations.mdx
@@ -87,7 +87,7 @@ Teams use `/teams/{team_id}/runs/{run_id}/continue` with `requirements`; workflo
 | Continuation claimed | `running` | Same |
 | Run finishes, or pauses again | `completed` / `paused` | Same |
 
-One row per run, ever. Poll, resume, cancel, and idempotency all key on the original `run_id` across any number of pause and continue cycles. A continuation gets exactly one execution regardless of `max_attempts`. A continuation leg that crashes is failed visibly and re-driven with [requeue](/agent-os/background-execution/operations#requeue), which replays the same confirmations.
+There is one row per run. Poll, resume, cancel, and idempotency all key on the original `run_id` across any number of pause and continue cycles. A continuation gets exactly one execution regardless of `max_attempts`. A continuation leg that crashes is failed visibly and re-driven with [requeue](/agent-os/background-execution/operations#requeue), which replays the same confirmations.
 
 ## Responses
 
@@ -102,13 +102,13 @@ One row per run, ever. Poll, resume, cancel, and idempotency all key on the orig
 
 ## Why inline continues are refused
 
-A ticket in `paused`, `queued`, or `running` owns its run's continuation. Every door that does not go through the queue (inline sync, inline SSE, MCP, AG-UI, Slack) refuses with `409`. Without that rule, an inline continue could validate against the run row while a durable continue validated against the ticket, and both could pass before either persisted. The result would be an approved tool executing twice. If the ticket cannot be looked up at all, the door fails closed with `503` rather than guessing.
+A ticket in `paused`, `queued`, or `running` owns its run's continuation. Every other continue path (inline sync, inline SSE, MCP, AG-UI, Slack) refuses with `409`. Without that rule, an inline continue could validate against the run row while a durable continue validated against the ticket, and both could pass before either persisted. An approved tool would then execute twice. If the ticket cannot be looked up at all, the request fails with `503` instead of proceeding unverified.
 
 Runs that never rode the queue, and `fork` or `regenerate` requests (which mint a new run), are unaffected.
 
 ## Cancel and retention
 
-Paused tickets are exempt from retention. A paused run waits for a human, and humans take arbitrary time, so the ticket is never cleaned up on age. An abandoned paused run therefore persists until something releases it:
+Paused tickets are exempt from retention. A paused run is waiting for a person, and there is no bound on how long that takes, so the ticket is never removed on age. An abandoned paused run persists until it is cancelled:
 
 ```bash
 curl -X POST "localhost:7777/agents/hitl-agent/runs/{run_id}/cancel?session_id={session_id}"

--- a/agent-os/background-execution/hitl-continuations.mdx
+++ b/agent-os/background-execution/hitl-continuations.mdx
@@ -1,0 +1,134 @@
+---
+title: Human-in-the-Loop Continuations
+description: "Continue a paused durable run through the queue with background=true. Same ticket, same run_id, one more attempt."
+---
+
+```python
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.job_queue.config import QueueConfig
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.tools import tool
+
+
+@tool(requires_confirmation=True)
+def delete_temp_files(directory: str) -> str:
+    """Delete temporary files in a directory. Requires human confirmation."""
+    return f"Deleted temp files in {directory}"
+
+
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+agent = Agent(
+    name="HITL Agent",
+    id="hitl-agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    tools=[delete_temp_files],
+    instructions="Use delete_temp_files when asked to delete or clean up files.",
+)
+
+agent_os = AgentOS(
+    agents=[agent],
+    db=db,
+    queue=QueueConfig(durable=True),
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="durable_continue:app", port=7777)
+```
+
+A durable run that pauses for confirmation parks its queue ticket as `paused`. Continuing it with `background=true` flips the same ticket back to `queued`, merges your confirmations into its payload, and lets whichever replica claims it finish the run. Kill the server after the `202` and restart it: the continuation still runs.
+
+## Flow
+
+<Steps>
+  <Step title="Submit">
+```bash
+curl -X POST localhost:7777/agents/hitl-agent/runs \
+  -F "message=Delete the temp files in /tmp/scratch" \
+  -F "background=true" -F "stream=false"
+```
+  </Step>
+  <Step title="Poll until PAUSED">
+```bash
+curl "localhost:7777/agents/hitl-agent/runs/{run_id}?session_id={session_id}"
+```
+    The response carries `status: "PAUSED"` and a `tools` array with the pending `delete_temp_files` call. The ticket is paused too: `GET /queue/jobs/{run_id}` shows `status: "paused"`.
+  </Step>
+  <Step title="Continue through the queue">
+    Set `confirmed: true` on the tool entry and send it back with `background=true`:
+```bash
+curl -X POST localhost:7777/agents/hitl-agent/runs/{run_id}/continue \
+  -F "session_id={session_id}" \
+  -F "background=true" -F "stream=false" \
+  -F 'tools=[{"tool_call_id": "...", "tool_name": "delete_temp_files", "confirmed": true, ...}]'
+```
+```json
+{"run_id": "{run_id}", "session_id": "{session_id}", "status": "PENDING"}
+```
+  </Step>
+  <Step title="Poll to completion">
+    The same poll URL returns `COMPLETED`. `GET /queue/jobs/{run_id}` shows `status: "completed"`, `attempt: 2`, `max_attempts: 2`.
+  </Step>
+</Steps>
+
+Teams use `/teams/{team_id}/runs/{run_id}/continue` with `requirements`; workflows use `/workflows/{workflow_id}/runs/{run_id}/continue` with `step_requirements`. The queue semantics are identical.
+
+## Ticket lifecycle
+
+| Event | Ticket status | `run_id` |
+|-------|---------------|----------|
+| Submission accepted | `queued` | Minted |
+| Worker claims | `running` | Same |
+| Run pauses for input | `paused` | Same |
+| Continue with `background=true` | `queued` (one more attempt granted) | Same |
+| Continuation claimed | `running` | Same |
+| Run finishes, or pauses again | `completed` / `paused` | Same |
+
+One row per run, ever. Poll, resume, cancel, and idempotency all key on the original `run_id` across any number of pause and continue cycles. A continuation gets exactly one execution regardless of `max_attempts`. A continuation leg that crashes is failed visibly and re-driven with [requeue](/agent-os/background-execution/operations#requeue), which replays the same confirmations.
+
+## Responses
+
+| Situation | Response |
+|-----------|----------|
+| Continue accepted | `202` with the same `run_id`. |
+| Second identical continue while the first is still queued | `202`. The second click attaches to the first. Its inputs are discarded. |
+| Continue while the run is settling between legs | `409` with `Retry-After: 1`. The window is the gap between two adjacent writes. Retry. |
+| Continue of a cancelled or finished run | `409`. |
+| Continue with `stream=true` on a run submitted with `stream=false` | `409`. The continuation would publish no events. Poll it. |
+| Continue **without** `background=true` on a queue-owned run | `409`: "Run ... was submitted through the durable queue; continue it with background=true". |
+
+## Why inline continues are refused
+
+A ticket in `paused`, `queued`, or `running` owns its run's continuation. Every door that does not go through the queue (inline sync, inline SSE, MCP, AG-UI, Slack) refuses with `409`. Without that rule, an inline continue could validate against the run row while a durable continue validated against the ticket, and both could pass before either persisted. The result would be an approved tool executing twice. If the ticket cannot be looked up at all, the door fails closed with `503` rather than guessing.
+
+Runs that never rode the queue, and `fork` or `regenerate` requests (which mint a new run), are unaffected.
+
+## Cancel and retention
+
+Paused tickets are exempt from retention. A paused run waits for a human, and humans take arbitrary time, so the ticket is never cleaned up on age. An abandoned paused run therefore persists until something releases it:
+
+```bash
+curl -X POST "localhost:7777/agents/hitl-agent/runs/{run_id}/cancel?session_id={session_id}"
+```
+
+Cancel moves the ticket to `cancelled` and the run row to `CANCELLED`. A later continue gets `409` instead of resurrecting the run.
+
+<Note>
+With `serialize_sessions=True` (the default), a paused run also holds its session's line. Later submissions to the same session wait until the paused run is continued or cancelled. See [Session serialization](/agent-os/background-execution/durable-queue#session-serialization).
+</Note>
+
+## Streaming continuations
+
+If the original submission used `stream=true`, continue with `stream=true` and `background=true` to receive an SSE tail of the post-approval events. Earlier events belong to `/resume`. Event indices keep increasing across the pause, so a client that resumes with its last index does not replay pre-approval history.
+
+## Next Steps
+
+| Task | Guide |
+|------|-------|
+| Re-drive a crashed continuation | [Requeue](/agent-os/background-execution/operations#requeue) |
+| Confirmation and approval flows in general | [Human-in-the-loop](/hitl/overview) |
+| Approvals from the Control Plane | [Approvals](/agent-os/approvals/overview) |

--- a/agent-os/background-execution/hitl-continuations.mdx
+++ b/agent-os/background-execution/hitl-continuations.mdx
@@ -1,6 +1,6 @@
 ---
 title: Human-in-the-Loop Continuations
-description: "Continue a paused durable run through the queue with background=true. Same ticket, same run_id, one more attempt."
+description: "Continue a paused durable run through the queue with background=true. Same job, same run_id, one more attempt."
 ---
 
 ```python
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     agent_os.serve(app="durable_continue:app", port=7777)
 ```
 
-A durable run that pauses for confirmation parks its queue ticket as `paused`. Continuing it with `background=true` flips the same ticket back to `queued`, merges your confirmations into its payload, and lets whichever replica claims it finish the run. Kill the server after the `202` and restart it: the continuation still runs.
+A durable run that pauses for confirmation parks its queue job as `paused`. Continuing it with `background=true` flips the same job back to `queued`, merges your confirmations into its payload, and lets whichever replica claims it finish the run. Kill the server after the `202` and restart it: the continuation still runs.
 
 ## Flow
 
@@ -55,7 +55,7 @@ curl -X POST localhost:7777/agents/hitl-agent/runs \
 ```bash
 curl "localhost:7777/agents/hitl-agent/runs/{run_id}?session_id={session_id}"
 ```
-    The response carries `status: "PAUSED"` and a `tools` array with the pending `delete_temp_files` call. The ticket is paused too: `GET /queue/jobs/{run_id}` shows `status: "paused"`.
+    The response carries `status: "PAUSED"` and a `tools` array with the pending `delete_temp_files` call. The job is paused too: `GET /queue/jobs/{run_id}` shows `status: "paused"`.
   </Step>
   <Step title="Continue through the queue">
     Set `confirmed: true` on the tool entry and send it back with `background=true`:
@@ -76,9 +76,9 @@ curl -X POST localhost:7777/agents/hitl-agent/runs/{run_id}/continue \
 
 Teams use `/teams/{team_id}/runs/{run_id}/continue` with `requirements`; workflows use `/workflows/{workflow_id}/runs/{run_id}/continue` with `step_requirements`. The queue semantics are identical.
 
-## Ticket lifecycle
+## Job lifecycle
 
-| Event | Ticket status | `run_id` |
+| Event | Job status | `run_id` |
 |-------|---------------|----------|
 | Submission accepted | `queued` | Minted |
 | Worker claims | `running` | Same |
@@ -87,7 +87,7 @@ Teams use `/teams/{team_id}/runs/{run_id}/continue` with `requirements`; workflo
 | Continuation claimed | `running` | Same |
 | Run finishes, or pauses again | `completed` / `paused` | Same |
 
-There is one row per run. Poll, resume, cancel, and idempotency all key on the original `run_id` across any number of pause and continue cycles. A continuation gets exactly one execution regardless of `max_attempts`. A continuation leg that crashes is failed visibly and re-driven with [requeue](/agent-os/background-execution/operations#requeue), which replays the same confirmations.
+There is one row per run. Poll, resume, cancel, and idempotency all key on the original `run_id` across any number of pause and continue cycles. A continuation gets exactly one execution regardless of `max_attempts`. A continuation that crashes is marked failed and re-driven with [requeue](/agent-os/background-execution/operations#requeue), which replays the same confirmations.
 
 ## Responses
 
@@ -95,26 +95,26 @@ There is one row per run. Poll, resume, cancel, and idempotency all key on the o
 |-----------|----------|
 | Continue accepted | `202` with the same `run_id`. |
 | Second identical continue while the first is still queued | `202`. The second click attaches to the first. Its inputs are discarded. |
-| Continue while the run is settling between legs | `409` with `Retry-After: 1`. The window is the gap between two adjacent writes. Retry. |
+| Continue while the run is transitioning between the pause and the continuation | `409` with `Retry-After: 1`. The window is the gap between two adjacent writes. Retry. |
 | Continue of a cancelled or finished run | `409`. |
 | Continue with `stream=true` on a run submitted with `stream=false` | `409`. The continuation would publish no events. Poll it. |
 | Continue **without** `background=true` on a queue-owned run | `409`: "Run ... was submitted through the durable queue; continue it with background=true". |
 
 ## Why inline continues are refused
 
-A ticket in `paused`, `queued`, or `running` owns its run's continuation. Every other continue path (inline sync, inline SSE, MCP, AG-UI, Slack) refuses with `409`. Without that rule, an inline continue could validate against the run row while a durable continue validated against the ticket, and both could pass before either persisted. An approved tool would then execute twice. If the ticket cannot be looked up at all, the request fails with `503` instead of proceeding unverified.
+A job in `paused`, `queued`, or `running` owns its run's continuation. Every other continue path (inline sync, inline SSE, MCP, AG-UI, Slack) refuses with `409`. Without that rule, an inline continue could validate against the run row while a durable continue validated against the job, and both could pass before either persisted. An approved tool would then execute twice. If the job cannot be looked up at all, the request fails with `503` instead of proceeding unverified.
 
 Runs that never rode the queue, and `fork` or `regenerate` requests (which mint a new run), are unaffected.
 
 ## Cancel and retention
 
-Paused tickets are exempt from retention. A paused run is waiting for a person, and there is no bound on how long that takes, so the ticket is never removed on age. An abandoned paused run persists until it is cancelled:
+Paused jobs are exempt from retention. A paused run is waiting for a person, and there is no bound on how long that takes, so the job is never removed on age. An abandoned paused run persists until it is cancelled:
 
 ```bash
 curl -X POST "localhost:7777/agents/hitl-agent/runs/{run_id}/cancel?session_id={session_id}"
 ```
 
-Cancel moves the ticket to `cancelled` and the run row to `CANCELLED`. A later continue gets `409` instead of resurrecting the run.
+Cancel moves the job to `cancelled` and the run row to `CANCELLED`. A later continue gets `409` instead of resurrecting the run.
 
 <Note>
 With `serialize_sessions=True` (the default), a paused run also holds its session's line. Later submissions to the same session wait until the paused run is continued or cancelled. See [Session serialization](/agent-os/background-execution/durable-queue#session-serialization).

--- a/agent-os/background-execution/hitl-continuations.mdx
+++ b/agent-os/background-execution/hitl-continuations.mdx
@@ -6,9 +6,8 @@ description: "Continue a paused durable run through the queue with background=tr
 ```python
 from agno.agent import Agent
 from agno.db.postgres import PostgresDb
-from agno.job_queue.config import QueueConfig
 from agno.models.openai import OpenAIResponses
-from agno.os import AgentOS
+from agno.os import AgentOS, QueueConfig
 from agno.tools import tool
 
 

--- a/agent-os/background-execution/multi-replica.mdx
+++ b/agent-os/background-execution/multi-replica.mdx
@@ -48,9 +48,16 @@ A background run started on replica A may execute on replica B, while the client
 
 Start a streaming run against one replica, then call `/resume` on another. Events replay and tail from Redis regardless of which replica executes the run.
 
-## The cancellation manager is set per replica
+## Both managers are set per replica
 
-In v2, cross-replica cancellation meant constructing `RedisRunCancellationManager` yourself and calling `set_cancellation_manager()` in every process. `queue.redis` does that for you: `AgentOS(...)` installs the Redis cancellation manager and the Redis event stream on the replica that constructs it, so every replica in the fleet is wired identically from one line of config.
+`queue.redis` installs two process-wide managers on the replica that constructs `AgentOS(...)`:
+
+| Manager | Default | Redis backend | Explicit setter |
+|---------|---------|---------------|-----------------|
+| Cancellation manager (`BaseRunCancellationManager`) | In-memory | `RedisRunCancellationManager` | `set_cancellation_manager()` |
+| Event stream (`BaseEventStream`) | `InMemoryEventStream` | `RedisEventStream` | `set_event_stream()` or `AgentOS(event_stream=...)` |
+
+In v2, cross-replica cancellation meant constructing `RedisRunCancellationManager` yourself and calling `set_cancellation_manager()` in every process, and the event buffer had no shared backend at all. `queue.redis` wires both from one line of config, so every replica in the fleet is set up identically.
 
 ```python
 # v2
@@ -63,7 +70,7 @@ set_cancellation_manager(RedisRunCancellationManager(redis_client=..., async_red
 agent_os = AgentOS(agents=[agent], db=db, queue=QueueConfig(redis="redis://localhost:6379"))
 ```
 
-An explicit `set_cancellation_manager()` call still wins. `queue.redis` only replaces the in-memory default, never a manager you installed yourself, so a [custom cancellation manager](/examples/agents/advanced/custom-cancellation-manager) keeps working. Cancellation keys are namespaced under `{key_prefix}:run:cancellation:` when `key_prefix` is set.
+An explicit setter still wins for either manager. `queue.redis` only replaces defaults, never a backend you installed yourself, so a [custom cancellation manager](/examples/agents/advanced/custom-cancellation-manager) or an `AgentOS(event_stream=...)` override keeps working. Keys are namespaced under `{key_prefix}:run:cancellation:` and `{key_prefix}:os:events:` when `key_prefix` is set.
 
 ## Two Redis roles
 

--- a/agent-os/background-execution/multi-replica.mdx
+++ b/agent-os/background-execution/multi-replica.mdx
@@ -70,9 +70,9 @@ Start a streaming run against one replica, then call `/resume` on another. Event
 | Setting | Role | Persistence | What a Redis fault costs |
 |---------|------|-------------|--------------------------|
 | `QueueConfig(redis=...)` | Coordination: event streams, cancel signals | None needed. Keys carry TTLs and are rebuilt from the database. | The live view degrades. Runs still execute and complete. Nothing is corrupted or stranded. |
-| `QueueConfig(db=RedisDb(...))` | Ticket storage: the queue table itself | AOF with `appendfsync everysec` or `always`. | Recently accepted jobs can be lost on a Redis crash under default RDB snapshotting. |
+| `QueueConfig(db=RedisDb(...))` | Job storage: the queue table itself | AOF with `appendfsync everysec` or `always`. | Recently accepted jobs can be lost on a Redis crash under default RDB snapshotting. |
 
-A common production layout is Postgres for `db` (truth and tickets) and a plain Redis or Valkey for `redis` (coordination). Pointing both at one Redis works, as in the [Redis event stream cookbook](https://github.com/agno-agi/agno/blob/feat/v3.0/cookbook/05_agent_os/background_tasks/redis_event_stream.py), but the persistence requirement then applies to it.
+A common production layout is Postgres for `db` (truth and jobs) and a plain Redis or Valkey for `redis` (coordination). Pointing both at one Redis works, as in the [Redis event stream cookbook](https://github.com/agno-agi/agno/blob/feat/v3.0/cookbook/05_agent_os/background_tasks/redis_event_stream.py), but the persistence requirement then applies to it.
 
 ## Connection options
 
@@ -108,7 +108,7 @@ Per-run stream keys expire 30 minutes after the last activity, refreshed while t
 
 ## Without Redis on multiple replicas
 
-Durable execution still works: tickets live in the database and any replica can claim them. The live view does not. A streaming submission accepted on replica A whose ticket is claimed by replica B produces a tail that idles until the client times out, even though the run completes. AgentOS logs this at startup:
+Durable execution still works: jobs live in the database and any replica can claim them. The live view does not. A streaming submission accepted on replica A whose job is claimed by replica B produces a tail that idles until the client times out, even though the run completes. AgentOS logs this at startup:
 
 ```
 Durable queue with the in-memory event stream: streamed views of queued runs

--- a/agent-os/background-execution/multi-replica.mdx
+++ b/agent-os/background-execution/multi-replica.mdx
@@ -6,9 +6,8 @@ description: "QueueConfig(redis=...) carries live events out and cancel signals 
 ```python
 from agno.agent import Agent
 from agno.db.postgres import PostgresDb
-from agno.job_queue.config import QueueConfig
 from agno.models.openai import OpenAIResponses
-from agno.os import AgentOS
+from agno.os import AgentOS, QueueConfig
 
 db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 
@@ -68,7 +67,7 @@ Pass a URL for the common case, or `RedisCoordination` to inject clients:
 from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
 
-from agno.job_queue.config import QueueConfig, RedisCoordination
+from agno.os import QueueConfig, RedisCoordination
 
 queue = QueueConfig(
     durable=True,

--- a/agent-os/background-execution/multi-replica.mdx
+++ b/agent-os/background-execution/multi-replica.mdx
@@ -1,0 +1,112 @@
+---
+title: Multi-Replica Deployments
+description: "QueueConfig(redis=...) carries live events out and cancel signals in between AgentOS replicas."
+---
+
+```python
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.job_queue.config import QueueConfig
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+agent = Agent(
+    name="Resumable Stream Agent",
+    id="resumable-stream-agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+)
+
+agent_os = AgentOS(
+    agents=[agent],
+    db=db,
+    queue=QueueConfig(
+        durable=True,
+        redis="redis://localhost:6379",
+    ),
+)
+app = agent_os.get_app()
+```
+
+```bash
+pip install redis
+```
+
+Set `redis` exactly when you run more than one replica. With one replica, in-process defaults do the same job.
+
+## Two directions, one setting
+
+A background run started on replica A may execute on replica B, while the client's next request lands on replica C. Two things have to cross replica boundaries:
+
+| Direction | What | Endpoint it serves |
+|-----------|------|--------------------|
+| Events out | The executing worker publishes run events to a Redis stream. Any replica can tail or replay them. | `POST /agents/{agent_id}/runs/{run_id}/resume`, streaming submissions and continues |
+| Cancel in | A cancel received by any replica is recorded in Redis. The executing worker sees it at its next checkpoint. | `POST /agents/{agent_id}/runs/{run_id}/cancel` |
+
+`redis` wires both from shared clients. Configuring only one is the classic half-working deployment: cancels reach every replica while resumed streams idle on the wrong one, or the reverse. If you configure a transport explicitly (`AgentOS(event_stream=...)` or `set_cancellation_manager()`), that configuration wins and `redis` fills in only the other one, with a warning that the two now ride different backends.
+
+Start a streaming run against one replica, then call `/resume` on another. Events replay and tail from Redis regardless of which replica executes the run.
+
+## Two Redis roles
+
+`queue.redis` and `db=RedisDb(...)` are different jobs. Users conflate them.
+
+| Setting | Role | Persistence | What a Redis fault costs |
+|---------|------|-------------|--------------------------|
+| `QueueConfig(redis=...)` | Coordination: event streams, cancel signals | None needed. Keys carry TTLs and are rebuilt from the database. | The live view degrades. Runs still execute and complete. Nothing is corrupted or stranded. |
+| `QueueConfig(db=RedisDb(...))` | Ticket storage: the queue table itself | AOF with `appendfsync everysec` or `always`. | Recently accepted jobs can be lost on a Redis crash under default RDB snapshotting. |
+
+A common production layout is Postgres for `db` (truth and tickets) and a plain Redis or Valkey for `redis` (coordination). Pointing both at one Redis works, as in the [Redis event stream cookbook](https://github.com/agno-agi/agno/blob/feat/v3.0/cookbook/05_agent_os/background_tasks/redis_event_stream.py), but the persistence requirement then applies to it.
+
+## Connection options
+
+Pass a URL for the common case, or `RedisCoordination` to inject clients:
+
+```python
+from redis import Redis
+from redis.asyncio import Redis as AsyncRedis
+
+from agno.job_queue.config import QueueConfig, RedisCoordination
+
+queue = QueueConfig(
+    durable=True,
+    redis=RedisCoordination(
+        sync_client=Redis.from_url("redis://localhost:6379"),
+        async_client=AsyncRedis.from_url("redis://localhost:6379"),
+        key_prefix="checkout-os",
+    ),
+)
+```
+
+| Field | Description |
+|-------|-------------|
+| `url` | Redis URL. Clients are constructed for you. |
+| `sync_client`, `async_client` | Existing clients. Both are required together. The cancellation manager needs both; the event stream uses the async one. |
+| `key_prefix` | Namespace for every coordination key. Set a per-deployment value when several AgentOS deployments share one Redis. With the default, they read each other's runs by `run_id`. |
+
+Valkey works anywhere Redis does. A `RedisCluster` client is rejected for the queue store.
+
+## Stream retention
+
+Per-run stream keys expire 30 minutes after the last activity, refreshed while the run is live. Each stream keeps roughly the most recent 10,000 events. A client that reconnects after expiry gets the persisted events from the database through `/resume` with `session_id`, not the live tail.
+
+## Without Redis on multiple replicas
+
+Durable execution still works: tickets live in the database and any replica can claim them. The live view does not. A streaming submission accepted on replica A whose ticket is claimed by replica B produces a tail that idles until the client times out, even though the run completes. AgentOS logs this at startup:
+
+```
+Durable queue with the in-memory event stream: streamed views of queued runs
+are replica-local. ... Set queue.redis to wire a shared event stream.
+```
+
+Polling is unaffected, because the run row is in the database.
+
+## Next Steps
+
+| Task | Guide |
+|------|-------|
+| Pin jobs to a subset of replicas | [Deployment affinity](/agent-os/background-execution/operations#deployment-affinity) |
+| Keep timing settings consistent across the fleet | [Fleet-wide settings](/agent-os/background-execution/operations#fleet-wide-settings) |
+| SSE resume protocol and meta events | [Background Execution (SDK)](/background-execution/overview) |

--- a/agent-os/background-execution/multi-replica.mdx
+++ b/agent-os/background-execution/multi-replica.mdx
@@ -1,6 +1,6 @@
 ---
 title: Multi-Replica Deployments
-description: "QueueConfig(redis=...) carries live events out and cancel signals in between AgentOS replicas."
+description: "QueueConfig(redis=...) sets the event stream and cancellation manager on every replica so runs can be resumed and cancelled from any of them."
 ---
 
 ```python
@@ -37,14 +37,14 @@ Set `redis` exactly when you run more than one replica. With one replica, in-pro
 
 ## One setting, two managers
 
-`queue.redis` sets **both** the event stream and the cancellation manager on every replica that constructs `AgentOS(...)`. There is nothing else to wire.
+`queue.redis` sets **both** the event stream and the cancellation manager on every replica that constructs `AgentOS(...)`. No other wiring is needed.
 
 | Manager | Direction | Default | Set by `queue.redis` to | Explicit setter |
 |---------|-----------|---------|--------------------------|-----------------|
 | Event stream (`BaseEventStream`) | Events **out**: the executing worker publishes run events; any replica can tail or replay them for `/resume`, streaming submissions, and continues. | `InMemoryEventStream` | `RedisEventStream` | `set_event_stream()` or `AgentOS(event_stream=...)` |
 | Cancellation manager (`BaseRunCancellationManager`) | Cancel **in**: a `/cancel` received by any replica is recorded in Redis; the executing worker sees it at its next checkpoint. | In-memory | `RedisRunCancellationManager` | `set_cancellation_manager()` |
 
-A background run started on replica A may execute on replica B while the client's next request lands on replica C. Both directions have to cross replica boundaries. Configuring only one is the classic half-working deployment: cancels reach every replica while resumed streams idle on the wrong one, or the reverse. That is why one setting wires both.
+A background run started on replica A may execute on replica B while the client's next request lands on replica C. Both directions have to cross replica boundaries. Configuring only one is a common misconfiguration: cancels reach every replica while resumed streams idle on the wrong one, or the reverse. One setting covers both so that cannot happen by accident.
 
 In v2, cross-replica cancellation meant constructing `RedisRunCancellationManager` yourself and calling `set_cancellation_manager()` in every process, and the event buffer had no shared backend at all.
 
@@ -65,7 +65,7 @@ Start a streaming run against one replica, then call `/resume` on another. Event
 
 ## Two Redis roles
 
-`queue.redis` and `db=RedisDb(...)` are different jobs. Users conflate them.
+`queue.redis` and `db=RedisDb(...)` are different settings with different requirements.
 
 | Setting | Role | Persistence | What a Redis fault costs |
 |---------|------|-------------|--------------------------|

--- a/agent-os/background-execution/multi-replica.mdx
+++ b/agent-os/background-execution/multi-replica.mdx
@@ -35,42 +35,33 @@ pip install redis
 
 Set `redis` exactly when you run more than one replica. With one replica, in-process defaults do the same job.
 
-## Two directions, one setting
+## One setting, two managers
 
-A background run started on replica A may execute on replica B, while the client's next request lands on replica C. Two things have to cross replica boundaries:
+`queue.redis` sets **both** the event stream and the cancellation manager on every replica that constructs `AgentOS(...)`. There is nothing else to wire.
 
-| Direction | What | Endpoint it serves |
-|-----------|------|--------------------|
-| Events out | The executing worker publishes run events to a Redis stream. Any replica can tail or replay them. | `POST /agents/{agent_id}/runs/{run_id}/resume`, streaming submissions and continues |
-| Cancel in | A cancel received by any replica is recorded in Redis. The executing worker sees it at its next checkpoint. | `POST /agents/{agent_id}/runs/{run_id}/cancel` |
+| Manager | Direction | Default | Set by `queue.redis` to | Explicit setter |
+|---------|-----------|---------|--------------------------|-----------------|
+| Event stream (`BaseEventStream`) | Events **out**: the executing worker publishes run events; any replica can tail or replay them for `/resume`, streaming submissions, and continues. | `InMemoryEventStream` | `RedisEventStream` | `set_event_stream()` or `AgentOS(event_stream=...)` |
+| Cancellation manager (`BaseRunCancellationManager`) | Cancel **in**: a `/cancel` received by any replica is recorded in Redis; the executing worker sees it at its next checkpoint. | In-memory | `RedisRunCancellationManager` | `set_cancellation_manager()` |
 
-`redis` wires both from shared clients. Configuring only one is the classic half-working deployment: cancels reach every replica while resumed streams idle on the wrong one, or the reverse. If you configure a transport explicitly (`AgentOS(event_stream=...)` or `set_cancellation_manager()`), that configuration wins and `redis` fills in only the other one, with a warning that the two now ride different backends.
+A background run started on replica A may execute on replica B while the client's next request lands on replica C. Both directions have to cross replica boundaries. Configuring only one is the classic half-working deployment: cancels reach every replica while resumed streams idle on the wrong one, or the reverse. That is why one setting wires both.
 
-Start a streaming run against one replica, then call `/resume` on another. Events replay and tail from Redis regardless of which replica executes the run.
-
-## Both managers are set per replica
-
-`queue.redis` installs two process-wide managers on the replica that constructs `AgentOS(...)`:
-
-| Manager | Default | Redis backend | Explicit setter |
-|---------|---------|---------------|-----------------|
-| Cancellation manager (`BaseRunCancellationManager`) | In-memory | `RedisRunCancellationManager` | `set_cancellation_manager()` |
-| Event stream (`BaseEventStream`) | `InMemoryEventStream` | `RedisEventStream` | `set_event_stream()` or `AgentOS(event_stream=...)` |
-
-In v2, cross-replica cancellation meant constructing `RedisRunCancellationManager` yourself and calling `set_cancellation_manager()` in every process, and the event buffer had no shared backend at all. `queue.redis` wires both from one line of config, so every replica in the fleet is set up identically.
+In v2, cross-replica cancellation meant constructing `RedisRunCancellationManager` yourself and calling `set_cancellation_manager()` in every process, and the event buffer had no shared backend at all.
 
 ```python
-# v2
+# v2: cancellation only, wired by hand in every process
 from agno.run.cancel import set_cancellation_manager
 from agno.run.cancellation_management.redis_cancellation_manager import RedisRunCancellationManager
 
 set_cancellation_manager(RedisRunCancellationManager(redis_client=..., async_redis_client=...))
 
-# v3
+# v3: event stream and cancellation manager, from one setting
 agent_os = AgentOS(agents=[agent], db=db, queue=QueueConfig(redis="redis://localhost:6379"))
 ```
 
-An explicit setter still wins for either manager. `queue.redis` only replaces defaults, never a backend you installed yourself, so a [custom cancellation manager](/examples/agents/advanced/custom-cancellation-manager) or an `AgentOS(event_stream=...)` override keeps working. Keys are namespaced under `{key_prefix}:run:cancellation:` and `{key_prefix}:os:events:` when `key_prefix` is set.
+An explicit setter still wins for either manager. `queue.redis` only replaces defaults, never a backend you installed yourself, so a [custom cancellation manager](/examples/agents/advanced/custom-cancellation-manager) or an `AgentOS(event_stream=...)` override keeps working. If exactly one of the two is explicit, AgentOS logs a warning that cancellation and events may ride different Redis instances. Keys are namespaced under `{key_prefix}:run:cancellation:` and `{key_prefix}:os:events:` when `key_prefix` is set.
+
+Start a streaming run against one replica, then call `/resume` on another. Events replay and tail from Redis regardless of which replica executes the run.
 
 ## Two Redis roles
 

--- a/agent-os/background-execution/multi-replica.mdx
+++ b/agent-os/background-execution/multi-replica.mdx
@@ -48,6 +48,23 @@ A background run started on replica A may execute on replica B, while the client
 
 Start a streaming run against one replica, then call `/resume` on another. Events replay and tail from Redis regardless of which replica executes the run.
 
+## The cancellation manager is set per replica
+
+In v2, cross-replica cancellation meant constructing `RedisRunCancellationManager` yourself and calling `set_cancellation_manager()` in every process. `queue.redis` does that for you: `AgentOS(...)` installs the Redis cancellation manager and the Redis event stream on the replica that constructs it, so every replica in the fleet is wired identically from one line of config.
+
+```python
+# v2
+from agno.run.cancel import set_cancellation_manager
+from agno.run.cancellation_management.redis_cancellation_manager import RedisRunCancellationManager
+
+set_cancellation_manager(RedisRunCancellationManager(redis_client=..., async_redis_client=...))
+
+# v3
+agent_os = AgentOS(agents=[agent], db=db, queue=QueueConfig(redis="redis://localhost:6379"))
+```
+
+An explicit `set_cancellation_manager()` call still wins. `queue.redis` only replaces the in-memory default, never a manager you installed yourself, so a [custom cancellation manager](/examples/agents/advanced/custom-cancellation-manager) keeps working. Cancellation keys are namespaced under `{key_prefix}:run:cancellation:` when `key_prefix` is set.
+
 ## Two Redis roles
 
 `queue.redis` and `db=RedisDb(...)` are different jobs. Users conflate them.

--- a/agent-os/background-execution/operations.mdx
+++ b/agent-os/background-execution/operations.mdx
@@ -3,7 +3,7 @@ title: Operations and Monitoring
 description: "The /queue endpoints: dead-letter listing, requeue, queue stats, retention, admin gating, and deployment affinity."
 ---
 
-The durable queue mounts an operator surface under `/queue`. With `max_attempts=1`, every crash is a dead end until someone looks, so these endpoints exist to see failed jobs, grant them another attempt, and watch queue depth.
+The durable queue mounts an operator surface under `/queue`. With the default `max_attempts=1`, a crashed run stays failed until an operator acts, so these endpoints list failed jobs, grant them another attempt, and report queue depth.
 
 ```bash
 curl localhost:7777/queue/stats
@@ -62,11 +62,11 @@ Requeue raises `max_attempts` to `attempt + 1` and moves the ticket back to `que
 | `clear_cancellation` | `false` | Requeueing a job that was cancelled. A recorded cancel is never cleared automatically. Without this flag the re-driven attempt is cancelled again at its first checkpoint, visibly. Set `true` as the explicit operator override. |
 | `force` | `false` | Requeueing a job that failed within the last `lock_grace_seconds`. Its worker may still be executing (a sweep proves heartbeats stopped, not that execution did). The request answers `409` until the grace elapses unless `force=true`. |
 
-Requeue never bypasses the fencing: if the presumed-dead worker finishes after all, the attempt that started later wins the ticket and the earlier one's late writes are discarded.
+Requeue does not bypass attempt fencing. If the presumed-dead worker finishes after all, the later attempt owns the ticket and the earlier one's writes are discarded.
 
 ## Stats and alerting
 
-`/queue/stats` returns two things worth alerting on:
+The signals to alert on:
 
 | Signal | Meaning |
 |--------|---------|
@@ -96,7 +96,7 @@ queue=QueueConfig(durable=True, deployment_id="gpu-pool")
 | `deployment_id=None` (default) | Unstamped jobs | Unstamped jobs only |
 | `deployment_id="gpu-pool"` | Jobs stamped `gpu-pool` | Unstamped jobs and jobs stamped `gpu-pool` |
 
-A mixed fleet is safe by construction. A continuation inherits the submitting job's stamp.
+A mixed fleet needs no extra configuration. A continuation inherits the submitting job's stamp.
 
 <Warning>
 Jobs stamped for a deployment with no live workers wait forever. They are queued, not stale, so no sweep touches them and no error is raised. The symptom is `oldest_queued_age_seconds` climbing in `/queue/stats`. Sweeping is not affinity-filtered: any replica can fail a stale job, because that only records a failure that already happened.

--- a/agent-os/background-execution/operations.mdx
+++ b/agent-os/background-execution/operations.mdx
@@ -19,7 +19,7 @@ curl localhost:7777/queue/stats
 |--------|------|---------|
 | `GET` | `/queue/stats` | Job counts by status and the oldest queued job's age in seconds. |
 | `GET` | `/queue/jobs` | Paginated job listing. `status` is repeatable. `status=failed` alone is the dead-letter list. |
-| `GET` | `/queue/jobs/{job_id}` | One ticket. `job_id` equals the run's `run_id`. |
+| `GET` | `/queue/jobs/{job_id}` | One job. `job_id` equals the run's `run_id`. |
 | `POST` | `/queue/jobs/{job_id}/requeue` | Grant a `failed` or `cancelled` job one more execution. |
 
 All four answer `503` when the durable queue is not enabled on the replica that served the request.
@@ -55,14 +55,14 @@ All four answer `503` when the durable queue is not enabled on the replica that 
 curl -X POST localhost:7777/queue/jobs/{job_id}/requeue
 ```
 
-Requeue raises `max_attempts` to `attempt + 1` and moves the ticket back to `queued`. Only `failed` and `cancelled` jobs qualify; anything else answers `400`. The replica that served the request claims the job immediately if it has capacity.
+Requeue raises `max_attempts` to `attempt + 1` and moves the job back to `queued`. Only `failed` and `cancelled` jobs qualify; anything else answers `400`. The replica that served the request claims the job immediately if it has capacity.
 
 | Query parameter | Default | When to set it |
 |-----------------|---------|----------------|
 | `clear_cancellation` | `false` | Requeueing a job that was cancelled. A recorded cancel is never cleared automatically. Without this flag the re-driven attempt is cancelled again at its first checkpoint, visibly. Set `true` as the explicit operator override. |
 | `force` | `false` | Requeueing a job that failed within the last `lock_grace_seconds`. Its worker may still be executing (a sweep proves heartbeats stopped, not that execution did). The request answers `409` until the grace elapses unless `force=true`. |
 
-Requeue does not bypass attempt fencing. If the presumed-dead worker finishes after all, the later attempt owns the ticket and the earlier one's writes are discarded.
+Requeue does not bypass attempt fencing. If the presumed-dead worker finishes after all, the later attempt owns the job and the earlier one's writes are discarded.
 
 ## Stats and alerting
 
@@ -77,7 +77,7 @@ The signals to alert on:
 
 ## Retention
 
-Once an hour, the worker deletes terminal jobs (`completed`, `failed`, `cancelled`) older than `retention_seconds` (default 24 hours). Paused tickets are exempt: a paused run's ticket is what a later continue re-queues, and it must outlive human latency. Cancel a paused run to release its ticket. Run rows and sessions are not touched by queue retention.
+Once an hour, the worker deletes terminal jobs (`completed`, `failed`, `cancelled`) older than `retention_seconds` (default 24 hours). Paused jobs are exempt: a paused run's job is what a later continue re-queues, and it must outlive human latency. Cancel a paused run to release its job. Run rows and sessions are not touched by queue retention.
 
 ## Access control
 
@@ -93,18 +93,18 @@ queue=QueueConfig(durable=True, deployment_id="gpu-pool")
 
 | Replica setting | Enqueues | Claims |
 |-----------------|----------|--------|
-| `deployment_id=None` (default) | Unstamped jobs | Unstamped jobs only |
-| `deployment_id="gpu-pool"` | Jobs stamped `gpu-pool` | Unstamped jobs and jobs stamped `gpu-pool` |
+| `deployment_id=None` (default) | Jobs with no `deployment_id` | Jobs with no `deployment_id` |
+| `deployment_id="gpu-pool"` | Jobs with `deployment_id="gpu-pool"` | Jobs with no `deployment_id` and jobs with `deployment_id="gpu-pool"` |
 
-A mixed fleet needs no extra configuration. A continuation inherits the submitting job's stamp.
+A mixed fleet needs no extra configuration. A continuation inherits the submitting job's `deployment_id`.
 
 <Warning>
-Jobs stamped for a deployment with no live workers wait forever. They are queued, not stale, so no sweep touches them and no error is raised. The symptom is `oldest_queued_age_seconds` climbing in `/queue/stats`. Sweeping is not affinity-filtered: any replica can fail a stale job, because that only records a failure that already happened.
+Jobs with a `deployment_id` that no live worker matches wait forever. They are queued, not stale, so no sweep touches them and no error is raised. The symptom is `oldest_queued_age_seconds` climbing in `/queue/stats`. Sweeping is not affinity-filtered: any replica can fail a stale job, because that only records a failure that already happened.
 </Warning>
 
 ## Fleet-wide settings
 
-Every replica sharing one queue table must use the same values for `lock_grace_seconds`, `stop_timeout_seconds`, `retention_seconds`, `max_attempts`, and `timeout_seconds`. Each is applied by whichever replica performs the action: the claimer's grace sets its heartbeat cadence while the sweeper's grace judges staleness, `max_attempts` is stamped per ticket by the accepting replica, and the smallest `retention_seconds` in the fleet wins the hourly cleanup. Divergent values, including transiently during a rolling deploy, can falsely sweep a healthy peer's runs or delete tickets early.
+Every replica sharing one queue table must use the same values for `lock_grace_seconds`, `stop_timeout_seconds`, `retention_seconds`, `max_attempts`, and `timeout_seconds`. Each is applied by whichever replica performs the action. The replica that claims a job heartbeats on its own `lock_grace_seconds`, while the replica that sweeps judges staleness on its own value. `max_attempts` is written onto each job by the replica that accepted it. The smallest `retention_seconds` in the fleet wins the hourly cleanup. Divergent values, including transiently during a rolling deploy, can falsely sweep a healthy peer's runs or delete jobs early.
 
 When changing `lock_grace_seconds` on a live fleet, only ever raise it, and roll the sweeping replicas first. A replica sweeping with a smaller grace than its peers heartbeat with judges their live leases stale.
 

--- a/agent-os/background-execution/operations.mdx
+++ b/agent-os/background-execution/operations.mdx
@@ -1,0 +1,121 @@
+---
+title: Operations and Monitoring
+description: "The /queue endpoints: dead-letter listing, requeue, queue stats, retention, admin gating, and deployment affinity."
+---
+
+The durable queue mounts an operator surface under `/queue`. With `max_attempts=1`, every crash is a dead end until someone looks, so these endpoints exist to see failed jobs, grant them another attempt, and watch queue depth.
+
+```bash
+curl localhost:7777/queue/stats
+```
+
+```json
+{"counts": {"completed": 3, "cancelled": 1, "running": 1}, "oldest_queued_age_seconds": null}
+```
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/queue/stats` | Job counts by status and the oldest queued job's age in seconds. |
+| `GET` | `/queue/jobs` | Paginated job listing. `status` is repeatable. `status=failed` alone is the dead-letter list. |
+| `GET` | `/queue/jobs/{job_id}` | One ticket. `job_id` equals the run's `run_id`. |
+| `POST` | `/queue/jobs/{job_id}/requeue` | Grant a `failed` or `cancelled` job one more execution. |
+
+All four answer `503` when the durable queue is not enabled on the replica that served the request.
+
+### Listing parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `status` | all | One of `queued`, `running`, `completed`, `failed`, `cancelled`, `paused`. Repeat to match several: `status=failed&status=cancelled`. |
+| `limit` | `20` | Jobs per page, 1 to 1000. |
+| `page` | `1` | Page number. |
+| `sort_by` | `created_at` | Also `updated_at`, `completed_at`, `status`, `attempt`, `component_type`, `component_id`, `user_id`. Unknown fields are ignored. |
+| `sort_order` | `desc` | `asc` or `desc`. |
+
+### Job fields
+
+| Field | Description |
+|-------|-------------|
+| `id` | The run's `run_id`. |
+| `component_type`, `component_id` | `agent`, `team`, or `workflow`, and which one. |
+| `session_id`, `user_id` | Session and user the run was submitted for. |
+| `status` | `queued`, `running`, `completed`, `failed`, `cancelled`, or `paused`. |
+| `attempt`, `max_attempts` | Executions started so far, and the budget. |
+| `error` | Terminal error of the last attempt. |
+| `locked_by`, `locked_at` | Worker holding the lease and when it was last refreshed. |
+| `idempotency_key` | Client-provided key, if any. |
+| `payload` | Serialized run parameters. Contains verbatim user input. |
+| `created_at`, `updated_at`, `completed_at` | Epoch seconds. |
+
+## Requeue
+
+```bash
+curl -X POST localhost:7777/queue/jobs/{job_id}/requeue
+```
+
+Requeue raises `max_attempts` to `attempt + 1` and moves the ticket back to `queued`. Only `failed` and `cancelled` jobs qualify; anything else answers `400`. The replica that served the request claims the job immediately if it has capacity.
+
+| Query parameter | Default | When to set it |
+|-----------------|---------|----------------|
+| `clear_cancellation` | `false` | Requeueing a job that was cancelled. A recorded cancel is never cleared automatically. Without this flag the re-driven attempt is cancelled again at its first checkpoint, visibly. Set `true` as the explicit operator override. |
+| `force` | `false` | Requeueing a job that failed within the last `lock_grace_seconds`. Its worker may still be executing (a sweep proves heartbeats stopped, not that execution did). The request answers `409` until the grace elapses unless `force=true`. |
+
+Requeue never bypasses the fencing: if the presumed-dead worker finishes after all, the attempt that started later wins the ticket and the earlier one's late writes are discarded.
+
+## Stats and alerting
+
+`/queue/stats` returns two things worth alerting on:
+
+| Signal | Meaning |
+|--------|---------|
+| `counts.queued` trending up | Submissions outpace execution. Add replicas or raise `max_concurrency`. Submissions get `429` at `max_queue_depth`. |
+| `oldest_queued_age_seconds` growing | Something claimable is not being claimed. Usually a [deployment affinity](#deployment-affinity) mismatch, or every replica at capacity. |
+| `counts.failed` | The dead-letter backlog. |
+| `counts.paused` | Runs waiting on a human. Each one holds its session's line. |
+
+## Retention
+
+Once an hour, the worker deletes terminal jobs (`completed`, `failed`, `cancelled`) older than `retention_seconds` (default 24 hours). Paused tickets are exempt: a paused run's ticket is what a later continue re-queues, and it must outlive human latency. Cancel a paused run to release its ticket. Run rows and sessions are not touched by queue retention.
+
+## Access control
+
+Job rows expose payloads and user IDs across tenants, and requeue grants execution budget, so `/queue` is an operator surface. Any request carrying a JWT identity must hold the admin scope, or it gets `403`, regardless of whether user isolation is on. Deployments without JWT enforcement (security key or open) pass through, matching how the run routes treat scope enforcement. See [JWT middleware](/agent-os/middleware/jwt) and [Scopes](/agent-os/security/authorization/scopes).
+
+## Deployment affinity
+
+`deployment_id` pins jobs to a subset of workers in a heterogeneous fleet:
+
+```python
+queue=QueueConfig(durable=True, deployment_id="gpu-pool")
+```
+
+| Replica setting | Enqueues | Claims |
+|-----------------|----------|--------|
+| `deployment_id=None` (default) | Unstamped jobs | Unstamped jobs only |
+| `deployment_id="gpu-pool"` | Jobs stamped `gpu-pool` | Unstamped jobs and jobs stamped `gpu-pool` |
+
+A mixed fleet is safe by construction. A continuation inherits the submitting job's stamp.
+
+<Warning>
+Jobs stamped for a deployment with no live workers wait forever. They are queued, not stale, so no sweep touches them and no error is raised. The symptom is `oldest_queued_age_seconds` climbing in `/queue/stats`. Sweeping is not affinity-filtered: any replica can fail a stale job, because that only records a failure that already happened.
+</Warning>
+
+## Fleet-wide settings
+
+Every replica sharing one queue table must use the same values for `lock_grace_seconds`, `stop_timeout_seconds`, `retention_seconds`, `max_attempts`, and `timeout_seconds`. Each is applied by whichever replica performs the action: the claimer's grace sets its heartbeat cadence while the sweeper's grace judges staleness, `max_attempts` is stamped per ticket by the accepting replica, and the smallest `retention_seconds` in the fleet wins the hourly cleanup. Divergent values, including transiently during a rolling deploy, can falsely sweep a healthy peer's runs or delete tickets early.
+
+When changing `lock_grace_seconds` on a live fleet, only ever raise it, and roll the sweeping replicas first. A replica sweeping with a smaller grace than its peers heartbeat with judges their live leases stale.
+
+## Shutdown and restart
+
+On graceful shutdown the worker stops claiming and gives in-flight runs `stop_timeout_seconds` (default 30, always below `lock_grace_seconds`) to finish. Heartbeats continue through the drain, so peers do not reclaim a run that is still finishing. Stragglers are cancelled once: with attempts remaining they return to `queued`, otherwise they fail with `interrupted by worker shutdown`. Queued jobs are untouched and execute after the restart, on whichever replica claims them.
+
+## Next Steps
+
+| Task | Guide |
+|------|-------|
+| Choose `max_attempts` and understand the guarantee | [Durable queue](/agent-os/background-execution/durable-queue#the-guarantee) |
+| Wire cancels and streams across replicas | [Multi-replica deployments](/agent-os/background-execution/multi-replica) |
+| Release a stuck paused run | [Cancel and retention](/agent-os/background-execution/hitl-continuations#cancel-and-retention) |

--- a/agent-os/background-execution/operations.mdx
+++ b/agent-os/background-execution/operations.mdx
@@ -66,8 +66,6 @@ Requeue does not bypass attempt fencing. If the presumed-dead worker finishes af
 
 ## Stats and alerting
 
-The signals to alert on:
-
 | Signal | Meaning |
 |--------|---------|
 | `counts.queued` trending up | Submissions outpace execution. Add replicas or raise `max_concurrency`. Submissions get `429` at `max_queue_depth`. |

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -11,7 +11,7 @@ Submit a run with `background=true` and AgentOS answers immediately with a `run_
 | Part | Setting | What it holds |
 |------|---------|---------------|
 | Truth | `AgentOS(db=...)` | Sessions, run rows, and the `agno_jobs` queue table. Losing anything else never loses a run. |
-| Coordination | `QueueConfig(redis=...)` | Live event streams and cancel signals between replicas. Ephemeral. |
+| Coordination | `QueueConfig(redis=...)` | Sets both the event stream (`RedisEventStream`) and the cancellation manager (`RedisRunCancellationManager`) on every replica. Ephemeral. |
 | Promise | `QueueConfig(durable=True)` | A committed ticket per accepted run. Whichever replica claims it executes it. |
 
 ## Quickstart
@@ -131,7 +131,7 @@ See [Durable queue](/agent-os/background-execution/durable-queue) for the exact 
 
 ## With more than one replica
 
-Set `QueueConfig(redis=...)` as soon as you run two or more replicas behind a load balancer. It wires the live event stream and cancel signals through a shared Redis, so a run started on one replica can be watched, resumed, and cancelled from any other.
+Set `QueueConfig(redis=...)` as soon as you run two or more replicas behind a load balancer. One setting installs both the event stream and the cancellation manager on each replica, backed by a shared Redis, so a run started on one replica can be watched, resumed, and cancelled from any other. No `set_cancellation_manager()` or `set_event_stream()` call is needed.
 
 See [Multi-replica deployments](/agent-os/background-execution/multi-replica) for what Redis does here, and why `queue.redis` is a different job from `db=RedisDb`.
 

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -135,6 +135,16 @@ Set `QueueConfig(redis=...)` as soon as you run two or more replicas behind a lo
 
 See [Multi-replica deployments](/agent-os/background-execution/multi-replica) for what Redis does here, and why `queue.redis` is a different job from `db=RedisDb`.
 
+## Upgrading from v2
+
+The client contract is unchanged. `background=true` returned the same `202` body, `PENDING` status, `/resume` and `/cancel` endpoints, and `400` without a `db` in v2. Without a `QueueConfig`, one thing is different in v3:
+
+| Behavior | v2 | v3 (no `QueueConfig`) |
+|----------|----|------------------------|
+| Concurrency | Unbounded `asyncio.create_task` per submission | Capped at 32 background runs per replica. Runs beyond the cap wait as `PENDING`. |
+
+Raise or disable the cap with `QueueConfig(max_concurrency=...)` or `AGNO_BACKGROUND_MAX_CONCURRENCY`. Durability, one-setting Redis coordination, idempotency keys, session ordering, and the `/queue` endpoints are all opt-in through `QueueConfig`.
+
 ## Guides
 
 <CardGroup cols={2}>

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -103,6 +103,10 @@ Teams and workflows use the same fields under `/teams/{team_id}/runs` and `/work
 Background execution requires a `db` on the agent, team, or workflow. Submissions without one are refused with `400`.
 </Note>
 
+<Note>
+The [AgentOS Control Plane](https://os.agno.com) submits every chat run with `background=true`. Everything on these pages, including the concurrency cap and `durable=True`, applies to runs started from the UI.
+</Note>
+
 ## Without durability
 
 | Behavior | Detail |

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -104,7 +104,7 @@ Background execution requires a `db` on the agent, team, or workflow. Submission
 </Note>
 
 <Note>
-The [AgentOS Control Plane](https://os.agno.com) submits every chat run with `background=true`. Everything on these pages, including the concurrency cap and `durable=True`, applies to runs started from the UI.
+The [AgentOS Control Plane](https://os.agno.com) submits every chat run with `background=true`. Runs started from the UI go through the same path as any other background submission: the concurrency cap applies, and the queue applies if your AgentOS is configured with `QueueConfig(durable=True)`.
 </Note>
 
 ## Without durability

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -105,7 +105,7 @@ Background execution requires a `db` on the agent, team, or workflow. Submission
 
 ## Without durability
 
-`background=true` works with no `QueueConfig` at all. What you get:
+`background=true` does not require a `QueueConfig`. Without one:
 
 | Behavior | Detail |
 |----------|--------|

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -35,9 +35,8 @@ docker run -d \
 ```python durable_queue.py
 from agno.agent import Agent
 from agno.db.postgres import PostgresDb
-from agno.job_queue.config import QueueConfig
 from agno.models.openai import OpenAIResponses
-from agno.os import AgentOS
+from agno.os import AgentOS, QueueConfig
 
 db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -137,13 +137,7 @@ See [Multi-replica deployments](/agent-os/background-execution/multi-replica) fo
 
 ## Upgrading from v2
 
-The client contract is unchanged. `background=true` returned the same `202` body, `PENDING` status, `/resume` and `/cancel` endpoints, and `400` without a `db` in v2. Without a `QueueConfig`, one thing is different in v3:
-
-| Behavior | v2 | v3 (no `QueueConfig`) |
-|----------|----|------------------------|
-| Concurrency | Unbounded `asyncio.create_task` per submission | Capped at 32 background runs per replica. Runs beyond the cap wait as `PENDING`. |
-
-Raise or disable the cap with `QueueConfig(max_concurrency=...)` or `AGNO_BACKGROUND_MAX_CONCURRENCY`. Durability, one-setting Redis coordination, idempotency keys, session ordering, and the `/queue` endpoints are all opt-in through `QueueConfig`.
+Background runs are capped at 32 per replica in v3. In v2 each submission spawned an unbounded `asyncio.create_task`; now runs beyond the cap wait as `PENDING`. Raise or disable the cap with `QueueConfig(max_concurrency=...)` or `AGNO_BACKGROUND_MAX_CONCURRENCY`. Durability, Redis coordination, idempotency keys, session ordering, and the `/queue` endpoints are opt-in through `QueueConfig`.
 
 ## Guides
 

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -1,0 +1,170 @@
+---
+title: Background Execution
+sidebarTitle: Overview
+description: "Accept runs with background=true, poll or stream them, and make acceptance durable with a database-backed job queue."
+---
+
+Submit a run with `background=true` and AgentOS answers immediately with a `run_id`. The run executes on the server while your client polls, streams, or disconnects. Add `QueueConfig(durable=True)` and that acceptance becomes a committed database row that survives crashes and deploys.
+
+**Your database is where truth lives, `queue.redis` is how replicas talk to each other, and `durable=True` turns acceptance into a promise.** Every page in this section maps onto one of those three parts.
+
+| Part | Setting | What it holds |
+|------|---------|---------------|
+| Truth | `AgentOS(db=...)` | Sessions, run rows, and the `agno_jobs` queue table. Losing anything else never loses a run. |
+| Coordination | `QueueConfig(redis=...)` | Live event streams and cancel signals between replicas. Ephemeral. |
+| Promise | `QueueConfig(durable=True)` | A committed ticket per accepted run. Whichever replica claims it executes it. |
+
+## Quickstart
+
+```bash
+pip install "agno[os]" openai psycopg
+```
+
+Run Postgres:
+
+```bash
+docker run -d \
+  -e POSTGRES_DB=ai \
+  -e POSTGRES_USER=ai \
+  -e POSTGRES_PASSWORD=ai \
+  -p 5532:5432 \
+  --name pgvector \
+  agnohq/pgvector:18
+```
+
+```python durable_queue.py
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.job_queue.config import QueueConfig
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+agent = Agent(
+    name="Durable Agent",
+    id="durable-agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+)
+
+agent_os = AgentOS(
+    agents=[agent],
+    db=db,
+    queue=QueueConfig(durable=True),
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="durable_queue:app", reload=True)
+```
+
+Submit a run:
+
+```bash
+curl -X POST localhost:7777/agents/durable-agent/runs \
+  -F "message=Write a haiku about queues" \
+  -F "background=true" \
+  -F "stream=false"
+```
+
+```json
+{"run_id": "20a47fb2-...", "session_id": "72b8bc0c-...", "status": "PENDING"}
+```
+
+The `202` is returned after the queue row commits. Poll for the result:
+
+```bash
+curl "localhost:7777/agents/durable-agent/runs/{run_id}?session_id={session_id}"
+```
+
+The response carries `status` (`PENDING`, `RUNNING`, `PAUSED`, `COMPLETED`, `CANCELLED`, or `ERROR`) and, once finished, `content`.
+
+## The 202 contract
+
+Every background submission, durable or not, returns the same shape:
+
+| Field | Meaning |
+|-------|---------|
+| `run_id` | Identifier for polling, resuming, cancelling, and continuing. Never changes for the life of the run. |
+| `session_id` | Session the run belongs to. Required on poll. |
+| `status` | `PENDING` on a fresh acceptance. |
+
+The `background` and `stream` form fields select the execution mode:
+
+| `background` | `stream` | Response |
+|:---:|:---:|---|
+| `true` | `false` | `202` with `run_id`. Poll `GET /agents/{agent_id}/runs/{run_id}`. |
+| `true` | `true` | SSE stream of the run's events. Disconnect and reconnect through `POST /agents/{agent_id}/runs/{run_id}/resume` with `last_event_index`. |
+| `false` | any | Inline execution. A client disconnect cancels the run. |
+
+Teams and workflows use the same fields under `/teams/{team_id}/runs` and `/workflows/{workflow_id}/runs`. See [Background Execution](/background-execution/overview) for the SDK-level `arun(background=True)` API and the SSE resume protocol.
+
+<Note>
+Background execution requires a `db` on the agent, team, or workflow. Submissions without one are refused with `400`.
+</Note>
+
+## Without durability
+
+`background=true` works with no `QueueConfig` at all. What you get:
+
+| Behavior | Detail |
+|----------|--------|
+| Bounded concurrency | At most `max_concurrency` background runs execute at once per replica (default 32, or `AGNO_BACKGROUND_MAX_CONCURRENCY`). |
+| Honest waiting | Runs beyond the cap are accepted as `PENDING`, wait in line, and can be cancelled without consuming a slot. |
+| Resumable streams | Events are buffered in-process. Reconnect through `/resume`. |
+
+What you lose: the run lives in the memory of the replica that accepted it. If that process dies, every waiting and in-flight run on it is gone, and nothing marks them as failed. In a multi-replica deployment, `/resume` and `/cancel` only work on the replica that holds the run.
+
+```python
+agent_os = AgentOS(
+    agents=[agent],
+    db=db,
+    queue=QueueConfig(max_concurrency=16),
+)
+```
+
+## With durability
+
+`QueueConfig(durable=True)` writes each accepted run as a row in the queue table before the `202` is sent. A worker on every replica claims rows and executes them. If a replica dies, its runs are either reclaimed by another replica or failed visibly, depending on `max_attempts`. Nothing is silently lost.
+
+See [Durable queue](/agent-os/background-execution/durable-queue) for the exact guarantee, retry policy, idempotency keys, and configuration.
+
+## With more than one replica
+
+Set `QueueConfig(redis=...)` as soon as you run two or more replicas behind a load balancer. It wires the live event stream and cancel signals through a shared Redis, so a run started on one replica can be watched, resumed, and cancelled from any other.
+
+See [Multi-replica deployments](/agent-os/background-execution/multi-replica) for what Redis does here, and why `queue.redis` is a different job from `db=RedisDb`.
+
+## Guides
+
+<CardGroup cols={2}>
+  <Card title="Durable queue" icon="database" href="/agent-os/background-execution/durable-queue">
+    Acceptance as a committed row. Crash semantics, retries, idempotency, session ordering.
+  </Card>
+  <Card title="Multi-replica deployments" icon="server" href="/agent-os/background-execution/multi-replica">
+    Wire events out and cancels in through Redis. Coordination versus ticket storage.
+  </Card>
+  <Card title="Human-in-the-loop continuations" icon="hand" href="/agent-os/background-execution/hitl-continuations">
+    Continue a paused durable run through the queue under the same run_id.
+  </Card>
+  <Card title="Operations and monitoring" icon="gauge" href="/agent-os/background-execution/operations">
+    Dead-letter listing, requeue, queue stats, retention, admin gating.
+  </Card>
+</CardGroup>
+
+## Limitations
+
+| Area | Limit |
+|------|-------|
+| Live stream view | Best-effort. The run row is authoritative. A disconnect is harmless and reconnecting replays events, but live-view continuity across retry attempts is not guaranteed. Event indices are strictly increasing, not gapless. Termination is signalled by run status, never by index arithmetic. |
+| Non-queueable submissions | Media uploads, kwargs that plain JSON cannot store (for example an `output_schema` class), factory-backed components, and version-pinned lookups cannot ride the queue. They fall back to the bounded in-process path with a logged warning. The client still gets a `202`. |
+| Queue stores | Postgres (sync and async) and `RedisDb`. Any other `db` fails at startup with a clear error rather than silently degrading the promise. `RedisCluster` clients are rejected for the queue store. |
+| Blocking work | Lease heartbeats run on a dedicated thread, so a sync model client or sync tool cannot starve its own lease. Blocking the event loop still delays cancellation checkpoints, timeout enforcement, and event publishing. Keep blocking work in threads. |
+| Development loop | Durable is durable in dev too. A job accepted before a restart executes after it. Runs in flight at the default `max_attempts=1` are failed with `interrupted by worker shutdown` once the drain window closes. |
+
+## Developer Resources
+
+- [QueueConfig source](https://github.com/agno-agi/agno/blob/feat/v3.0/libs/agno/agno/job_queue/config.py)
+- [Durable queue cookbook](https://github.com/agno-agi/agno/tree/feat/v3.0/cookbook/05_agent_os/background_tasks)
+- [Background Execution (SDK)](/background-execution/overview)

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -12,7 +12,7 @@ Submit a run with `background=true` and AgentOS answers immediately with a `run_
 |------|---------|---------------|
 | Truth | `AgentOS(db=...)` | Sessions, run rows, and the `agno_jobs` queue table. Losing any other component never loses a run. |
 | Coordination | `QueueConfig(redis=...)` | Sets both the event stream (`RedisEventStream`) and the cancellation manager (`RedisRunCancellationManager`) on every replica. Ephemeral. |
-| Promise | `QueueConfig(durable=True)` | A committed ticket per accepted run. Whichever replica claims it executes it. |
+| Promise | `QueueConfig(durable=True)` | A committed job row per accepted run. Whichever replica claims it executes it. |
 
 ## Quickstart
 
@@ -146,7 +146,7 @@ Background runs are capped at 32 per replica in v3. In v2 each submission spawne
     Acceptance as a committed row. Crash semantics, retries, idempotency, session ordering.
   </Card>
   <Card title="Multi-replica deployments" icon="server" href="/agent-os/background-execution/multi-replica">
-    Wire events out and cancels in through Redis. Coordination versus ticket storage.
+    Wire events out and cancels in through Redis. Coordination versus job storage.
   </Card>
   <Card title="Human-in-the-loop continuations" icon="hand" href="/agent-os/background-execution/hitl-continuations">
     Continue a paused durable run through the queue under the same run_id.

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -6,11 +6,11 @@ description: "Accept runs with background=true, poll or stream them, and make ac
 
 Submit a run with `background=true` and AgentOS answers immediately with a `run_id`. The run executes on the server while your client polls, streams, or disconnects. Add `QueueConfig(durable=True)` and that acceptance becomes a committed database row that survives crashes and deploys.
 
-**Your database is where truth lives, `queue.redis` is how replicas talk to each other, and `durable=True` turns acceptance into a promise.** Every page in this section maps onto one of those three parts.
+**Your database is where truth lives, `queue.redis` is how replicas talk to each other, and `durable=True` turns acceptance into a promise.**
 
 | Part | Setting | What it holds |
 |------|---------|---------------|
-| Truth | `AgentOS(db=...)` | Sessions, run rows, and the `agno_jobs` queue table. Losing anything else never loses a run. |
+| Truth | `AgentOS(db=...)` | Sessions, run rows, and the `agno_jobs` queue table. Losing any other component never loses a run. |
 | Coordination | `QueueConfig(redis=...)` | Sets both the event stream (`RedisEventStream`) and the cancellation manager (`RedisRunCancellationManager`) on every replica. Ephemeral. |
 | Promise | `QueueConfig(durable=True)` | A committed ticket per accepted run. Whichever replica claims it executes it. |
 
@@ -110,10 +110,10 @@ Background execution requires a `db` on the agent, team, or workflow. Submission
 | Behavior | Detail |
 |----------|--------|
 | Bounded concurrency | At most `max_concurrency` background runs execute at once per replica (default 32, or `AGNO_BACKGROUND_MAX_CONCURRENCY`). |
-| Honest waiting | Runs beyond the cap are accepted as `PENDING`, wait in line, and can be cancelled without consuming a slot. |
+| Waiting | Runs beyond the cap are accepted as `PENDING`, wait for a slot, and can be cancelled while waiting. |
 | Resumable streams | Events are buffered in-process. Reconnect through `/resume`. |
 
-What you lose: the run lives in the memory of the replica that accepted it. If that process dies, every waiting and in-flight run on it is gone, and nothing marks them as failed. In a multi-replica deployment, `/resume` and `/cancel` only work on the replica that holds the run.
+The run lives in the memory of the replica that accepted it. If that process dies, every waiting and in-flight run on it is lost, and nothing marks them as failed. In a multi-replica deployment, `/resume` and `/cancel` only work on the replica that holds the run.
 
 ```python
 agent_os = AgentOS(
@@ -125,7 +125,7 @@ agent_os = AgentOS(
 
 ## With durability
 
-`QueueConfig(durable=True)` writes each accepted run as a row in the queue table before the `202` is sent. A worker on every replica claims rows and executes them. If a replica dies, its runs are either reclaimed by another replica or failed visibly, depending on `max_attempts`. Nothing is silently lost.
+`QueueConfig(durable=True)` writes each accepted run as a row in the queue table before the `202` is sent. A worker on every replica claims rows and executes them. If a replica dies, its runs are either reclaimed by another replica or marked failed, depending on `max_attempts`.
 
 See [Durable queue](/agent-os/background-execution/durable-queue) for the exact guarantee, retry policy, idempotency keys, and configuration.
 
@@ -166,11 +166,11 @@ Raise or disable the cap with `QueueConfig(max_concurrency=...)` or `AGNO_BACKGR
 
 | Area | Limit |
 |------|-------|
-| Live stream view | Best-effort. The run row is authoritative. A disconnect is harmless and reconnecting replays events, but live-view continuity across retry attempts is not guaranteed. Event indices are strictly increasing, not gapless. Termination is signalled by run status, never by index arithmetic. |
+| Live stream view | Best-effort. The run row is authoritative. A disconnect is harmless and reconnecting replays events, but continuity across retry attempts is not guaranteed. Event indices are strictly increasing, not gapless. Termination is signalled by run status, not by index arithmetic. |
 | Non-queueable submissions | Media uploads, kwargs that plain JSON cannot store (for example an `output_schema` class), factory-backed components, and version-pinned lookups cannot ride the queue. They fall back to the bounded in-process path with a logged warning. The client still gets a `202`. |
-| Queue stores | Postgres (sync and async) and `RedisDb`. Any other `db` fails at startup with a clear error rather than silently degrading the promise. `RedisCluster` clients are rejected for the queue store. |
+| Queue stores | Postgres (sync and async) and `RedisDb`. Any other `db` raises at startup. `RedisCluster` clients are rejected for the queue store. |
 | Blocking work | Lease heartbeats run on a dedicated thread, so a sync model client or sync tool cannot starve its own lease. Blocking the event loop still delays cancellation checkpoints, timeout enforcement, and event publishing. Keep blocking work in threads. |
-| Development loop | Durable is durable in dev too. A job accepted before a restart executes after it. Runs in flight at the default `max_attempts=1` are failed with `interrupted by worker shutdown` once the drain window closes. |
+| Development loop | The queue behaves the same in development. A job accepted before a restart executes after it. Runs in flight at the default `max_attempts=1` are failed with `interrupted by worker shutdown` once the drain window closes. |
 
 ## Developer Resources
 

--- a/agent-os/background-execution/overview.mdx
+++ b/agent-os/background-execution/overview.mdx
@@ -105,8 +105,6 @@ Background execution requires a `db` on the agent, team, or workflow. Submission
 
 ## Without durability
 
-`background=true` does not require a `QueueConfig`. Without one:
-
 | Behavior | Detail |
 |----------|--------|
 | Bounded concurrency | At most `max_concurrency` background runs execute at once per replica (default 32, or `AGNO_BACKGROUND_MAX_CONCURRENCY`). |

--- a/background-execution/overview.mdx
+++ b/background-execution/overview.mdx
@@ -325,7 +325,7 @@ AgentOS can remove the affinity requirement entirely. `QueueConfig(redis=...)` w
 
 The detached task and event buffer live in-process on the instance that started the run. The default cancellation manager is also in-memory. In a multi-replica setup, a `/resume` request that lands on a different instance can replay persisted events for a local entity when `session_id` is provided, then closes. It cannot tail the live task on the originating instance. A `/cancel` request on the wrong instance does not stop the task on the origin.
 
-Configure session affinity on the initial run-start request, then route that client's `/resume` and `/cancel` requests to the same instance. An explicit `run_id`-to-instance mapping can provide the same guarantee. Hashing only the generated `run_id` on reconnect is insufficient because the initial request was routed before that ID existed. A shared cancellation manager such as `RedisRunCancellationManager` removes the affinity requirement for `/cancel`, but live `/resume` still needs the originating instance.
+Configure session affinity on the initial run-start request, then route that client's `/resume` and `/cancel` requests to the same instance. An explicit `run_id`-to-instance mapping can provide the same guarantee. Hashing only the generated `run_id` on reconnect is insufficient because the initial request was routed before that ID existed. In AgentOS, `QueueConfig(redis=...)` removes the affinity requirement for both: it sets the cancellation manager (`RedisRunCancellationManager`) and the event stream (`RedisEventStream`) on every replica, so `/cancel` and live `/resume` work from any instance. See [Multi-replica deployments](/agent-os/background-execution/multi-replica).
 
 ## Developer Resources
 

--- a/background-execution/overview.mdx
+++ b/background-execution/overview.mdx
@@ -319,6 +319,10 @@ The `/resume` stream can include these meta events:
 
 ## Multi-Container Deployments
 
+<Note>
+AgentOS can remove the affinity requirement entirely. `QueueConfig(redis=...)` wires a shared event stream and cancellation manager so `/resume` and `/cancel` work from any replica, and `QueueConfig(durable=True)` makes accepted runs survive process restarts. See [AgentOS Background Execution](/agent-os/background-execution/overview).
+</Note>
+
 The detached task and event buffer live in-process on the instance that started the run. The default cancellation manager is also in-memory. In a multi-replica setup, a `/resume` request that lands on a different instance can replay persisted events for a local entity when `session_id` is provided, then closes. It cannot tail the live task on the originating instance. A `/cancel` request on the wrong instance does not stop the task on the origin.
 
 Configure session affinity on the initial run-start request, then route that client's `/resume` and `/cancel` requests to the same instance. An explicit `run_id`-to-instance mapping can provide the same guarantee. Hashing only the generated `run_id` on reconnect is insufficient because the initial request was routed before that ID existed. A shared cancellation manager such as `RedisRunCancellationManager` removes the affinity requirement for `/cancel`, but live `/resume` still needs the originating instance.

--- a/docs.json
+++ b/docs.json
@@ -8984,6 +8984,15 @@
                 ]
               },
               {
+                "group": "Queue",
+                "pages": [
+                  "reference-api/schema/queue/get-queue-stats",
+                  "reference-api/schema/queue/list-queue-jobs",
+                  "reference-api/schema/queue/get-queue-job",
+                  "reference-api/schema/queue/requeue-queue-job"
+                ]
+              },
+              {
                 "group": "Service Accounts",
                 "pages": [
                   "reference-api/schema/service-accounts/create-service-account",

--- a/docs.json
+++ b/docs.json
@@ -4783,6 +4783,16 @@
               },
               "agent-os/config",
               "agent-os/background-tasks/overview",
+              {
+                "group": "Background Execution",
+                "pages": [
+                  "agent-os/background-execution/overview",
+                  "agent-os/background-execution/durable-queue",
+                  "agent-os/background-execution/multi-replica",
+                  "agent-os/background-execution/hitl-continuations",
+                  "agent-os/background-execution/operations"
+                ]
+              },
               "agent-os/scheduler/overview",
               "agent-os/approvals/overview",
               "agent-os/lifespan",

--- a/other/v3-changelog.mdx
+++ b/other/v3-changelog.mdx
@@ -102,19 +102,19 @@ The major changes are:
 </Accordion>
 
 <Accordion title="Durable background execution">
-  - Accepted `background=True` requests are committed job rows that survive
-    crashes, restarts and deploys. Any replica's worker can claim and execute
-    them.
-  - Concurrency is bounded. Excess submissions wait in `pending` status instead
-    of overloading the process.
-  - Runs can be tailed (`stream=true`), resumed after a disconnect (`/resume`)
-    and cancelled from any replica.
-  - `Idempotency-Key` headers deduplicate resubmissions.
-  - Redis is optional coordination (live event streams, cross-replica
-    cancellation), never truth. A Redis fault degrades the live view; it cannot
-    lose or corrupt a run.
-  - Background execution requires a `db` on the component and returns a 400
-    without one.
+  - The `background=True` client contract is unchanged from v2 (`202` body,
+    `PENDING` status, `/resume`, `/cancel`, `400` without a `db`).
+  - Concurrency is bounded by default: 32 background runs per replica, excess
+    submissions wait as `PENDING`. Configure with `QueueConfig(max_concurrency=...)`
+    or `AGNO_BACKGROUND_MAX_CONCURRENCY`.
+  - `QueueConfig(durable=True)`: accepted requests are committed job rows that
+    survive crashes, restarts and deploys. Any replica's worker can claim and
+    execute them. Enables `Idempotency-Key` deduplication and the `/queue`
+    operations endpoints.
+  - `QueueConfig(redis=...)`: live event streams and cross-replica cancellation
+    from one setting, so runs can be tailed, resumed and cancelled from any
+    replica. Redis is coordination, never truth. A Redis fault degrades the live
+    view; it cannot lose or corrupt a run.
   - External framework agents (LangGraph, Claude, DSPy, etc.) stream inline
     when `background=true` is requested; their runs are not resumable.
 </Accordion>

--- a/other/v3-changelog.mdx
+++ b/other/v3-changelog.mdx
@@ -102,11 +102,9 @@ The major changes are:
 </Accordion>
 
 <Accordion title="Durable background execution">
-  - The `background=True` client contract is unchanged from v2 (`202` body,
-    `PENDING` status, `/resume`, `/cancel`, `400` without a `db`).
-  - Concurrency is bounded by default: 32 background runs per replica, excess
-    submissions wait as `PENDING`. Configure with `QueueConfig(max_concurrency=...)`
-    or `AGNO_BACKGROUND_MAX_CONCURRENCY`.
+  - Background runs are capped at 32 per replica by default; excess submissions
+    wait as `PENDING`. Configure with `QueueConfig(max_concurrency=...)` or
+    `AGNO_BACKGROUND_MAX_CONCURRENCY`.
   - `QueueConfig(durable=True)`: accepted requests are committed job rows that
     survive crashes, restarts and deploys. Any replica's worker can claim and
     execute them. Enables `Idempotency-Key` deduplication and the `/queue`

--- a/other/v3-migration.mdx
+++ b/other/v3-migration.mdx
@@ -262,17 +262,13 @@ addition to sessions. What this means for your code and data:
 
 ### 7. Background execution and durable queues
 
-`background=True` on AgentOS keeps its v2 contract: the same `202` body
-(`run_id`, `session_id`, `status: "PENDING"`), the same `/resume` and
-`/cancel` endpoints, and the same `400` when the component has no `db`.
+Background runs are now capped at 32 per replica. In v2 each `background=True`
+submission spawned an unbounded `asyncio.create_task`; in v3 runs beyond the
+cap wait as `PENDING` instead of overloading the process. Raise or disable the
+cap with `AgentOS(queue=QueueConfig(max_concurrency=...))` or
+`AGNO_BACKGROUND_MAX_CONCURRENCY`.
 
-One default changed. In v2 each submission spawned an unbounded
-`asyncio.create_task`. In v3 background runs are capped at 32 per replica;
-runs beyond the cap wait as `PENDING` instead of overloading the process.
-Raise or disable the cap with `AgentOS(queue=QueueConfig(max_concurrency=...))`
-or `AGNO_BACKGROUND_MAX_CONCURRENCY`.
-
-Everything else is opt-in through `QueueConfig`:
+The rest of the queue is opt-in through `QueueConfig`:
 
 - `durable=True`: accepted requests become **committed rows** that survive
   crashes, restarts and deploys; any replica's worker can execute them. Enables

--- a/other/v3-migration.mdx
+++ b/other/v3-migration.mdx
@@ -262,26 +262,29 @@ addition to sessions. What this means for your code and data:
 
 ### 7. Background execution and durable queues
 
-`background=True` on AgentOS is rebuilt around a durable job queue. In v2 it
-spawned an unbounded `asyncio.create_task`, and a process death silently lost
-every waiting and in-flight run. In v3:
+`background=True` on AgentOS keeps its v2 contract: the same `202` body
+(`run_id`, `session_id`, `status: "PENDING"`), the same `/resume` and
+`/cancel` endpoints, and the same `400` when the component has no `db`.
 
-- Accepted requests are **committed rows** that survive crashes, restarts and
-  deploys; any replica's worker can execute them.
-- Runs are **bounded** by a concurrency cap; excess submissions wait in the
-  queue in `pending` status instead of overloading the process.
-- Every run can be watched (`stream=true` tails), resumed after a disconnect
-  (`/resume`) and cancelled from any replica.
-- `Idempotency-Key` headers deduplicate resubmissions.
-- Redis is optional **coordination** (live event streams, cross-replica
-  cancellation), never truth. A Redis fault degrades the live view; it cannot
+One default changed. In v2 each submission spawned an unbounded
+`asyncio.create_task`. In v3 background runs are capped at 32 per replica;
+runs beyond the cap wait as `PENDING` instead of overloading the process.
+Raise or disable the cap with `AgentOS(queue=QueueConfig(max_concurrency=...))`
+or `AGNO_BACKGROUND_MAX_CONCURRENCY`.
+
+Everything else is opt-in through `QueueConfig`:
+
+- `durable=True`: accepted requests become **committed rows** that survive
+  crashes, restarts and deploys; any replica's worker can execute them. Enables
+  `Idempotency-Key` deduplication and the `/queue` operations endpoints.
+- `redis=...`: one setting wires both the live event stream and cross-replica
+  cancellation, so runs can be resumed and cancelled from any replica. Redis is
+  **coordination**, never truth. A Redis fault degrades the live view; it cannot
   lose or corrupt a run.
 
-Breaking implications: background execution requires a `db` on the agent
-(enforced with a 400), run status now transitions `pending → running →
-completed` (poll `GET /agents/{id}/runs/{run_id}` for the terminal state), and
-external framework agents (LangGraph, Claude, etc.) stream inline, so their
-runs are not resumable.
+External framework agents (LangGraph, Claude, etc.) stream inline when
+`background=true` is requested, so their runs are not resumable. See
+[AgentOS Background Execution](/agent-os/background-execution/overview).
 
 ### 8. Culture feature removed
 

--- a/reference-api/openapi.yaml
+++ b/reference-api/openapi.yaml
@@ -10329,6 +10329,269 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalServerErrorResponse'
+  /queue/jobs:
+    get:
+      tags:
+      - Queue
+      summary: List Queue Jobs
+      description: 'List job queue jobs, optionally filtered by status. Repeat the status param to match any of several (e.g. status=failed&status=cancelled for the requeueable set; status=failed alone is the dead-letter list). Useful sort_by fields: created_at (default), updated_at, completed_at, status, attempt, component_type, component_id, user_id. Unknown sort fields are ignored.'
+      operationId: list_queue_jobs
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: array
+            items:
+              type: string
+          - type: 'null'
+          description: Status filter; repeatable to match any of several statuses
+          title: Status
+        description: Status filter; repeatable to match any of several statuses
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          description: Number of jobs to return per page
+          default: 20
+          title: Limit
+        description: Number of jobs to return per page
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          description: Page number for pagination
+          default: 1
+          title: Page
+        description: Page number for pagination
+      - name: sort_by
+        in: query
+        required: false
+        schema:
+          type: string
+          description: Field to sort jobs by
+          default: created_at
+          title: Sort By
+        description: Field to sort jobs by
+      - name: sort_order
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortOrder'
+          description: Sort order (asc or desc)
+          default: desc
+        description: Sort order (asc or desc)
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResponse_QueueJobSchema_'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthenticatedResponse'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorResponse'
+        '503':
+          description: Durable job queue not enabled on this replica
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /queue/jobs/{job_id}:
+    get:
+      tags:
+      - Queue
+      summary: Get Queue Job
+      operationId: get_queue_job
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueueJobSchema'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthenticatedResponse'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorResponse'
+        '503':
+          description: Durable job queue not enabled on this replica
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /queue/jobs/{job_id}/requeue:
+    post:
+      tags:
+      - Queue
+      summary: Requeue Failed Queue Job
+      description: 'Requeue a terminally failed or cancelled job for one more execution (raises its attempt budget by one). The operator remedy for crashed runs under the no-silent-re-execution default. Requeueing a CANCELLED job whose cancellation intent is still live requires clear_cancellation=true - an explicit override of the recorded cancel; without it the re-driven attempt is re-cancelled at its first checkpoint. Requeueing a job that FAILED within the last lock_grace seconds requires force=true: its worker may still be executing (swept-but-alive), and a second producer would race unfenced writes.'
+      operationId: requeue_queue_job
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job Id
+      - name: clear_cancellation
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: Clear Cancellation
+      - name: force
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: Force
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueueJobSchema'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthenticatedResponse'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorResponse'
+        '503':
+          description: Durable job queue not enabled on this replica
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /queue/stats:
+    get:
+      tags:
+      - Queue
+      summary: Queue Stats
+      description: Job counts by status and the oldest queued job's age - the queue-health signals to alert on.
+      operationId: get_queue_stats
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthenticatedResponse'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorResponse'
+        '503':
+          description: Durable job queue not enabled on this replica
+      security:
+      - HTTPBearer: []
 components:
   schemas:
     ActivityMessage:
@@ -13808,6 +14071,22 @@ components:
         - data
         - meta
       title: PaginatedResponse[LearningUserStats]
+    PaginatedResponse_QueueJobSchema_:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/QueueJobSchema'
+          type: array
+          title: Data
+          description: List of items for the current page
+        meta:
+          $ref: '#/components/schemas/PaginationInfo'
+          description: Pagination metadata
+      type: object
+      required:
+      - data
+      - meta
+      title: PaginatedResponse[QueueJobSchema]
     PaginatedResponse_RegistryContentResponse_:
       properties:
         data:
@@ -14024,6 +14303,111 @@ components:
         - $ref: '#/components/schemas/FilePart'
         - $ref: '#/components/schemas/DataPart'
       title: Part
+    QueueJobSchema:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Job ID (identical to the run's run_id)
+        component_type:
+          type: string
+          title: Component Type
+          description: 'Component kind: agent, team or workflow'
+        component_id:
+          type: string
+          title: Component Id
+          description: ID of the agent/team/workflow the run executes on
+        session_id:
+          type: string
+          title: Session Id
+          description: Session the run belongs to
+        job_type:
+          type: string
+          title: Job Type
+          description: Kind of work the ticket carries (runs only today)
+          default: run
+        user_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: User Id
+          description: User the run was submitted for
+        payload:
+          additionalProperties: true
+          type: object
+          title: Payload
+          description: Serialized run parameters
+        status:
+          type: string
+          title: Status
+          description: queued | running | completed | failed | cancelled | paused
+        attempt:
+          type: integer
+          title: Attempt
+          description: Executions started so far
+          default: 0
+        max_attempts:
+          type: integer
+          title: Max Attempts
+          description: Execution budget under any failure mode
+          default: 1
+        idempotency_key:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Idempotency Key
+          description: Client-provided dedupe key, if any
+        available_at:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Available At
+          description: Epoch seconds the job becomes claimable
+        locked_by:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Locked By
+          description: Worker currently holding the job's lock
+        locked_at:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Locked At
+          description: Epoch seconds the current lock was taken
+        error:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+          description: Terminal error of the last attempt, if any
+        created_at:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Created At
+          description: Epoch seconds the job was accepted
+        updated_at:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Updated At
+          description: Epoch seconds of the last state change
+        completed_at:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Completed At
+          description: Epoch seconds the job reached a terminal state
+      type: object
+      required:
+      - id
+      - component_type
+      - component_id
+      - session_id
+      - status
+      title: QueueJobSchema
+      description: One durable queue job (a background run's queue ticket).
     ReaderSchema:
       properties:
         id:

--- a/reference-api/schema/queue/get-queue-job.mdx
+++ b/reference-api/schema/queue/get-queue-job.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /queue/jobs/{job_id}
+---

--- a/reference-api/schema/queue/get-queue-stats.mdx
+++ b/reference-api/schema/queue/get-queue-stats.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /queue/stats
+---

--- a/reference-api/schema/queue/list-queue-jobs.mdx
+++ b/reference-api/schema/queue/list-queue-jobs.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /queue/jobs
+---

--- a/reference-api/schema/queue/requeue-queue-job.mdx
+++ b/reference-api/schema/queue/requeue-queue-job.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /queue/jobs/{job_id}/requeue
+---

--- a/reference/agent-os/agent-os.mdx
+++ b/reference/agent-os/agent-os.mdx
@@ -34,6 +34,8 @@ description: "Parameter and method reference for the AgentOS class that serves a
 | `tracing` | `bool` | `False` | Enable OpenTelemetry tracing for all agents and teams |
 | `auto_provision_dbs` | `bool` | `True` | Whether to automatically provision databases |
 | `run_hooks_in_background` | `bool` | `False` | Run agent/team pre/post hooks as FastAPI background tasks |
+| `queue` | `Optional[QueueConfig]` | `None` | Background run execution: per-replica concurrency cap, Redis coordination for multi-replica deployments, and the durable job queue. `None` keeps the process defaults (cap of 32 or `AGNO_BACKGROUND_MAX_CONCURRENCY`). See [Background Execution](/agent-os/background-execution/overview) and the [QueueConfig fields](/agent-os/background-execution/durable-queue#configuration) |
+| `event_stream` | `Optional[BaseEventStream]` | `None` | Explicit event stream override. Takes precedence over the stream `queue.redis` would configure. Defaults to the in-memory stream |
 | `telemetry` | `bool` | `True` | Log minimal telemetry for analytics |
 | `registry` | `Optional[Registry]` | `None` | Registry to use for the AgentOS |
 | `scheduler` | `bool` | `False` | Whether to enable the cron scheduler |


### PR DESCRIPTION
## Summary

User-facing docs for AgentOS durable background execution (the v3.0 job queue, agno-agi/agno#9079). Adds a **Background Execution** group to the AgentOS tab with five pages:

- `agent-os/background-execution/overview` - mental model (db = truth, `queue.redis` = coordination, `durable=True` = promise), quickstart, 202 contract, modes, limitations
- `agent-os/background-execution/durable-queue` - the guarantee, `max_attempts` crash semantics, queue stores, idempotency keys, session serialization, latency, full `QueueConfig` reference
- `agent-os/background-execution/multi-replica` - events out / cancel in via `queue.redis`, coordination vs `db=RedisDb` ticket storage, `RedisCoordination`
- `agent-os/background-execution/hitl-continuations` - continuing a paused durable run through the queue under the same `run_id`
- `agent-os/background-execution/operations` - `/queue` endpoints, requeue, stats, retention, admin gating, `deployment_id`

Also adds a cross-link note to the SDK-level `background-execution/overview` Multi-Container section.

## Verification

- Ran `cookbook/05_agent_os/background_tasks/durable_queue.py` and `durable_continue.py` (feat/v3.0, 3.0.0a4) against local Postgres. Confirmed the 202/poll contract, ticket states, `/queue/stats` and `/queue/jobs`, Idempotency-Key dedup, paused ticket, 409 on inline continue, 202 durable continue and double-click attach, cancel of a paused run, requeue behavior.
- Every `QueueConfig` field re-checked against `libs/agno/agno/job_queue/config.py`.
- `mint broken-links` and `scripts/inventory/run_all.py`: 0 broken links.

## Review notes

- The session serialization and local-wake content (`serialize_sessions`, "starts in milliseconds", requeue claiming immediately) documents agno-agi/agno#9587 and agno-agi/agno#9667, which are still **open**. Those sections should ship with, or be removed if those PRs don't land in, v3.0.
- Not verified live: multi-replica behavior, `max_attempts=2` crash reclaim, `RedisDb` as queue store, streaming through the queue. All written from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)